### PR TITLE
Improve catalogue form UX and sidebar navigation

### DIFF
--- a/lib/phoenix_kit_catalogue.ex
+++ b/lib/phoenix_kit_catalogue.ex
@@ -76,7 +76,9 @@ defmodule PhoenixKitCatalogue do
   @impl PhoenixKit.Module
   def admin_tabs do
     [
-      # Main tab
+      # Main tab — parent container, redirects to first subtab.
+      # match: fn -> false prevents the parent itself from ever highlighting;
+      # subtab_display: :always ensures subtabs are always visible.
       %Tab{
         id: :admin_catalogue,
         label: "Catalogue",
@@ -85,11 +87,47 @@ defmodule PhoenixKitCatalogue do
         priority: 660,
         level: :admin,
         permission: module_key(),
-        match: :prefix,
+        match: fn _current_path -> false end,
         group: :admin_modules,
-        subtab_display: :when_active,
+        subtab_display: :always,
         highlight_with_subtabs: false,
+        redirect_to_first_subtab: true,
         live_view: {PhoenixKitCatalogue.Web.CataloguesLive, :index}
+      },
+      # Subtabs — Catalogues, Manufacturers, Suppliers
+      %Tab{
+        id: :admin_catalogue_list,
+        label: "Catalogues",
+        icon: "hero-rectangle-stack",
+        path: "catalogue",
+        priority: 661,
+        level: :admin,
+        permission: module_key(),
+        match: :exact,
+        parent: :admin_catalogue,
+        live_view: {PhoenixKitCatalogue.Web.CataloguesLive, :index}
+      },
+      %Tab{
+        id: :admin_catalogue_manufacturers,
+        label: "Manufacturers",
+        icon: "hero-building-office",
+        path: "catalogue/manufacturers",
+        priority: 662,
+        level: :admin,
+        permission: module_key(),
+        parent: :admin_catalogue,
+        live_view: {PhoenixKitCatalogue.Web.CataloguesLive, :manufacturers}
+      },
+      %Tab{
+        id: :admin_catalogue_suppliers,
+        label: "Suppliers",
+        icon: "hero-truck",
+        path: "catalogue/suppliers",
+        priority: 663,
+        level: :admin,
+        permission: module_key(),
+        parent: :admin_catalogue,
+        live_view: {PhoenixKitCatalogue.Web.CataloguesLive, :suppliers}
       },
       # Static paths MUST come before wildcard :uuid paths
       # so Phoenix router matches them first.
@@ -100,31 +138,19 @@ defmodule PhoenixKitCatalogue do
         label: "New Catalogue",
         icon: "hero-plus",
         path: "catalogue/new",
-        priority: 661,
+        priority: 664,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
         visible: false,
         live_view: {PhoenixKitCatalogue.Web.CatalogueFormLive, :new}
       },
-      # Manufacturers — all static paths before any :uuid wildcard
-      %Tab{
-        id: :admin_catalogue_manufacturers,
-        label: "Manufacturers",
-        icon: "hero-building-office-2",
-        path: "catalogue/manufacturers",
-        priority: 662,
-        level: :admin,
-        permission: module_key(),
-        parent: :admin_catalogue,
-        live_view: {PhoenixKitCatalogue.Web.CataloguesLive, :manufacturers}
-      },
       %Tab{
         id: :admin_catalogue_manufacturer_new,
         label: "New Manufacturer",
         icon: "hero-plus",
         path: "catalogue/manufacturers/new",
-        priority: 663,
+        priority: 665,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -136,31 +162,19 @@ defmodule PhoenixKitCatalogue do
         label: "Edit Manufacturer",
         icon: "hero-pencil-square",
         path: "catalogue/manufacturers/:uuid/edit",
-        priority: 664,
+        priority: 666,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
         visible: false,
         live_view: {PhoenixKitCatalogue.Web.ManufacturerFormLive, :edit}
       },
-      # Suppliers — all static paths before any :uuid wildcard
-      %Tab{
-        id: :admin_catalogue_suppliers,
-        label: "Suppliers",
-        icon: "hero-truck",
-        path: "catalogue/suppliers",
-        priority: 665,
-        level: :admin,
-        permission: module_key(),
-        parent: :admin_catalogue,
-        live_view: {PhoenixKitCatalogue.Web.CataloguesLive, :suppliers}
-      },
       %Tab{
         id: :admin_catalogue_supplier_new,
         label: "New Supplier",
         icon: "hero-plus",
         path: "catalogue/suppliers/new",
-        priority: 666,
+        priority: 667,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -172,7 +186,7 @@ defmodule PhoenixKitCatalogue do
         label: "Edit Supplier",
         icon: "hero-pencil-square",
         path: "catalogue/suppliers/:uuid/edit",
-        priority: 667,
+        priority: 668,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -185,7 +199,7 @@ defmodule PhoenixKitCatalogue do
         label: "Edit Category",
         icon: "hero-pencil-square",
         path: "catalogue/categories/:uuid/edit",
-        priority: 668,
+        priority: 669,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -198,7 +212,7 @@ defmodule PhoenixKitCatalogue do
         label: "Edit Item",
         icon: "hero-pencil-square",
         path: "catalogue/items/:uuid/edit",
-        priority: 669,
+        priority: 670,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -211,7 +225,7 @@ defmodule PhoenixKitCatalogue do
         label: "Catalogue",
         icon: "hero-rectangle-stack",
         path: "catalogue/:uuid",
-        priority: 670,
+        priority: 671,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -223,7 +237,7 @@ defmodule PhoenixKitCatalogue do
         label: "Edit Catalogue",
         icon: "hero-pencil-square",
         path: "catalogue/:uuid/edit",
-        priority: 671,
+        priority: 672,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -235,7 +249,7 @@ defmodule PhoenixKitCatalogue do
         label: "New Category",
         icon: "hero-plus",
         path: "catalogue/:catalogue_uuid/categories/new",
-        priority: 672,
+        priority: 673,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,
@@ -247,7 +261,7 @@ defmodule PhoenixKitCatalogue do
         label: "New Item",
         icon: "hero-plus",
         path: "catalogue/:catalogue_uuid/items/new",
-        priority: 673,
+        priority: 674,
         level: :admin,
         permission: module_key(),
         parent: :admin_catalogue,

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -67,7 +67,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     changeset =
       socket.assigns.catalogue
       |> Catalogue.change_catalogue(params)
-      |> Map.put(:action, :validate)
+      |> Map.put(:action, socket.assigns.changeset.action)
 
     {:noreply, assign(socket, :changeset, changeset)}
   end
@@ -146,14 +146,22 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       <%!-- Header --%>
       <div class="flex items-center gap-3">
         <.link navigate={Paths.index()} class="btn btn-ghost btn-sm btn-square">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
           </svg>
         </.link>
         <div>
           <h1 class="text-2xl font-bold">{@page_title}</h1>
           <p class="text-sm text-base-content/60 mt-0.5">
-            {if @action == :new, do: "Create a new product catalogue to organize categories and items.", else: "Update catalogue details and settings."}
+            {if @action == :new,
+              do: "Create a new product catalogue to organize categories and items.",
+              else: "Update catalogue details and settings."}
           </p>
         </div>
       </div>
@@ -165,73 +173,99 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
             multilang_enabled={@multilang_enabled}
             language_tabs={@language_tabs}
             current_lang={@current_lang}
+            class="card-body pb-0 pt-4"
           />
 
-          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5">
+          <.multilang_fields_wrapper
+            multilang_enabled={@multilang_enabled}
+            current_lang={@current_lang}
+            skeleton_class="card-body pt-0 flex flex-col gap-5"
+          >
             <:skeleton>
               <%!-- Name --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-20"></div>
-                <div class="skeleton h-12 w-full"></div>
+              <div class="form-control">
+                <div class="label">
+                  <div class="skeleton h-4 w-14"></div>
+                </div>
+                <div class="skeleton h-12 w-full rounded-lg"></div>
               </div>
               <%!-- Description --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-28"></div>
-                <div class="skeleton h-24 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Status --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-16"></div>
-                <div class="skeleton h-12 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Buttons --%>
-              <div class="flex justify-end gap-3">
-                <div class="skeleton h-12 w-20"></div>
-                <div class="skeleton h-12 w-36"></div>
+              <div class="form-control">
+                <div class="label">
+                  <div class="skeleton h-4 w-24"></div>
+                </div>
+                <div class="skeleton h-20 w-full rounded-lg"></div>
               </div>
             </:skeleton>
-            <div class="card-body flex flex-col gap-5">
+            <div class="card-body pt-0 flex flex-col gap-5">
               <.translatable_field
-                field_name="name" form_prefix="catalogue" changeset={@changeset}
-                schema_field={:name} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label="Name" placeholder="e.g., Kitchen Furniture"
-                required class="w-full"
-              />
-
-              <.translatable_field
-                field_name="description" form_prefix="catalogue" changeset={@changeset}
-                schema_field={:description} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label="Description" type="textarea"
-                placeholder="Brief description of what this catalogue contains..."
+                field_name="name"
+                form_prefix="catalogue"
+                changeset={@changeset}
+                schema_field={:name}
+                multilang_enabled={@multilang_enabled}
+                current_lang={@current_lang}
+                primary_language={@primary_language}
+                lang_data={@lang_data}
+                label="Name"
+                placeholder="e.g., Kitchen Furniture"
+                required
                 class="w-full"
               />
 
-              <div class="divider my-0"></div>
-
-              <div class="form-control">
-                <span class="label-text font-semibold mb-2">Status</span>
-                <select name="catalogue[status]" class="select select-bordered w-full transition-colors focus:select-primary">
-                  <option value="active" selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}>Active</option>
-                  <option value="archived" selected={Ecto.Changeset.get_field(@changeset, :status) == "archived"}>Archived</option>
-                </select>
-                <span class="label-text-alt text-base-content/50 mt-1">Archived catalogues are hidden from active views.</span>
-              </div>
-
-              <%!-- Actions --%>
-              <div class="divider my-0"></div>
-
-              <div class="flex justify-end gap-3">
-                <.link navigate={Paths.index()} class="btn btn-ghost">Cancel</.link>
-                <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">
-                  {if @action == :new, do: "Create Catalogue", else: "Save Changes"}
-                </button>
-              </div>
+              <.translatable_field
+                field_name="description"
+                form_prefix="catalogue"
+                changeset={@changeset}
+                schema_field={:description}
+                multilang_enabled={@multilang_enabled}
+                current_lang={@current_lang}
+                primary_language={@primary_language}
+                lang_data={@lang_data}
+                label="Description"
+                type="textarea"
+                placeholder="Brief description of what this catalogue contains..."
+                class="w-full"
+              />
             </div>
           </.multilang_fields_wrapper>
+
+          <div class="card-body flex flex-col gap-5 pt-0">
+            <div class="divider my-0"></div>
+
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Status</span>
+              <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+                <select name="catalogue[status]">
+                  <option
+                    value="active"
+                    selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
+                  >
+                    Active
+                  </option>
+                  <option
+                    value="archived"
+                    selected={Ecto.Changeset.get_field(@changeset, :status) == "archived"}
+                  >
+                    Archived
+                  </option>
+                </select>
+              </label>
+              <span class="label-text-alt text-base-content/50 mt-1">
+                Archived catalogues are hidden from active views.
+              </span>
+            </div>
+
+            <%!-- Actions --%>
+            <div class="divider my-0"></div>
+
+            <div class="flex justify-end gap-3">
+              <.link navigate={Paths.index()} class="btn btn-ghost">Cancel</.link>
+              <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">
+                {if @action == :new, do: "Create Catalogue", else: "Save Changes"}
+              </button>
+            </div>
+          </div>
         </div>
       </.form>
 
@@ -240,7 +274,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
         <div class="card-body flex flex-row items-center justify-between gap-4">
           <div>
             <span class="text-sm font-semibold text-error">Permanently Delete Catalogue</span>
-            <p class="text-xs text-base-content/50">This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.</p>
+            <p class="text-xs text-base-content/50">
+              This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.
+            </p>
           </div>
           <button
             :if={!@confirm_delete}

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -1,24 +1,13 @@
 defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
-  @moduledoc "Create/edit form for manufacturers with multilang support and supplier linking."
+  @moduledoc "Create/edit form for manufacturers with supplier linking."
 
   use Phoenix.LiveView
 
   require Logger
 
-  import PhoenixKitWeb.Components.MultilangForm
-
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Manufacturer
-
-  @translatable_fields ["name", "description"]
-  @preserve_fields %{
-    "status" => :status,
-    "website" => :website,
-    "contact_info" => :contact_info,
-    "logo_url" => :logo_url,
-    "notes" => :notes
-  }
 
   @impl true
   def mount(params, _session, socket) do
@@ -51,8 +40,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
       all_suppliers = Catalogue.list_suppliers(status: "active")
 
       {:ok,
-       socket
-       |> assign(
+       assign(socket,
          page_title:
            if(action == :new, do: "New Manufacturer", else: "Edit #{manufacturer.name}"),
          action: action,
@@ -60,27 +48,16 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
          changeset: changeset,
          all_suppliers: all_suppliers,
          linked_supplier_uuids: MapSet.new(linked_supplier_uuids)
-       )
-       |> mount_multilang()}
+       )}
     end
   end
 
   @impl true
-  def handle_event("switch_language", %{"lang" => lang_code}, socket) do
-    {:noreply, handle_switch_language(socket, lang_code)}
-  end
-
   def handle_event("validate", %{"manufacturer" => params}, socket) do
-    params =
-      merge_translatable_params(params, socket, @translatable_fields,
-        changeset: socket.assigns.changeset,
-        preserve_fields: @preserve_fields
-      )
-
     changeset =
       socket.assigns.manufacturer
       |> Catalogue.change_manufacturer(params)
-      |> Map.put(:action, :validate)
+      |> Map.put(:action, socket.assigns.changeset.action)
 
     {:noreply, assign(socket, :changeset, changeset)}
   end
@@ -97,12 +74,6 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
   end
 
   def handle_event("save", %{"manufacturer" => params}, socket) do
-    params =
-      merge_translatable_params(params, socket, @translatable_fields,
-        changeset: socket.assigns.changeset,
-        preserve_fields: @preserve_fields
-      )
-
     save_manufacturer(socket, socket.assigns.action, params)
   end
 
@@ -144,185 +115,230 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
 
   @impl true
   def render(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :lang_data,
-        get_lang_data(assigns.changeset, assigns.current_lang, assigns.multilang_enabled)
-      )
-
     ~H"""
     <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
       <%!-- Header --%>
       <div class="flex items-center gap-3">
         <.link navigate={Paths.manufacturers()} class="btn btn-ghost btn-sm btn-square">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
           </svg>
         </.link>
         <div>
           <h1 class="text-2xl font-bold">{@page_title}</h1>
           <p class="text-sm text-base-content/60 mt-0.5">
-            {if @action == :new, do: "Add a new manufacturer to your catalogue system.", else: "Update manufacturer details and supplier links."}
+            {if @action == :new,
+              do: "Add a new manufacturer to your catalogue system.",
+              else: "Update manufacturer details and supplier links."}
           </p>
         </div>
       </div>
 
       <.form for={to_form(@changeset)} phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
-          <.multilang_tabs multilang_enabled={@multilang_enabled} language_tabs={@language_tabs} current_lang={@current_lang} />
-
-          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5">
-            <:skeleton>
-              <%!-- Name --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-20"></div>
-                <div class="skeleton h-12 w-full"></div>
-              </div>
-              <%!-- Description --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-28"></div>
-                <div class="skeleton h-24 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Contact & Web header --%>
-              <div class="skeleton h-5 w-32"></div>
-              <%!-- Website + Contact grid --%>
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-20"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-24"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-              </div>
-              <%!-- Logo URL --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-20"></div>
-                <div class="skeleton h-12 w-full"></div>
-              </div>
-              <%!-- Notes --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-16"></div>
-                <div class="skeleton h-20 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Status --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-16"></div>
-                <div class="skeleton h-12 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Buttons --%>
-              <div class="flex justify-end gap-3">
-                <div class="skeleton h-12 w-20"></div>
-                <div class="skeleton h-12 w-40"></div>
-              </div>
-            </:skeleton>
-            <div class="card-body flex flex-col gap-5">
-              <.translatable_field
-                field_name="name" form_prefix="manufacturer" changeset={@changeset}
-                schema_field={:name} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label="Name" placeholder="e.g., Blum, Hettich" required
-                class="w-full"
+          <div class="card-body flex flex-col gap-5">
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Name *</span>
+              <input
+                type="text"
+                name="manufacturer[name]"
+                value={Ecto.Changeset.get_field(@changeset, :name) || ""}
+                class="input input-bordered w-full transition-colors focus:input-primary"
+                placeholder="e.g., Blum, Hettich"
               />
+              <p :for={msg <- changeset_errors(@changeset, :name)} class="text-error text-sm mt-1">
+                {msg}
+              </p>
+            </div>
 
-              <.translatable_field
-                field_name="description" form_prefix="manufacturer" changeset={@changeset}
-                schema_field={:description} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label="Description" type="textarea"
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Description</span>
+              <textarea
+                name="manufacturer[description]"
+                class="textarea textarea-bordered w-full transition-colors focus:textarea-primary"
+                rows="3"
                 placeholder="Brief description of this manufacturer..."
-                class="w-full"
-              />
+              >{Ecto.Changeset.get_field(@changeset, :description) || ""}</textarea>
+            </div>
 
-              <div class="divider my-0"></div>
+            <div class="divider my-0"></div>
 
-              <%!-- Contact & web --%>
-              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                </svg>
-                Contact & Web
-              </h2>
+            <%!-- Contact & web --%>
+            <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
+              Contact & Web
+            </h2>
 
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">Website</span>
-                  <input type="url" name="manufacturer[website]" value={Ecto.Changeset.get_field(@changeset, :website) || ""} class="input input-bordered w-full transition-colors focus:input-primary" placeholder="https://..." />
-                </div>
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">Contact Info</span>
-                  <input type="text" name="manufacturer[contact_info]" value={Ecto.Changeset.get_field(@changeset, :contact_info) || ""} class="input input-bordered w-full transition-colors focus:input-primary" placeholder="Email or phone" />
-                </div>
-              </div>
-
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div class="form-control">
-                <span class="label-text font-semibold mb-2">Logo URL</span>
-                <input type="url" name="manufacturer[logo_url]" value={Ecto.Changeset.get_field(@changeset, :logo_url) || ""} class="input input-bordered w-full transition-colors focus:input-primary" placeholder="https://..." />
+                <span class="label-text font-semibold mb-2">Website</span>
+                <input
+                  type="url"
+                  name="manufacturer[website]"
+                  value={Ecto.Changeset.get_field(@changeset, :website) || ""}
+                  class="input input-bordered w-full transition-colors focus:input-primary"
+                  placeholder="https://..."
+                />
               </div>
-
               <div class="form-control">
-                <span class="label-text font-semibold mb-2">Notes</span>
-                <textarea name="manufacturer[notes]" class="textarea textarea-bordered w-full min-h-[5rem] transition-colors focus:textarea-primary" rows="2" placeholder="Internal notes about this manufacturer...">{Ecto.Changeset.get_field(@changeset, :notes) || ""}</textarea>
-              </div>
-
-              <div class="divider my-0"></div>
-
-              <div class="form-control">
-                <span class="label-text font-semibold mb-2">Status</span>
-                <select name="manufacturer[status]" class="select select-bordered w-full transition-colors focus:select-primary">
-                  <option value="active" selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}>Active</option>
-                  <option value="inactive" selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}>Inactive</option>
-                </select>
-                <span class="label-text-alt text-base-content/50 mt-1">Inactive manufacturers won't appear in item dropdowns.</span>
-              </div>
-
-              <%!-- Supplier links --%>
-              <div :if={@all_suppliers != []} class="flex flex-col gap-4">
-                <div class="divider my-0"></div>
-
-                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                  </svg>
-                  Linked Suppliers
-                </h2>
-                <p class="text-sm text-base-content/50 -mt-2">Click to toggle supplier associations.</p>
-
-                <div class="flex flex-wrap gap-2">
-                  <label
-                    :for={supplier <- @all_suppliers}
-                    class={[
-                      "badge badge-lg cursor-pointer gap-1.5 select-none transition-colors",
-                      if(MapSet.member?(@linked_supplier_uuids, supplier.uuid), do: "badge-primary", else: "badge-ghost hover:badge-outline")
-                    ]}
-                    phx-click="toggle_supplier"
-                    phx-value-uuid={supplier.uuid}
-                  >
-                    <svg :if={MapSet.member?(@linked_supplier_uuids, supplier.uuid)} xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-                    </svg>
-                    {supplier.name}
-                  </label>
-                </div>
-              </div>
-
-              <%!-- Actions --%>
-              <div class="divider my-0"></div>
-
-              <div class="flex justify-end gap-3">
-                <.link navigate={Paths.manufacturers()} class="btn btn-ghost">Cancel</.link>
-                <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">{if @action == :new, do: "Create Manufacturer", else: "Save Changes"}</button>
+                <span class="label-text font-semibold mb-2">Contact Info</span>
+                <input
+                  type="text"
+                  name="manufacturer[contact_info]"
+                  value={Ecto.Changeset.get_field(@changeset, :contact_info) || ""}
+                  class="input input-bordered w-full transition-colors focus:input-primary"
+                  placeholder="Email or phone"
+                />
               </div>
             </div>
-          </.multilang_fields_wrapper>
+
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Logo URL</span>
+              <input
+                type="url"
+                name="manufacturer[logo_url]"
+                value={Ecto.Changeset.get_field(@changeset, :logo_url) || ""}
+                class="input input-bordered w-full transition-colors focus:input-primary"
+                placeholder="https://..."
+              />
+            </div>
+
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Notes</span>
+              <textarea
+                name="manufacturer[notes]"
+                class="textarea textarea-bordered w-full min-h-[5rem] transition-colors focus:textarea-primary"
+                rows="2"
+                placeholder="Internal notes about this manufacturer..."
+              >{Ecto.Changeset.get_field(@changeset, :notes) || ""}</textarea>
+            </div>
+
+            <div class="divider my-0"></div>
+
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Status</span>
+              <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+                <select name="manufacturer[status]">
+                  <option
+                    value="active"
+                    selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
+                  >
+                    Active
+                  </option>
+                  <option
+                    value="inactive"
+                    selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}
+                  >
+                    Inactive
+                  </option>
+                </select>
+              </label>
+              <span class="label-text-alt text-base-content/50 mt-1">
+                Inactive manufacturers won't appear in item dropdowns.
+              </span>
+            </div>
+
+            <%!-- Supplier links --%>
+            <div :if={@all_suppliers != []} class="flex flex-col gap-4">
+              <div class="divider my-0"></div>
+
+              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                  />
+                </svg>
+                Linked Suppliers
+              </h2>
+              <p class="text-sm text-base-content/50 -mt-2">Click to toggle supplier associations.</p>
+
+              <div class="flex flex-wrap gap-2">
+                <label
+                  :for={supplier <- @all_suppliers}
+                  class={[
+                    "badge badge-lg cursor-pointer gap-1.5 select-none transition-colors",
+                    if(MapSet.member?(@linked_supplier_uuids, supplier.uuid),
+                      do: "badge-primary",
+                      else: "badge-ghost hover:badge-outline"
+                    )
+                  ]}
+                  phx-click="toggle_supplier"
+                  phx-value-uuid={supplier.uuid}
+                >
+                  <svg
+                    :if={MapSet.member?(@linked_supplier_uuids, supplier.uuid)}
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-3.5 w-3.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  {supplier.name}
+                </label>
+              </div>
+            </div>
+
+            <%!-- Actions --%>
+            <div class="divider my-0"></div>
+
+            <div class="flex justify-end gap-3">
+              <.link navigate={Paths.manufacturers()} class="btn btn-ghost">Cancel</.link>
+              <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">
+                {if @action == :new, do: "Create Manufacturer", else: "Save Changes"}
+              </button>
+            </div>
+          </div>
         </div>
       </.form>
     </div>
     """
   end
+
+  defp changeset_errors(%Ecto.Changeset{action: action, errors: errors}, field)
+       when not is_nil(action) do
+    errors
+    |> Keyword.get_values(field)
+    |> Enum.map(fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+      end)
+    end)
+  end
+
+  defp changeset_errors(_changeset, _field), do: []
 end

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -333,12 +333,14 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
        when not is_nil(action) do
     errors
     |> Keyword.get_values(field)
-    |> Enum.map(fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-      end)
-    end)
+    |> Enum.map(&translate_error/1)
   end
 
   defp changeset_errors(_changeset, _field), do: []
+
+  defp translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
 end

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -1,23 +1,13 @@
 defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
-  @moduledoc "Create/edit form for suppliers with multilang support and manufacturer linking."
+  @moduledoc "Create/edit form for suppliers with manufacturer linking."
 
   use Phoenix.LiveView
 
   require Logger
 
-  import PhoenixKitWeb.Components.MultilangForm
-
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Supplier
-
-  @translatable_fields ["name", "description"]
-  @preserve_fields %{
-    "status" => :status,
-    "website" => :website,
-    "contact_info" => :contact_info,
-    "notes" => :notes
-  }
 
   @impl true
   def mount(params, _session, socket) do
@@ -48,35 +38,23 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
       all_manufacturers = Catalogue.list_manufacturers(status: "active")
 
       {:ok,
-       socket
-       |> assign(
+       assign(socket,
          page_title: if(action == :new, do: "New Supplier", else: "Edit #{supplier.name}"),
          action: action,
          supplier: supplier,
          changeset: changeset,
          all_manufacturers: all_manufacturers,
          linked_manufacturer_uuids: MapSet.new(linked_manufacturer_uuids)
-       )
-       |> mount_multilang()}
+       )}
     end
   end
 
   @impl true
-  def handle_event("switch_language", %{"lang" => lang_code}, socket) do
-    {:noreply, handle_switch_language(socket, lang_code)}
-  end
-
   def handle_event("validate", %{"supplier" => params}, socket) do
-    params =
-      merge_translatable_params(params, socket, @translatable_fields,
-        changeset: socket.assigns.changeset,
-        preserve_fields: @preserve_fields
-      )
-
     changeset =
       socket.assigns.supplier
       |> Catalogue.change_supplier(params)
-      |> Map.put(:action, :validate)
+      |> Map.put(:action, socket.assigns.changeset.action)
 
     {:noreply, assign(socket, :changeset, changeset)}
   end
@@ -93,12 +71,6 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
   end
 
   def handle_event("save", %{"supplier" => params}, socket) do
-    params =
-      merge_translatable_params(params, socket, @translatable_fields,
-        changeset: socket.assigns.changeset,
-        preserve_fields: @preserve_fields
-      )
-
     save_supplier(socket, socket.assigns.action, params)
   end
 
@@ -136,175 +108,221 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
 
   @impl true
   def render(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :lang_data,
-        get_lang_data(assigns.changeset, assigns.current_lang, assigns.multilang_enabled)
-      )
-
     ~H"""
     <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
       <%!-- Header --%>
       <div class="flex items-center gap-3">
         <.link navigate={Paths.suppliers()} class="btn btn-ghost btn-sm btn-square">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
           </svg>
         </.link>
         <div>
           <h1 class="text-2xl font-bold">{@page_title}</h1>
           <p class="text-sm text-base-content/60 mt-0.5">
-            {if @action == :new, do: "Add a new supplier to your catalogue system.", else: "Update supplier details and manufacturer links."}
+            {if @action == :new,
+              do: "Add a new supplier to your catalogue system.",
+              else: "Update supplier details and manufacturer links."}
           </p>
         </div>
       </div>
 
       <.form for={to_form(@changeset)} phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
-          <.multilang_tabs multilang_enabled={@multilang_enabled} language_tabs={@language_tabs} current_lang={@current_lang} />
-
-          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5">
-            <:skeleton>
-              <%!-- Name --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-20"></div>
-                <div class="skeleton h-12 w-full"></div>
-              </div>
-              <%!-- Description --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-28"></div>
-                <div class="skeleton h-24 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Contact & Web header --%>
-              <div class="skeleton h-5 w-32"></div>
-              <%!-- Website + Contact grid --%>
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-20"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-24"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-              </div>
-              <%!-- Notes --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-16"></div>
-                <div class="skeleton h-20 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Status --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-16"></div>
-                <div class="skeleton h-12 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Buttons --%>
-              <div class="flex justify-end gap-3">
-                <div class="skeleton h-12 w-20"></div>
-                <div class="skeleton h-12 w-36"></div>
-              </div>
-            </:skeleton>
-            <div class="card-body flex flex-col gap-5">
-              <.translatable_field
-                field_name="name" form_prefix="supplier" changeset={@changeset}
-                schema_field={:name} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label="Name" placeholder="e.g., Regional Distributors Inc." required
-                class="w-full"
+          <div class="card-body flex flex-col gap-5">
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Name *</span>
+              <input
+                type="text"
+                name="supplier[name]"
+                value={Ecto.Changeset.get_field(@changeset, :name) || ""}
+                class="input input-bordered w-full transition-colors focus:input-primary"
+                placeholder="e.g., Regional Distributors Inc."
               />
+              <p :for={msg <- changeset_errors(@changeset, :name)} class="text-error text-sm mt-1">
+                {msg}
+              </p>
+            </div>
 
-              <.translatable_field
-                field_name="description" form_prefix="supplier" changeset={@changeset}
-                schema_field={:description} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label="Description" type="textarea"
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Description</span>
+              <textarea
+                name="supplier[description]"
+                class="textarea textarea-bordered w-full transition-colors focus:textarea-primary"
+                rows="3"
                 placeholder="Brief description of this supplier..."
-                class="w-full"
-              />
+              >{Ecto.Changeset.get_field(@changeset, :description) || ""}</textarea>
+            </div>
 
-              <div class="divider my-0"></div>
+            <div class="divider my-0"></div>
 
-              <%!-- Contact & web --%>
-              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                </svg>
-                Contact & Web
-              </h2>
+            <%!-- Contact & web --%>
+            <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
+              Contact & Web
+            </h2>
 
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">Website</span>
-                  <input type="url" name="supplier[website]" value={Ecto.Changeset.get_field(@changeset, :website) || ""} class="input input-bordered w-full transition-colors focus:input-primary" placeholder="https://..." />
-                </div>
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">Contact Info</span>
-                  <input type="text" name="supplier[contact_info]" value={Ecto.Changeset.get_field(@changeset, :contact_info) || ""} class="input input-bordered w-full transition-colors focus:input-primary" placeholder="Email or phone" />
-                </div>
-              </div>
-
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div class="form-control">
-                <span class="label-text font-semibold mb-2">Notes</span>
-                <textarea name="supplier[notes]" class="textarea textarea-bordered w-full min-h-[5rem] transition-colors focus:textarea-primary" rows="2" placeholder="Internal notes about this supplier...">{Ecto.Changeset.get_field(@changeset, :notes) || ""}</textarea>
+                <span class="label-text font-semibold mb-2">Website</span>
+                <input
+                  type="url"
+                  name="supplier[website]"
+                  value={Ecto.Changeset.get_field(@changeset, :website) || ""}
+                  class="input input-bordered w-full transition-colors focus:input-primary"
+                  placeholder="https://..."
+                />
               </div>
-
-              <div class="divider my-0"></div>
-
               <div class="form-control">
-                <span class="label-text font-semibold mb-2">Status</span>
-                <select name="supplier[status]" class="select select-bordered w-full transition-colors focus:select-primary">
-                  <option value="active" selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}>Active</option>
-                  <option value="inactive" selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}>Inactive</option>
-                </select>
-                <span class="label-text-alt text-base-content/50 mt-1">Inactive suppliers won't appear in manufacturer linking.</span>
-              </div>
-
-              <%!-- Manufacturer links --%>
-              <div :if={@all_manufacturers != []} class="flex flex-col gap-4">
-                <div class="divider my-0"></div>
-
-                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                  </svg>
-                  Linked Manufacturers
-                </h2>
-                <p class="text-sm text-base-content/50 -mt-2">Click to toggle manufacturer associations.</p>
-
-                <div class="flex flex-wrap gap-2">
-                  <label
-                    :for={m <- @all_manufacturers}
-                    class={[
-                      "badge badge-lg cursor-pointer gap-1.5 select-none transition-colors",
-                      if(MapSet.member?(@linked_manufacturer_uuids, m.uuid), do: "badge-primary", else: "badge-ghost hover:badge-outline")
-                    ]}
-                    phx-click="toggle_manufacturer"
-                    phx-value-uuid={m.uuid}
-                  >
-                    <svg :if={MapSet.member?(@linked_manufacturer_uuids, m.uuid)} xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-                    </svg>
-                    {m.name}
-                  </label>
-                </div>
-              </div>
-
-              <%!-- Actions --%>
-              <div class="divider my-0"></div>
-
-              <div class="flex justify-end gap-3">
-                <.link navigate={Paths.suppliers()} class="btn btn-ghost">Cancel</.link>
-                <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">{if @action == :new, do: "Create Supplier", else: "Save Changes"}</button>
+                <span class="label-text font-semibold mb-2">Contact Info</span>
+                <input
+                  type="text"
+                  name="supplier[contact_info]"
+                  value={Ecto.Changeset.get_field(@changeset, :contact_info) || ""}
+                  class="input input-bordered w-full transition-colors focus:input-primary"
+                  placeholder="Email or phone"
+                />
               </div>
             </div>
-          </.multilang_fields_wrapper>
+
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Notes</span>
+              <textarea
+                name="supplier[notes]"
+                class="textarea textarea-bordered w-full min-h-[5rem] transition-colors focus:textarea-primary"
+                rows="2"
+                placeholder="Internal notes about this supplier..."
+              >{Ecto.Changeset.get_field(@changeset, :notes) || ""}</textarea>
+            </div>
+
+            <div class="divider my-0"></div>
+
+            <div class="form-control">
+              <span class="label-text font-semibold mb-2">Status</span>
+              <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+                <select name="supplier[status]">
+                  <option
+                    value="active"
+                    selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
+                  >
+                    Active
+                  </option>
+                  <option
+                    value="inactive"
+                    selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}
+                  >
+                    Inactive
+                  </option>
+                </select>
+              </label>
+              <span class="label-text-alt text-base-content/50 mt-1">
+                Inactive suppliers won't appear in manufacturer linking.
+              </span>
+            </div>
+
+            <%!-- Manufacturer links --%>
+            <div :if={@all_manufacturers != []} class="flex flex-col gap-4">
+              <div class="divider my-0"></div>
+
+              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                  />
+                </svg>
+                Linked Manufacturers
+              </h2>
+              <p class="text-sm text-base-content/50 -mt-2">
+                Click to toggle manufacturer associations.
+              </p>
+
+              <div class="flex flex-wrap gap-2">
+                <label
+                  :for={m <- @all_manufacturers}
+                  class={[
+                    "badge badge-lg cursor-pointer gap-1.5 select-none transition-colors",
+                    if(MapSet.member?(@linked_manufacturer_uuids, m.uuid),
+                      do: "badge-primary",
+                      else: "badge-ghost hover:badge-outline"
+                    )
+                  ]}
+                  phx-click="toggle_manufacturer"
+                  phx-value-uuid={m.uuid}
+                >
+                  <svg
+                    :if={MapSet.member?(@linked_manufacturer_uuids, m.uuid)}
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-3.5 w-3.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  {m.name}
+                </label>
+              </div>
+            </div>
+
+            <%!-- Actions --%>
+            <div class="divider my-0"></div>
+
+            <div class="flex justify-end gap-3">
+              <.link navigate={Paths.suppliers()} class="btn btn-ghost">Cancel</.link>
+              <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">
+                {if @action == :new, do: "Create Supplier", else: "Save Changes"}
+              </button>
+            </div>
+          </div>
         </div>
       </.form>
     </div>
     """
   end
+
+  defp changeset_errors(%Ecto.Changeset{action: action, errors: errors}, field)
+       when not is_nil(action) do
+    errors
+    |> Keyword.get_values(field)
+    |> Enum.map(fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+      end)
+    end)
+  end
+
+  defp changeset_errors(_changeset, _field), do: []
 end

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -317,12 +317,14 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
        when not is_nil(action) do
     errors
     |> Keyword.get_values(field)
-    |> Enum.map(fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-      end)
-    end)
+    |> Enum.map(&translate_error/1)
   end
 
   defp changeset_errors(_changeset, _field), do: []
+
+  defp translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
 end


### PR DESCRIPTION
Summary

  - Move non-translatable fields (status, actions) outside the multilang language
  switcher in the catalogue form so they don't flash skeleton on language switch
  - Remove multilang from manufacturer and supplier forms — company names don't need
  translations
  - Fix daisyUI 5 select text centering by wrapping <select> in <label class="select">
  - Fix premature validation errors showing before first form submission
  - Show Catalogues, Manufacturers, and Suppliers as sidebar subtabs instead of Catalogue
   being the main view
  - Fix missing manufacturer icon (hero-building-office-2 → hero-building-office)