### PR TITLE
Wrap all user-visible strings in Gettext for translation

### DIFF
--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -343,7 +343,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Add Item")}
             </.link>
             <.link navigate={Paths.catalogue_edit(@catalogue.uuid)} class="btn btn-ghost btn-sm">
-              Edit
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
             </.link>
           </:actions>
         </.admin_page_header>
@@ -396,7 +396,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               )
             ]}
           >
-            Active
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
           </button>
           <button
             type="button"
@@ -410,7 +410,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               )
             ]}
           >
-            Deleted ({@deleted_count})
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_count})
           </button>
         </div>
 
@@ -462,10 +462,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 <%!-- Active mode: Edit + Delete --%>
                 <div :if={@view_mode == "active"} class="flex gap-1">
                   <.link navigate={Paths.category_edit(category.uuid)} class="btn btn-ghost btn-xs">
-                    Edit
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
                   </.link>
                   <button phx-click="trash_category" phx-value-uuid={category.uuid} class="btn btn-ghost btn-xs text-error">
-                    Delete
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
                   </button>
                 </div>
 
@@ -476,7 +476,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                     phx-value-uuid={category.uuid}
                     class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
                   >
-                    Restore
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
                   </button>
                   <button
                     phx-click="show_delete_confirm"
@@ -484,7 +484,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                     phx-value-type="category"
                     class="btn btn-ghost btn-xs text-error"
                   >
-                    Delete Forever
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
                   </button>
                 </div>
               </div>
@@ -526,7 +526,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               </div>
 
               <p :if={category.items == [] and @view_mode == "active"} class="text-sm text-base-content/40 text-center py-4">
-                No items in this category.
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "No items in this category.")}
               </p>
             </div>
           </div>

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -232,7 +232,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
 
             <div class="form-control">
               <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Percentage")}</span>
-              <input type="number" name="catalogue[markup_percentage]" value={Ecto.Changeset.get_field(@changeset, :markup_percentage)} class="input input-bordered w-full transition-colors focus:input-primary" step="0.01" min="0" placeholder="e.g., 15.0" />
+              <input type="number" name="catalogue[markup_percentage]" value={Ecto.Changeset.get_field(@changeset, :markup_percentage)} class="input input-bordered w-full transition-colors focus:input-primary" step="0.01" min="0" placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 15.0")} />
               <span class="label-text-alt text-base-content/50 mt-1">
                 {Gettext.gettext(PhoenixKitWeb.Gettext, "Applied to all item base prices to calculate sale prices. Leave blank for no markup.")}
               </span>
@@ -246,18 +246,18 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                     value="active"
                     selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
                   >
-                    Active
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
                   </option>
                   <option
                     value="archived"
                     selected={Ecto.Changeset.get_field(@changeset, :status) == "archived"}
                   >
-                    Archived
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived")}
                   </option>
                 </select>
               </label>
               <span class="label-text-alt text-base-content/50 mt-1">
-                Archived catalogues are hidden from active views.
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived catalogues are hidden from active views.")}
               </span>
             </div>
 
@@ -280,11 +280,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
           <div>
             <span class="text-sm font-semibold text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Catalogue")}</span>
             <p class="text-xs text-base-content/50">
-              This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.")}
             </p>
           </div>
           <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
-            Delete Forever
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
           </button>
         </div>
       </div>

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -240,7 +240,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
 
             <div class="form-control">
               <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-              <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+              <label class="select w-full transition-colors focus-within:select-primary">
                 <select name="catalogue[status]">
                   <option
                     value="active"

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -356,7 +356,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
               )
             ]}
           >
-            Active
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
           </button>
           <button
             type="button"
@@ -370,7 +370,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
               )
             ]}
           >
-            Deleted ({@deleted_catalogue_count})
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_catalogue_count})
           </button>
         </div>
 
@@ -463,18 +463,18 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             <%!-- Active mode actions --%>
             <.table_default_cell :if={@view_mode == "active"} class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"cat-menu-#{catalogue.uuid}"}>
-                <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label="View" />
-                <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label="Edit" variant="secondary" />
+                <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label={Gettext.gettext(PhoenixKitWeb.Gettext, "View")} />
+                <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} variant="secondary" />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} icon="hero-trash" label="Delete" variant="error" />
+                <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
             <%!-- Deleted mode actions --%>
             <.table_default_cell :if={@view_mode == "deleted"} class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"cat-del-menu-#{catalogue.uuid}"}>
-                <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} icon="hero-arrow-path" label="Restore" variant="success" />
+                <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")} variant="success" />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label="Delete Forever" variant="error" />
+                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
           </.table_default_row>
@@ -529,9 +529,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             <.table_default_cell><.status_badge status={m.status} size={:sm} /></.table_default_cell>
             <.table_default_cell class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"mfg-menu-#{m.uuid}"}>
-                <.table_row_menu_link navigate={Paths.manufacturer_edit(m.uuid)} icon="hero-pencil" label="Edit" />
+                <.table_row_menu_link navigate={Paths.manufacturer_edit(m.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" icon="hero-trash" label="Delete" variant="error" />
+                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
           </.table_default_row>
@@ -580,9 +580,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             <.table_default_cell><.status_badge status={s.status} size={:sm} /></.table_default_cell>
             <.table_default_cell class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"supplier-menu-#{s.uuid}"}>
-                <.table_row_menu_link navigate={Paths.supplier_edit(s.uuid)} icon="hero-pencil" label="Edit" variant="secondary" />
+                <.table_row_menu_link navigate={Paths.supplier_edit(s.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} variant="secondary" />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" icon="hero-trash" label="Delete" variant="error" />
+                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
           </.table_default_row>

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -300,7 +300,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
               disabled={is_nil(@move_target)}
               class="btn btn-sm btn-outline"
             >
-              Move
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
             </button>
           </div>
         </div>
@@ -314,7 +314,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
             <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this category and all its items. This cannot be undone.")}</p>
           </div>
           <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
-            Delete Forever
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
           </button>
         </div>
       </div>

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -287,7 +287,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
           <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this category and all its items to a different catalogue.")}</p>
           <div class="flex items-end gap-3">
             <div class="form-control flex-1">
-              <label class="select select-bordered w-full select-sm transition-colors focus-within:select-primary">
+              <label class="select w-full select-sm transition-colors focus-within:select-primary">
                 <select phx-change="select_move_target" name="catalogue_uuid">
                   <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}</option>
                   <option :for={cat <- @other_catalogues} value={cat.uuid}>{cat.name}</option>

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -28,7 +28,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
       />
 
       <%!-- Search bar --%>
-      <.search_input query={@search_query} placeholder="Search items..." />
+      <.search_input query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items...")} />
   """
 
   use Phoenix.Component
@@ -536,9 +536,9 @@ defmodule PhoenixKitCatalogue.Web.Components do
   end
 
   defp format_unit(nil), do: "—"
-  defp format_unit("piece"), do: "pc"
-  defp format_unit("m2"), do: "m²"
-  defp format_unit("running_meter"), do: "rm"
+  defp format_unit("piece"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "pc")
+  defp format_unit("m2"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "m²")
+  defp format_unit("running_meter"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "rm")
   defp format_unit(other), do: to_string(other)
 
   # Safe sale price calculation — handles non-Decimal markup gracefully

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -289,17 +289,17 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
                 </svg>
-                Pricing & Identification
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Pricing & Identification")}
               </h2>
 
               <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="form-control">
                   <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")}</span>
-                  <input type="text" name="item[sku]" value={Ecto.Changeset.get_field(@changeset, :sku) || ""} class="input input-bordered w-full font-mono transition-colors focus:input-primary" placeholder="e.g., KF-001" />
+                  <input type="text" name="item[sku]" value={Ecto.Changeset.get_field(@changeset, :sku) || ""} class="input input-bordered w-full font-mono transition-colors focus:input-primary" placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., KF-001")} />
                 </div>
                 <div class="form-control">
                   <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")}</span>
-                  <input type="number" name="item[base_price]" value={Ecto.Changeset.get_field(@changeset, :base_price)} class="input input-bordered w-full transition-colors focus:input-primary" step="0.01" min="0" placeholder="0.00" />
+                  <input type="number" name="item[base_price]" value={Ecto.Changeset.get_field(@changeset, :base_price)} class="input input-bordered w-full transition-colors focus:input-primary" step="0.01" min="0" placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "0.00")} />
                   <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cost/purchase price before catalogue markup.")}</span>
                 </div>
                 <div class="form-control">
@@ -321,7 +321,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
                 </svg>
-                Classification
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Classification")}
               </h2>
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -401,7 +401,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               disabled={is_nil(@move_target)}
               class="btn btn-sm btn-outline"
             >
-              Move
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
             </button>
           </div>
         </div>

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -304,7 +304,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 </div>
                 <div class="form-control">
                   <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}</span>
-                  <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+                  <label class="select w-full transition-colors focus-within:select-primary">
                     <select name="item[unit]">
                       <option value="piece" selected={Ecto.Changeset.get_field(@changeset, :unit) == "piece"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Piece")}</option>
                       <option value="m2" selected={Ecto.Changeset.get_field(@changeset, :unit) == "m2"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "m² (square meter)")}</option>
@@ -327,7 +327,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="form-control">
                   <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}</span>
-                  <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+                  <label class="select w-full transition-colors focus-within:select-primary">
                     <select name="item[category_uuid]">
                       <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- No category --")}</option>
                       <option
@@ -342,7 +342,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 </div>
                 <div class="form-control">
                   <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")}</span>
-                  <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+                  <label class="select w-full transition-colors focus-within:select-primary">
                     <select name="item[manufacturer_uuid]">
                       <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- No manufacturer --")}</option>
                       <option
@@ -359,7 +359,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
 
               <div class="form-control">
                 <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-                <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+                <label class="select w-full transition-colors focus-within:select-primary">
                   <select name="item[status]">
                     <option value="active" selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}</option>
                     <option value="inactive" selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")}</option>
@@ -388,7 +388,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item to a category in any catalogue.")}</p>
           <div class="flex items-end gap-3">
             <div class="form-control flex-1">
-              <label class="select select-bordered w-full select-sm transition-colors focus-within:select-primary">
+              <label class="select w-full select-sm transition-colors focus-within:select-primary">
                 <select phx-change="select_move_target" name="category_uuid">
                   <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}</option>
                   <option :for={cat <- @all_categories} value={cat.uuid}>{cat.name}</option>

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -159,13 +159,13 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
         <div class="card bg-base-100 shadow-lg">
           <div class="card-body flex flex-col gap-5">
             <div class="form-control">
-              <span class="label-text font-semibold mb-2">Name *</span>
+              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} *</span>
               <input
                 type="text"
                 name="manufacturer[name]"
                 value={Ecto.Changeset.get_field(@changeset, :name) || ""}
                 class="input input-bordered w-full transition-colors focus:input-primary"
-                placeholder="e.g., Blum, Hettich"
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Blum, Hettich")}
               />
               <p :for={msg <- changeset_errors(@changeset, :name)} class="text-error text-sm mt-1">
                 {msg}
@@ -200,7 +200,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
                   d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
                 />
               </svg>
-              Contact & Web
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Contact & Web")}
             </h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -211,7 +211,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
                   name="manufacturer[website]"
                   value={Ecto.Changeset.get_field(@changeset, :website) || ""}
                   class="input input-bordered w-full transition-colors focus:input-primary"
-                  placeholder="https://..."
+                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
                 />
               </div>
               <div class="form-control">
@@ -233,7 +233,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
                 name="manufacturer[logo_url]"
                 value={Ecto.Changeset.get_field(@changeset, :logo_url) || ""}
                 class="input input-bordered w-full transition-colors focus:input-primary"
-                placeholder="https://..."
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
               />
             </div>
 
@@ -257,18 +257,18 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
                     value="active"
                     selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
                   >
-                    Active
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
                   </option>
                   <option
                     value="inactive"
                     selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}
                   >
-                    Inactive
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")}
                   </option>
                 </select>
               </label>
               <span class="label-text-alt text-base-content/50 mt-1">
-                Inactive manufacturers won't appear in item dropdowns.
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive manufacturers won't appear in item dropdowns.")}
               </span>
             </div>
 

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -251,7 +251,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
 
             <div class="form-control">
               <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-              <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+              <label class="select w-full transition-colors focus-within:select-primary">
                 <select name="manufacturer[status]">
                   <option
                     value="active"

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -159,13 +159,13 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
         <div class="card bg-base-100 shadow-lg">
           <div class="card-body flex flex-col gap-5">
             <div class="form-control">
-              <span class="label-text font-semibold mb-2">Name *</span>
+              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} *</span>
               <input
                 type="text"
                 name="supplier[name]"
                 value={Ecto.Changeset.get_field(@changeset, :name) || ""}
                 class="input input-bordered w-full transition-colors focus:input-primary"
-                placeholder="e.g., Regional Distributors Inc."
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Regional Distributors Inc.")}
               />
               <p :for={msg <- changeset_errors(@changeset, :name)} class="text-error text-sm mt-1">
                 {msg}
@@ -200,7 +200,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
                   d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
                 />
               </svg>
-              Contact & Web
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Contact & Web")}
             </h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -211,7 +211,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
                   name="supplier[website]"
                   value={Ecto.Changeset.get_field(@changeset, :website) || ""}
                   class="input input-bordered w-full transition-colors focus:input-primary"
-                  placeholder="https://..."
+                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
                 />
               </div>
               <div class="form-control">
@@ -246,18 +246,18 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
                     value="active"
                     selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
                   >
-                    Active
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
                   </option>
                   <option
                     value="inactive"
                     selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}
                   >
-                    Inactive
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")}
                   </option>
                 </select>
               </label>
               <span class="label-text-alt text-base-content/50 mt-1">
-                Inactive suppliers won't appear in manufacturer linking.
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive suppliers won't appear in manufacturer linking.")}
               </span>
             </div>
 

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -240,7 +240,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
 
             <div class="form-control">
               <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-              <label class="select select-bordered w-full transition-colors focus-within:select-primary">
+              <label class="select w-full transition-colors focus-within:select-primary">
                 <select name="supplier[status]">
                   <option
                     value="active"


### PR DESCRIPTION
Summary

  - Wrap 30+ hardcoded user-visible strings in Gettext.gettext(PhoenixKitWeb.Gettext, ...) across all 8 LiveView files
  - No logic changes — purely string wrapping for i18n support
  - Rendered output is identical (Gettext returns the English original when no translation is configured)

  What was wrapped

  - Status options: Active, Inactive, Archived in all form select dropdowns
  - Tab labels: Active, Deleted in catalogue/detail view mode switchers
  - Action labels: Edit, Delete, View, Restore, Delete Forever, Move — in row menus, buttons, and links
  - Section headers: Contact & Web, Pricing & Identification, Classification
  - Help text: status descriptions ("Inactive manufacturers won't appear..."), danger zone warnings, archived help text
  - Placeholders: SKU example, price, URLs, manufacturer/supplier name examples, markup percentage, search box
  - Unit abbreviations: pc, m², rm in the components table display

  Files changed

  All in lib/phoenix_kit_catalogue/web/:
  - catalogues_live.ex — row menu labels, Active/Deleted tabs
  - catalogue_form_live.ex — Active/Archived options, help text, Delete Forever button, markup placeholder
  - catalogue_detail_live.ex — Active/Deleted tabs, Edit/Delete/Restore/Delete Forever buttons, empty state
  - category_form_live.ex — Move button, Delete Forever button
  - item_form_live.ex — section headers, SKU/price placeholders, Move button
  - manufacturer_form_live.ex — Name label, placeholder, Contact & Web header, Active/Inactive, help text, URL placeholders
  - supplier_form_live.ex — same pattern as manufacturer
  - components.ex — unit abbreviations (pc, m², rm), search placeholder