### PR TITLE
Catalogue improvements: paged search, item markup override, import wizard expansion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,8 @@ Multi-step file import wizard for bulk item creation from XLSX/CSV files.
 
 - **Parser** (`import/parser.ex`): Format detection, XLSX via `XlsxReader`, CSV with auto-separator detection, BOM stripping
 - **Mapper** (`import/mapper.ex`): Auto-detect column mappings, unit normalization, import plan builder with validation
-- **Executor** (`import/executor.ex`): Two-phase execution (categories then items), progress reporting, language support, actor_uuid threading for activity logs
-- **ImportLive** (`web/import_live.ex`): Upload → sheet select → column mapping → confirm → importing → results. ETS buffering for large files, duplicate detection, multilang support
+- **Executor** (`import/executor.ex`): Three-phase execution (1: get-or-create categories + manufacturers + suppliers in column mode; 2: insert items resolving category/manufacturer per row; 3: create manufacturer↔supplier M:N links from per-row pairs and/or fixed supplier→all-touched-manufacturers), progress reporting, language support, actor_uuid threading for activity logs. Items get `manufacturer_uuid` directly; suppliers attach via the M:N join because items don't have a supplier FK
+- **ImportLive** (`web/import_live.ex`): Upload → sheet select → column mapping → confirm → importing → results. ETS buffering for large files, duplicate detection, multilang support. Three pickers (category / manufacturer / supplier) share a four-mode vocabulary — `:none` / `:column` (per-row from a CSV column) / `:create` (inline form, persisted at execute time so cancelling the confirm step doesn't leave orphans) / `:existing` (pick from active records). The `available_picker_columns/2` filter prevents a picker from silently clobbering a sibling's column mapping; switching sheets / replacing the file calls `reset_picker_state/1` so picker assigns can never reference stale column indices
 
 ### Search API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ This is a **PhoenixKit module** that implements the `PhoenixKit.Module` behaviou
 
 - **Catalogue** (`phoenix_kit_cat_catalogues`) — top-level groupings with name, description, markup_percentage (default 0%), status (active/archived/deleted)
 - **Category** (`phoenix_kit_cat_categories`) — subdivisions within a catalogue with position ordering, status (active/deleted)
-- **Item** (`phoenix_kit_cat_items`) — individual products with SKU, base_price, unit of measure, manufacturer link, status (active/deleted). **Belongs directly to a catalogue via `catalogue_uuid`** (required), with an optional `category_uuid` for grouping. Items without a category are "uncategorized within a catalogue" — still scoped to that catalogue. Sale price computed via catalogue's markup_percentage
+- **Item** (`phoenix_kit_cat_items`) — individual products with SKU, base_price, unit of measure, manufacturer link, status (active/deleted). **Belongs directly to a catalogue via `catalogue_uuid`** (required), with an optional `category_uuid` for grouping. Items without a category are "uncategorized within a catalogue" — still scoped to that catalogue. Sale price computed via catalogue's `markup_percentage` unless the item has its own `markup_percentage` override (nullable column, V97): `NULL` inherits from the catalogue, any Decimal (including `0`) overrides it. `Item.sale_price(item, catalogue_markup)` and `Item.effective_markup(item, catalogue_markup)` both honor the override transparently
 - **Manufacturer** (`phoenix_kit_cat_manufacturers`) — company directory with name, website, logo, status (active/inactive)
 - **Supplier** (`phoenix_kit_cat_suppliers`) — delivery companies with name, website, status (active/inactive)
 - **ManufacturerSupplier** (`phoenix_kit_cat_manufacturer_suppliers`) — many-to-many join table
@@ -89,6 +89,22 @@ Multi-step file import wizard for bulk item creation from XLSX/CSV files.
 - **Mapper** (`import/mapper.ex`): Auto-detect column mappings, unit normalization, import plan builder with validation
 - **Executor** (`import/executor.ex`): Two-phase execution (categories then items), progress reporting, language support, actor_uuid threading for activity logs
 - **ImportLive** (`web/import_live.ex`): Upload → sheet select → column mapping → confirm → importing → results. ETS buffering for large files, duplicate detection, multilang support
+
+### Search API
+
+Three search functions, each paired with an unbounded count function. Results page through the same `InfiniteScroll` sentinel that drives the category walk in `CatalogueDetailLive`.
+
+| List function | Count function | Scope |
+|---------------|---------------|-------|
+| `search_items/2` | `count_search_items/1` | All non-deleted catalogues |
+| `search_items_in_catalogue/3` | `count_search_items_in_catalogue/2` | One catalogue |
+| `search_items_in_category/3` | `count_search_items_in_category/2` | One category |
+
+All list functions take `:limit` (default 50) and `:offset` (default 0) in `opts`. Sort order is deterministic for paging — each query appends `asc: i.uuid` as the final tie-breaker. Count functions run the same `where` clauses but with `select: count(i.uuid)` and no `:limit`/`:offset`/`:order_by`/`:preload`, so they return the full matching total regardless of the current page.
+
+**LiveView usage pattern** (see `CatalogueDetailLive.run_search/2` and `load_next_search_batch/1`): fetch first page + total on search, render a sentinel while `search_has_more = loaded < total`, append pages via the shared `InfiniteScroll` hook. `search_results_summary` accepts an optional `loaded` attr to render "Showing X of Y" while paging.
+
+**Async + loading state** (same LiveView): searches run inside `start_async(:search, …)` so a newer query cancels a pending one and stale responses are dropped by a query-equality guard in `handle_async(:search, {:ok, …})`. While a search is in flight, the template shows a "Searching for …" status line (first search) or dims the prior results with `opacity-50` and shows a small spinner next to the summary (subsequent searches). Unexpected task exits log a warning and surface a user-visible flash; expected cancellation reasons (`:shutdown` / `:killed`) are no-ops.
 
 ### Web Layer
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Designed for manufacturing companies (e.g. kitchen/furniture producers) that nee
 - **Items** — individual products with SKU, base price, computed sale price, unit of measure
 - **Manufacturers** — company directory with many-to-many supplier linking
 - **Suppliers** — delivery companies linked to manufacturers
-- **Pricing** — base price per item + markup percentage per catalogue = computed sale price
+- **Pricing** — base price per item + markup percentage per catalogue = computed sale price, with an optional per-item markup override
 - **Search** — case-insensitive search by name, description, or SKU (per-category, per-catalogue, and global)
 - **Soft-delete** — catalogues, categories, and items support trash/restore with cascading
 - **Multilingual** — all translatable fields use PhoenixKit's multilang system
@@ -121,7 +121,12 @@ Catalogue.restore_item(item)                       # cascades up to category + c
 Catalogue.permanently_delete_item(item)            # hard-delete
 Catalogue.trash_items_in_category(cat_uuid)        # bulk soft-delete
 Catalogue.move_item_to_category(item, new_cat_uuid)
-Catalogue.item_pricing(item)                       # %{base_price, markup_percentage, price}
+Catalogue.item_pricing(item)                       # %{base_price, catalogue_markup, item_markup, markup_percentage, price}
+
+# Per-item markup override (nullable — defaults to inherit from catalogue)
+Catalogue.create_item(%{name: "Special Oak", base_price: 100, markup_percentage: 50, catalogue_uuid: cat.uuid})
+Item.sale_price(item, catalogue.markup_percentage)  # honors item override if set
+Item.effective_markup(item, catalogue.markup_percentage) # returns the override or the fallback
 Catalogue.swap_category_positions(cat_a, cat_b)    # atomic position swap
 
 # ── Manufacturers ─────────────────────────────────────
@@ -144,8 +149,14 @@ Catalogue.list_manufacturers_for_supplier(s_uuid)
 # ── Search ────────────────────────────────────────────
 Catalogue.search_items("oak")                      # global across all catalogues
 Catalogue.search_items("oak", limit: 10)
+Catalogue.search_items("oak", limit: 100, offset: 100)   # paging
 Catalogue.search_items_in_catalogue(cat_uuid, "panel")
 Catalogue.search_items_in_category(cat_uuid, "oak") # within one category
+
+# Unbounded total for paging / summaries
+Catalogue.count_search_items("oak")
+Catalogue.count_search_items_in_catalogue(cat_uuid, "panel")
+Catalogue.count_search_items_in_category(cat_uuid, "oak")
 
 # ── Counts ────────────────────────────────────────────
 Catalogue.item_count_for_catalogue(cat_uuid)       # active items
@@ -211,7 +222,12 @@ Global table/card toggle that syncs all tables sharing the same `storage_key`:
 ### `search_results_summary/1` and `empty_state/1`
 
 ```heex
-<.search_results_summary count={length(@results)} query={@query} />
+<%!-- Full result set loaded --%>
+<.search_results_summary count={@total} query={@query} />
+
+<%!-- Paged results — renders "Showing 100 of 237 results for …" --%>
+<.search_results_summary count={@total} query={@query} loaded={length(@results)} />
+
 <.empty_state message="No items yet." />
 ```
 

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -2164,6 +2164,22 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
+  Returns a map of `catalogue_uuid => non_deleted_category_count`, in a
+  single query. Useful for displaying category counts alongside a
+  catalogue list (e.g. in the import wizard's catalogue picker) without
+  N+1 lookups.
+  """
+  def category_counts_by_catalogue do
+    from(c in Category,
+      where: c.status != "deleted",
+      group_by: c.catalogue_uuid,
+      select: {c.catalogue_uuid, count(c.uuid)}
+    )
+    |> repo().all()
+    |> Map.new()
+  end
+
+  @doc """
   Counts deleted items in a catalogue, including items without a category.
   """
   def deleted_item_count_for_catalogue(catalogue_uuid) do

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -1818,24 +1818,51 @@ defmodule PhoenixKitCatalogue.Catalogue do
   and logs a warning so the caller still gets a renderable result
   instead of crashing a template.
 
-  Returns a map with `:base_price`, `:markup_percentage`, and `:price`
-  (sale price). Returns `nil` values if the item has no base price.
+  Returns a map with:
+
+    * `:base_price` — the item's stored base price (or `nil` if unset)
+    * `:catalogue_markup` — the parent catalogue's `markup_percentage`
+      (the inherited default for items without an override)
+    * `:item_markup` — the item's `markup_percentage` override, or
+      `nil` when the item inherits from the catalogue
+    * `:markup_percentage` — the markup actually applied to compute
+      `:price` — the item's override if set, otherwise the catalogue's
+    * `:price` — the computed sale price (or `nil` if no base price)
+
+  Returns `nil` for `:price` if the item has no base price.
 
   ## Examples
 
+      # Item inherits the catalogue's markup
       Catalogue.item_pricing(item)
-      #=> %{base_price: Decimal.new("100.00"), markup_percentage: Decimal.new("15.0"), price: Decimal.new("115.00")}
+      #=> %{
+      #=>   base_price: Decimal.new("100.00"),
+      #=>   catalogue_markup: Decimal.new("15.0"),
+      #=>   item_markup: nil,
+      #=>   markup_percentage: Decimal.new("15.0"),
+      #=>   price: Decimal.new("115.00")
+      #=> }
 
-      Catalogue.item_pricing(item_without_category)
-      #=> %{base_price: Decimal.new("100.00"), markup_percentage: Decimal.new("0"), price: Decimal.new("100.00")}
+      # Item overrides to 50%
+      Catalogue.item_pricing(item_with_override)
+      #=> %{
+      #=>   base_price: Decimal.new("100.00"),
+      #=>   catalogue_markup: Decimal.new("15.0"),
+      #=>   item_markup: Decimal.new("50.0"),
+      #=>   markup_percentage: Decimal.new("50.0"),
+      #=>   price: Decimal.new("150.00")
+      #=> }
   """
   def item_pricing(%Item{} = item) do
-    markup = safe_markup_for_item(item)
+    catalogue_markup = safe_markup_for_item(item)
+    effective = Item.effective_markup(item, catalogue_markup)
 
     %{
       base_price: item.base_price,
-      markup_percentage: markup,
-      price: Item.sale_price(item, markup)
+      catalogue_markup: catalogue_markup,
+      item_markup: item.markup_percentage,
+      markup_percentage: effective,
+      price: Item.sale_price(item, catalogue_markup)
     }
   end
 
@@ -1885,14 +1912,17 @@ defmodule PhoenixKitCatalogue.Catalogue do
   ## Options
 
     * `:limit` — max results to return (default 50)
+    * `:offset` — number of results to skip, for paging (default 0)
 
   ## Examples
 
       Catalogue.search_items("oak")
       Catalogue.search_items("OAK-18", limit: 10)
+      Catalogue.search_items("oak", limit: 100, offset: 100)
   """
   def search_items(query, opts \\ []) do
     limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
     pattern = "%#{sanitize_like(query)}%"
 
     from(i in Item,
@@ -1907,11 +1937,42 @@ defmodule PhoenixKitCatalogue.Catalogue do
           ilike(i.description, ^pattern) or
           ilike(i.sku, ^pattern) or
           fragment("?::text ILIKE ?", i.data, ^pattern),
-      order_by: [asc: i.name],
+      order_by: [asc: i.name, asc: i.uuid],
       limit: ^limit,
+      offset: ^offset,
       preload: [:catalogue, category: :catalogue, manufacturer: []]
     )
     |> repo().all()
+  end
+
+  @doc """
+  Returns the total number of items across all non-deleted catalogues
+  that match a search query, using the same matching rules as
+  `search_items/2`. Runs independently of `:limit`/`:offset`.
+
+  ## Examples
+
+      Catalogue.count_search_items("oak")
+      #=> 1204
+  """
+  def count_search_items(query) do
+    pattern = "%#{sanitize_like(query)}%"
+
+    from(i in Item,
+      join: cat in Catalogue,
+      on: i.catalogue_uuid == cat.uuid,
+      left_join: c in Category,
+      on: i.category_uuid == c.uuid,
+      where: i.status != "deleted" and cat.status != "deleted",
+      where: is_nil(c.uuid) or c.status != "deleted",
+      where:
+        ilike(i.name, ^pattern) or
+          ilike(i.description, ^pattern) or
+          ilike(i.sku, ^pattern) or
+          fragment("?::text ILIKE ?", i.data, ^pattern),
+      select: count(i.uuid)
+    )
+    |> repo().one()
   end
 
   @doc """
@@ -1927,14 +1988,17 @@ defmodule PhoenixKitCatalogue.Catalogue do
   ## Options
 
     * `:limit` — max results to return (default 50)
+    * `:offset` — number of results to skip, for paging (default 0)
 
   ## Examples
 
       Catalogue.search_items_in_catalogue(catalogue_uuid, "panel")
       Catalogue.search_items_in_catalogue(catalogue_uuid, "SKU", limit: 25)
+      Catalogue.search_items_in_catalogue(catalogue_uuid, "panel", limit: 100, offset: 100)
   """
   def search_items_in_catalogue(catalogue_uuid, query, opts \\ []) do
     limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
     pattern = "%#{sanitize_like(query)}%"
 
     from(i in Item,
@@ -1948,11 +2012,44 @@ defmodule PhoenixKitCatalogue.Catalogue do
           ilike(i.description, ^pattern) or
           ilike(i.sku, ^pattern) or
           fragment("?::text ILIKE ?", i.data, ^pattern),
-      order_by: [asc_nulls_last: c.position, asc: i.name],
+      order_by: [asc_nulls_last: c.position, asc: i.name, asc: i.uuid],
       limit: ^limit,
+      offset: ^offset,
       preload: [:catalogue, category: :catalogue, manufacturer: []]
     )
     |> repo().all()
+  end
+
+  @doc """
+  Returns the total number of items in a catalogue that match a search
+  query, using the same matching rules as `search_items_in_catalogue/3`.
+
+  Useful for paginating or driving "N of M" summaries alongside paged
+  search results. Runs independently of `:limit`/`:offset` — this is the
+  unbounded total.
+
+  ## Examples
+
+      Catalogue.count_search_items_in_catalogue(catalogue_uuid, "panel")
+      #=> 237
+  """
+  def count_search_items_in_catalogue(catalogue_uuid, query) do
+    pattern = "%#{sanitize_like(query)}%"
+
+    from(i in Item,
+      left_join: c in Category,
+      on: i.category_uuid == c.uuid,
+      where: i.catalogue_uuid == ^catalogue_uuid,
+      where: i.status != "deleted",
+      where: is_nil(c.uuid) or c.status != "deleted",
+      where:
+        ilike(i.name, ^pattern) or
+          ilike(i.description, ^pattern) or
+          ilike(i.sku, ^pattern) or
+          fragment("?::text ILIKE ?", i.data, ^pattern),
+      select: count(i.uuid)
+    )
+    |> repo().one()
   end
 
   @doc """
@@ -1966,13 +2063,16 @@ defmodule PhoenixKitCatalogue.Catalogue do
   ## Options
 
     * `:limit` — max results to return (default 50)
+    * `:offset` — number of results to skip, for paging (default 0)
 
   ## Examples
 
       Catalogue.search_items_in_category(category_uuid, "panel")
+      Catalogue.search_items_in_category(category_uuid, "panel", limit: 100, offset: 100)
   """
   def search_items_in_category(category_uuid, query, opts \\ []) do
     limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
     pattern = "%#{sanitize_like(query)}%"
 
     from(i in Item,
@@ -1983,11 +2083,38 @@ defmodule PhoenixKitCatalogue.Catalogue do
           ilike(i.description, ^pattern) or
           ilike(i.sku, ^pattern) or
           fragment("?::text ILIKE ?", i.data, ^pattern),
-      order_by: [asc: i.name],
+      order_by: [asc: i.name, asc: i.uuid],
       limit: ^limit,
+      offset: ^offset,
       preload: [:catalogue, category: :catalogue, manufacturer: []]
     )
     |> repo().all()
+  end
+
+  @doc """
+  Returns the total number of non-deleted items in a category that
+  match a search query, using the same matching rules as
+  `search_items_in_category/3`. Runs independently of `:limit`/`:offset`.
+
+  ## Examples
+
+      Catalogue.count_search_items_in_category(category_uuid, "panel")
+      #=> 42
+  """
+  def count_search_items_in_category(category_uuid, query) do
+    pattern = "%#{sanitize_like(query)}%"
+
+    from(i in Item,
+      where: i.category_uuid == ^category_uuid,
+      where: i.status != "deleted",
+      where:
+        ilike(i.name, ^pattern) or
+          ilike(i.description, ^pattern) or
+          ilike(i.sku, ^pattern) or
+          fragment("?::text ILIKE ?", i.data, ^pattern),
+      select: count(i.uuid)
+    )
+    |> repo().one()
   end
 
   defp sanitize_like(query) do

--- a/lib/phoenix_kit_catalogue/import/executor.ex
+++ b/lib/phoenix_kit_catalogue/import/executor.ex
@@ -6,20 +6,30 @@ defmodule PhoenixKitCatalogue.Import.Executor do
   are inserted with progress reporting back to the calling process.
   """
 
+  require Logger
+
   alias PhoenixKit.Utils.Multilang
   alias PhoenixKitCatalogue.Catalogue
 
   @type import_result :: %{
           created: non_neg_integer(),
           errors: [{non_neg_integer(), String.t()}],
-          categories_created: non_neg_integer()
+          categories_created: non_neg_integer(),
+          manufacturers_created: non_neg_integer(),
+          suppliers_created: non_neg_integer(),
+          manufacturer_supplier_links_created: non_neg_integer()
         }
 
   @doc """
   Executes an import plan.
 
-  Creates categories first, then items. Sends `{:import_progress, current, total}`
-  messages to `notify_pid` after each item.
+  Phase 1: get-or-create categories / manufacturers / suppliers
+  (column mode only — fixed-uuid modes skip phase 1 for the
+  corresponding entity). Phase 2: insert items, resolving
+  `category_uuid` / `manufacturer_uuid` per row from the lookups
+  built in phase 1 (or the fixed UUIDs). Phase 3: link
+  manufacturers↔suppliers (M:N). Sends `{:import_progress, current,
+  total}` messages to `notify_pid` after each item.
 
   ## Options
 
@@ -29,15 +39,23 @@ defmodule PhoenixKitCatalogue.Import.Executor do
       get-or-create lookup for column-mode category creation matches
       column values against every translation any existing category
       has, not just the current import language. Default `false`.
+    * `:manufacturer_uuid` — fixed manufacturer UUID to assign all
+      items to (skips phase 1 manufacturer creation)
+    * `:supplier_uuid` — fixed supplier UUID; in phase 3 this supplier
+      is linked (M:N) to every distinct manufacturer the items in
+      this import ended up assigned to
   """
   @spec execute(map(), String.t(), pid(), keyword()) :: import_result()
   def execute(import_plan, catalogue_uuid, notify_pid, opts \\ []) do
     language = Keyword.get(opts, :language)
     fixed_category_uuid = Keyword.get(opts, :category_uuid)
+    fixed_manufacturer_uuid = Keyword.get(opts, :manufacturer_uuid)
+    fixed_supplier_uuid = Keyword.get(opts, :supplier_uuid)
     match_across = Keyword.get(opts, :match_categories_across_languages, false)
     activity_opts = build_activity_opts(opts)
 
-    # Phase 1: Create categories (only if no fixed category)
+    # Phase 1: get-or-create supporting records (skipped per-entity
+    # when a fixed UUID is provided for it)
     {category_lookup, categories_created} =
       if fixed_category_uuid do
         {%{}, 0}
@@ -51,16 +69,41 @@ defmodule PhoenixKitCatalogue.Import.Executor do
         )
       end
 
-    # Phase 2: Create items
-    total = length(import_plan.items)
+    # `Map.get` defaults guard against older callers / hand-built plans
+    # that don't include the new keys (mirrors the same forgiving
+    # contract `categories_to_create` already had via the Mapper).
+    {manufacturer_lookup, manufacturers_created} =
+      if fixed_manufacturer_uuid do
+        {%{}, 0}
+      else
+        create_manufacturers(Map.get(import_plan, :manufacturers_to_create, []), activity_opts)
+      end
 
-    {created, errors} =
+    {supplier_lookup, suppliers_created} =
+      if fixed_supplier_uuid do
+        {%{}, 0}
+      else
+        create_suppliers(Map.get(import_plan, :suppliers_to_create, []), activity_opts)
+      end
+
+    # Phase 2: Create items, accumulating M:N link pairs along the way
+    total = length(import_plan.items)
+    initial_acc = {0, [], MapSet.new(), MapSet.new()}
+
+    {created, errors, link_pairs, manufacturers_touched} =
       import_plan.items
       |> Enum.with_index(1)
-      |> Enum.reduce({0, []}, fn {item_attrs, idx}, {cr, errs} ->
-        attrs =
+      |> Enum.reduce(initial_acc, fn {item_attrs, idx}, {cr, errs, pairs, mfrs} ->
+        {mfr_uuid, attrs} =
           item_attrs
+          |> resolve_manufacturer(manufacturer_lookup, fixed_manufacturer_uuid)
+
+        {sup_uuid, attrs} = resolve_supplier(attrs, supplier_lookup, fixed_supplier_uuid)
+
+        attrs =
+          attrs
           |> Map.put(:catalogue_uuid, catalogue_uuid)
+          |> maybe_put(:manufacturer_uuid, mfr_uuid)
           |> resolve_category(category_lookup, fixed_category_uuid)
           |> apply_language(language)
 
@@ -68,16 +111,22 @@ defmodule PhoenixKitCatalogue.Import.Executor do
 
         send(notify_pid, {:import_progress, idx, total})
 
-        case result do
-          {:ok, :created} -> {cr + 1, errs}
-          {:error, reason} -> {cr, [{idx, reason} | errs]}
-        end
+        accumulate_item_result(result, {cr, errs, pairs, mfrs}, idx, mfr_uuid, sup_uuid)
       end)
+
+    # Phase 3: M:N links. A fixed supplier (existing/create mode) gets
+    # linked to every manufacturer the import ended up touching;
+    # otherwise we use the per-row pairs collected during phase 2.
+    pairs_to_link = expand_supplier_links(link_pairs, manufacturers_touched, fixed_supplier_uuid)
+    links_created = create_manufacturer_supplier_links(pairs_to_link)
 
     result = %{
       created: created,
       errors: Enum.reverse(errors),
-      categories_created: categories_created
+      categories_created: categories_created,
+      manufacturers_created: manufacturers_created,
+      suppliers_created: suppliers_created,
+      manufacturer_supplier_links_created: links_created
     }
 
     send(notify_pid, {:import_result, result})
@@ -276,5 +325,186 @@ defmodule PhoenixKitCatalogue.Import.Executor do
           uuid -> Map.put(attrs, :category_uuid, uuid)
         end
     end
+  end
+
+  # ── Manufacturer creation + per-item resolution ───────────────
+
+  defp create_manufacturers([], _activity_opts), do: {%{}, 0}
+
+  defp create_manufacturers(names, activity_opts) do
+    existing =
+      Catalogue.list_manufacturers()
+      |> Map.new(fn m -> {m.name, m.uuid} end)
+
+    Enum.reduce(names, {existing, 0}, fn name, acc ->
+      get_or_create_manufacturer(acc, name, activity_opts)
+    end)
+  end
+
+  defp get_or_create_manufacturer({lookup, count}, name, _activity_opts)
+       when is_map_key(lookup, name),
+       do: {lookup, count}
+
+  defp get_or_create_manufacturer({lookup, count}, name, activity_opts) do
+    case Catalogue.create_manufacturer(%{name: name}, activity_opts) do
+      {:ok, mfr} ->
+        {Map.put(lookup, name, mfr.uuid), count + 1}
+
+      {:error, changeset} ->
+        # Items referencing this name will fall through with
+        # `manufacturer_uuid: nil`; surface why so it's debuggable.
+        Logger.warning(
+          "Import: failed to create manufacturer #{inspect(name)}: " <>
+            inspect(changeset.errors)
+        )
+
+        {lookup, count}
+    end
+  end
+
+  # Returns `{manufacturer_uuid_or_nil, attrs_without_placeholder}`.
+  # When a fixed UUID is supplied (existing/create UI mode) every item
+  # gets it; otherwise we resolve from the column-mode lookup. A blank
+  # or unmatched name leaves `manufacturer_uuid` unset on the item.
+  defp resolve_manufacturer(attrs, _lookup, fixed_uuid) when is_binary(fixed_uuid) do
+    {fixed_uuid, Map.delete(attrs, :_manufacturer_name)}
+  end
+
+  defp resolve_manufacturer(attrs, lookup, _fixed_uuid) do
+    case Map.pop(attrs, :_manufacturer_name) do
+      {nil, attrs} -> {nil, attrs}
+      {"", attrs} -> {nil, attrs}
+      {name, attrs} -> {Map.get(lookup, name), attrs}
+    end
+  end
+
+  # ── Supplier creation + per-row resolution ────────────────────
+
+  defp create_suppliers([], _activity_opts), do: {%{}, 0}
+
+  defp create_suppliers(names, activity_opts) do
+    existing =
+      Catalogue.list_suppliers()
+      |> Map.new(fn s -> {s.name, s.uuid} end)
+
+    Enum.reduce(names, {existing, 0}, fn name, acc ->
+      get_or_create_supplier(acc, name, activity_opts)
+    end)
+  end
+
+  defp get_or_create_supplier({lookup, count}, name, _activity_opts)
+       when is_map_key(lookup, name),
+       do: {lookup, count}
+
+  defp get_or_create_supplier({lookup, count}, name, activity_opts) do
+    case Catalogue.create_supplier(%{name: name}, activity_opts) do
+      {:ok, sup} ->
+        {Map.put(lookup, name, sup.uuid), count + 1}
+
+      {:error, changeset} ->
+        Logger.warning(
+          "Import: failed to create supplier #{inspect(name)}: " <>
+            inspect(changeset.errors)
+        )
+
+        {lookup, count}
+    end
+  end
+
+  # Returns `{supplier_uuid_or_nil, attrs_without_placeholder}`. Items
+  # don't have a `supplier_uuid` column — the uuid travels alongside
+  # the item attrs (not into them) and is used only for building the
+  # M:N link in phase 3. We still strip the placeholder so it doesn't
+  # leak into changeset cast.
+  defp resolve_supplier(attrs, _lookup, fixed_uuid) when is_binary(fixed_uuid) do
+    {fixed_uuid, Map.delete(attrs, :_supplier_name)}
+  end
+
+  defp resolve_supplier(attrs, lookup, _fixed_uuid) do
+    case Map.pop(attrs, :_supplier_name) do
+      {nil, attrs} -> {nil, attrs}
+      {"", attrs} -> {nil, attrs}
+      {name, attrs} -> {Map.get(lookup, name), attrs}
+    end
+  end
+
+  # ── M:N link creation (phase 3) ───────────────────────────────
+
+  # When the user picked a single supplier (existing / create mode),
+  # link it to every manufacturer the import touched. Otherwise the
+  # set of links comes purely from per-row pairs accumulated during
+  # phase 2.
+  defp expand_supplier_links(link_pairs, _manufacturers_touched, nil), do: link_pairs
+
+  defp expand_supplier_links(link_pairs, manufacturers_touched, fixed_supplier_uuid) do
+    Enum.reduce(manufacturers_touched, link_pairs, fn mfr_uuid, acc ->
+      MapSet.put(acc, {mfr_uuid, fixed_supplier_uuid})
+    end)
+  end
+
+  # Threads one item-insert outcome into the phase-2 accumulator: bumps
+  # the success counter and records the (mfr, sup) pair / manufacturer
+  # for phase-3 linking on `:ok`; appends to the error list on `:error`.
+  defp accumulate_item_result({:ok, :created}, {cr, errs, pairs, mfrs}, _idx, mfr_uuid, sup_uuid) do
+    new_pairs = maybe_record_pair(pairs, mfr_uuid, sup_uuid)
+    new_mfrs = maybe_record_manufacturer(mfrs, mfr_uuid)
+    {cr + 1, errs, new_pairs, new_mfrs}
+  end
+
+  defp accumulate_item_result({:error, reason}, {cr, errs, pairs, mfrs}, idx, _mfr, _sup) do
+    {cr, [{idx, reason} | errs], pairs, mfrs}
+  end
+
+  defp maybe_record_pair(pairs, mfr_uuid, sup_uuid)
+       when is_binary(mfr_uuid) and is_binary(sup_uuid),
+       do: MapSet.put(pairs, {mfr_uuid, sup_uuid})
+
+  defp maybe_record_pair(pairs, _, _), do: pairs
+
+  defp maybe_record_manufacturer(mfrs, mfr_uuid) when is_binary(mfr_uuid),
+    do: MapSet.put(mfrs, mfr_uuid)
+
+  defp maybe_record_manufacturer(mfrs, _), do: mfrs
+
+  # Skip the put when value is nil so we don't accidentally clobber
+  # `manufacturer_uuid` to nil (e.g. via the Item changeset's cast
+  # treating it as an explicit nil) when the row had no manufacturer.
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp create_manufacturer_supplier_links(pairs) do
+    # `link_manufacturer_supplier/2` returns `{:error, changeset}` on
+    # the unique-constraint violation when the link already exists —
+    # that's the idempotency guarantee, so we treat it as a no-op.
+    # Other errors (e.g., transient DB error) get logged so they're
+    # debuggable; we still don't fail the whole import on a bad link
+    # since items themselves are independent of the M:N graph.
+    Enum.reduce(pairs, 0, fn pair, count -> attempt_link(pair, count) end)
+  end
+
+  defp attempt_link({mfr_uuid, sup_uuid}, count) do
+    case Catalogue.link_manufacturer_supplier(mfr_uuid, sup_uuid) do
+      {:ok, _} ->
+        count + 1
+
+      {:error, %Ecto.Changeset{errors: errors}} ->
+        log_link_error(mfr_uuid, sup_uuid, errors)
+        count
+    end
+  end
+
+  defp log_link_error(mfr_uuid, sup_uuid, errors) do
+    if unique_constraint_error?(errors) do
+      :ok
+    else
+      Logger.warning(
+        "Import: failed to link manufacturer #{mfr_uuid} ↔ supplier #{sup_uuid}: " <>
+          inspect(errors)
+      )
+    end
+  end
+
+  defp unique_constraint_error?(errors) do
+    Enum.any?(errors, fn {_, {_, opts}} -> opts[:constraint] == :unique end)
   end
 end

--- a/lib/phoenix_kit_catalogue/import/executor.ex
+++ b/lib/phoenix_kit_catalogue/import/executor.ex
@@ -6,6 +6,7 @@ defmodule PhoenixKitCatalogue.Import.Executor do
   are inserted with progress reporting back to the calling process.
   """
 
+  alias PhoenixKit.Utils.Multilang
   alias PhoenixKitCatalogue.Catalogue
 
   @type import_result :: %{
@@ -24,11 +25,16 @@ defmodule PhoenixKitCatalogue.Import.Executor do
 
     * `:language` — language code for multilang import (e.g. `"et"`)
     * `:category_uuid` — fixed category UUID to assign all items to
+    * `:match_categories_across_languages` — when `true`, the
+      get-or-create lookup for column-mode category creation matches
+      column values against every translation any existing category
+      has, not just the current import language. Default `false`.
   """
   @spec execute(map(), String.t(), pid(), keyword()) :: import_result()
   def execute(import_plan, catalogue_uuid, notify_pid, opts \\ []) do
     language = Keyword.get(opts, :language)
     fixed_category_uuid = Keyword.get(opts, :category_uuid)
+    match_across = Keyword.get(opts, :match_categories_across_languages, false)
     activity_opts = build_activity_opts(opts)
 
     # Phase 1: Create categories (only if no fixed category)
@@ -36,7 +42,13 @@ defmodule PhoenixKitCatalogue.Import.Executor do
       if fixed_category_uuid do
         {%{}, 0}
       else
-        create_categories(import_plan.categories_to_create, catalogue_uuid, activity_opts)
+        create_categories(
+          import_plan.categories_to_create,
+          catalogue_uuid,
+          language,
+          match_across,
+          activity_opts
+        )
       end
 
     # Phase 2: Create items
@@ -75,28 +87,97 @@ defmodule PhoenixKitCatalogue.Import.Executor do
 
   # ── Category Creation ─────────────────────────────────────────
 
-  defp create_categories(category_names, catalogue_uuid, activity_opts) do
-    # Load existing categories for this catalogue
-    existing =
-      Catalogue.list_categories_for_catalogue(catalogue_uuid)
-      |> Map.new(fn cat -> {cat.name, cat.uuid} end)
+  defp create_categories(category_names, catalogue_uuid, language, match_across, activity_opts) do
+    existing_categories = Catalogue.list_categories_for_catalogue(catalogue_uuid)
+    existing = build_category_lookup(existing_categories, language, match_across)
 
     Enum.reduce(category_names, {existing, 0}, fn name, {lookup, count} ->
       if Map.has_key?(lookup, name) do
         {lookup, count}
       else
-        get_or_create_category(name, catalogue_uuid, lookup, count, activity_opts)
+        get_or_create_category(name, catalogue_uuid, language, lookup, count, activity_opts)
       end
     end)
   end
 
-  defp get_or_create_category(name, catalogue_uuid, lookup, count, activity_opts) do
+  # Builds the `name => uuid` lookup the importer uses to match column
+  # values to existing categories.
+  #
+  # Without a language we fall back to the bare `name` field — same as
+  # the pre-multilang behavior, and the right thing for catalogues that
+  # never enabled translations.
+  #
+  # With a language, we ALSO index each category by its translated
+  # `_name` in that language, so importing a CSV with category column
+  # values like "Konksud" matches a category whose `data.et._name` is
+  # "Konksud" — even if its bare/primary name is "Hooks". The bare
+  # `name` is also indexed as a fallback so categories without a
+  # translation set in this language are still findable by their
+  # primary name. On collisions the language-specific entry wins
+  # because it's `Map.put`-ed last.
+  #
+  # When `match_across_languages` is true, we additionally index every
+  # `_name` translation present on each category — so a column value
+  # can match against a sibling-language translation even when
+  # importing under a different language. Useful for consolidating
+  # multilingual catalogues without forcing the user to re-import once
+  # per language tab.
+  defp build_category_lookup(categories, nil, _match_across) do
+    Map.new(categories, fn cat -> {cat.name, cat.uuid} end)
+  end
+
+  defp build_category_lookup(categories, language, match_across) do
+    Enum.reduce(categories, %{}, fn cat, acc ->
+      acc
+      |> Map.put(cat.name, cat.uuid)
+      |> maybe_index_all_translations(cat, match_across)
+      |> maybe_index_translation(cat, language)
+    end)
+  end
+
+  defp maybe_index_all_translations(acc, _cat, false), do: acc
+
+  defp maybe_index_all_translations(acc, %{data: data} = cat, true) when is_map(data) do
+    Enum.reduce(data, acc, fn
+      {key, %{"_name" => name}}, inner_acc
+      when is_binary(name) and name != "" and key != "_primary_language" ->
+        Map.put(inner_acc, name, cat.uuid)
+
+      _, inner_acc ->
+        inner_acc
+    end)
+  end
+
+  defp maybe_index_all_translations(acc, _cat, true), do: acc
+
+  defp maybe_index_translation(acc, cat, language) do
+    case translated_name(cat, language) do
+      nil -> acc
+      translated -> Map.put(acc, translated, cat.uuid)
+    end
+  end
+
+  defp translated_name(%{data: data}, language) when is_map(data) do
+    case Multilang.get_language_data(data, language) do
+      %{"_name" => name} when is_binary(name) and name != "" -> name
+      _ -> nil
+    end
+  end
+
+  defp translated_name(_cat, _language), do: nil
+
+  defp get_or_create_category(name, catalogue_uuid, language, lookup, count, activity_opts) do
     position = Catalogue.next_category_position(catalogue_uuid)
 
-    case Catalogue.create_category(
-           %{name: name, catalogue_uuid: catalogue_uuid, position: position},
-           activity_opts
-         ) do
+    # Apply the import language to the category the same way we do for
+    # items — so the imported name lands in `data` under the chosen
+    # language tab and `_primary_language` is set, instead of being a
+    # bare string with no translation context.
+    attrs =
+      %{name: name, catalogue_uuid: catalogue_uuid, position: position}
+      |> apply_language(language)
+
+    case Catalogue.create_category(attrs, activity_opts) do
       {:ok, category} ->
         {Map.put(lookup, name, category.uuid), count + 1}
 

--- a/lib/phoenix_kit_catalogue/import/mapper.ex
+++ b/lib/phoenix_kit_catalogue/import/mapper.ex
@@ -14,6 +14,8 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
           | :markup_percentage
           | :unit
           | :category
+          | :manufacturer
+          | :supplier
           | :skip
           | {:data, String.t()}
 
@@ -26,6 +28,8 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
   @type import_plan :: %{
           items: [map()],
           categories_to_create: [String.t()],
+          manufacturers_to_create: [String.t()],
+          suppliers_to_create: [String.t()],
           custom_fields: [String.t()],
           errors: [{non_neg_integer(), String.t()}],
           stats: %{total: non_neg_integer(), valid: non_neg_integer(), invalid: non_neg_integer()}
@@ -60,7 +64,10 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
     base_price: ~w(price hind preis cost maksumus kulu base_price baseprice),
     markup_percentage:
       ~w(markup margin naceenka juurdehindlus aufschlag markup_percentage markup_percent markup%),
-    unit: ~w(unit uhik einheit masseinheit measure uom)
+    unit: ~w(unit uhik einheit masseinheit measure uom),
+    manufacturer:
+      ~w(manufacturer hersteller tootja brand bra_nd vendor maker producer firma manufacturer_name),
+    supplier: ~w(supplier tarnija lieferant distributor reseller wholesaler supplier_name)
   }
 
   # ── Public API ────────────────────────────────────────────────
@@ -78,7 +85,9 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
       {:base_price, "Base Price"},
       {:markup_percentage, "Markup Override (%)"},
       {:unit, "Unit of Measure"},
-      {:category, "Create Categories"}
+      {:category, "Create Categories"},
+      {:manufacturer, "Manufacturer"},
+      {:supplier, "Supplier"}
     ]
   end
 
@@ -130,24 +139,11 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
     items = Enum.reverse(items)
     errors = Enum.reverse(errors)
 
-    categories_to_create =
-      mappings
-      |> Enum.find(fn m -> m.target == :category end)
-      |> case do
-        nil ->
-          []
-
-        %{column_index: idx} ->
-          rows
-          |> Enum.map(fn row -> Enum.at(row, idx, "") end)
-          |> Enum.reject(&(&1 == ""))
-          |> Enum.uniq()
-          |> Enum.sort()
-      end
-
     %{
       items: items,
-      categories_to_create: categories_to_create,
+      categories_to_create: unique_column_names(mappings, rows, :category),
+      manufacturers_to_create: unique_column_names(mappings, rows, :manufacturer),
+      suppliers_to_create: unique_column_names(mappings, rows, :supplier),
       custom_fields: custom_fields,
       errors: errors,
       stats: %{
@@ -156,6 +152,24 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
         invalid: length(errors)
       }
     }
+  end
+
+  # Pulls every distinct, non-blank value from the column mapped to
+  # `target`. Used to compute `categories_to_create`,
+  # `manufacturers_to_create`, and `suppliers_to_create` for the
+  # executor's get-or-create phases.
+  defp unique_column_names(mappings, rows, target) do
+    case Enum.find(mappings, fn m -> m.target == target end) do
+      nil ->
+        []
+
+      %{column_index: idx} ->
+        rows
+        |> Enum.map(fn row -> row |> Enum.at(idx, "") |> String.trim() end)
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.uniq()
+        |> Enum.sort()
+    end
   end
 
   @doc """
@@ -434,6 +448,25 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
 
   defp apply_mapping(acc, :category, value, _unit_map),
     do: Map.put(acc, :_category_name, String.trim(value))
+
+  # Manufacturer / supplier names get the same `_<x>_name` placeholder
+  # treatment as `:category` — the executor resolves them to UUIDs (or
+  # creates the records) at import time. Blank cells skip the
+  # placeholder entirely so the executor knows the row has no
+  # manufacturer/supplier and won't try to look one up or link.
+  defp apply_mapping(acc, :manufacturer, value, _unit_map) do
+    case String.trim(value) do
+      "" -> acc
+      name -> Map.put(acc, :_manufacturer_name, name)
+    end
+  end
+
+  defp apply_mapping(acc, :supplier, value, _unit_map) do
+    case String.trim(value) do
+      "" -> acc
+      name -> Map.put(acc, :_supplier_name, name)
+    end
+  end
 
   defp apply_mapping(acc, {:data, field_name}, value, _unit_map) do
     data = Map.get(acc, :data, %{})

--- a/lib/phoenix_kit_catalogue/import/mapper.ex
+++ b/lib/phoenix_kit_catalogue/import/mapper.ex
@@ -11,6 +11,7 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
           | :description
           | :sku
           | :base_price
+          | :markup_percentage
           | :unit
           | :category
           | :skip
@@ -57,6 +58,8 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
     sku: ~w(sku artikkel article code kood nr number art artikelnr item_code product_code),
     name: ~w(name nimi nimetus kirjeldus description bezeichnung toode product),
     base_price: ~w(price hind preis cost maksumus kulu base_price baseprice),
+    markup_percentage:
+      ~w(markup margin naceenka juurdehindlus aufschlag markup_percentage markup_percent markup%),
     unit: ~w(unit uhik einheit masseinheit measure uom)
   }
 
@@ -73,6 +76,7 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
       {:description, "Description"},
       {:sku, "Article Code"},
       {:base_price, "Base Price"},
+      {:markup_percentage, "Markup Override (%)"},
       {:unit, "Unit of Measure"},
       {:category, "Create Categories"}
     ]
@@ -226,6 +230,7 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
     name_matches?(import_item, existing) and
       sku_matches?(import_item, existing) and
       price_matches?(import_item, existing) and
+      markup_matches?(import_item, existing) and
       unit_matches?(import_item, existing) and
       category_matches?(existing, category_uuid) and
       language_matches?(import_item, existing, language)
@@ -241,6 +246,20 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
 
   defp price_matches?(import_item, existing) do
     case {import_item[:base_price], existing.base_price} do
+      {nil, nil} -> true
+      {nil, _} -> false
+      {_, nil} -> false
+      {a, b} -> Decimal.equal?(a, b)
+    end
+  end
+
+  # Two items match only when they share the same markup posture: both
+  # inheriting from the catalogue (`nil`/`nil`), both overriding to the
+  # same value, or one overriding while the other doesn't (different).
+  # Without this, importing a price-list of overrides would silently
+  # collapse onto inheritance-only existing rows.
+  defp markup_matches?(import_item, existing) do
+    case {import_item[:markup_percentage], existing.markup_percentage} do
       {nil, nil} -> true
       {nil, _} -> false
       {_, nil} -> false
@@ -386,6 +405,24 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
     end
   end
 
+  # A blank cell in the markup column means "no override" — the item
+  # inherits the catalogue's markup. Any non-blank value must be a valid
+  # non-negative number; otherwise the row is rejected so a typo in one
+  # cell doesn't silently fall back to the catalogue default and confuse
+  # the user about why their override didn't take effect.
+  defp apply_mapping(acc, :markup_percentage, value, _unit_map) do
+    case String.trim(value) do
+      "" ->
+        acc
+
+      trimmed ->
+        case normalize_price(trimmed) do
+          {:ok, decimal} -> Map.put(acc, :markup_percentage, decimal)
+          :error -> Map.put(acc, :_markup_error, trimmed)
+        end
+    end
+  end
+
   defp apply_mapping(acc, :unit, value, unit_map) do
     normalized = normalize_unit(value, unit_map)
     data = Map.get(acc, :data, %{})
@@ -411,8 +448,11 @@ defmodule PhoenixKitCatalogue.Import.Mapper do
       Map.has_key?(attrs, :_price_error) ->
         {:error, "Invalid price: #{attrs[:_price_error]}"}
 
+      Map.has_key?(attrs, :_markup_error) ->
+        {:error, "Invalid markup: #{attrs[:_markup_error]}"}
+
       true ->
-        {:ok, Map.drop(attrs, [:_price_error])}
+        {:ok, Map.drop(attrs, [:_price_error, :_markup_error])}
     end
   end
 

--- a/lib/phoenix_kit_catalogue/import/parser.ex
+++ b/lib/phoenix_kit_catalogue/import/parser.ex
@@ -93,7 +93,11 @@ defmodule PhoenixKitCatalogue.Import.Parser do
         headers = Enum.map(header_row, &to_string/1)
 
         rows =
-          data_rows |> Enum.map(fn row -> Enum.map(row, &to_string/1) end) |> reject_empty_rows()
+          data_rows
+          |> Enum.map(fn row -> Enum.map(row, &to_string/1) end)
+          |> reject_empty_rows()
+
+        {headers, rows} = reject_empty_columns(headers, rows)
 
         {:ok, %{sheets: sheets, headers: headers, rows: rows, row_count: length(rows)}}
 
@@ -131,6 +135,7 @@ defmodule PhoenixKitCatalogue.Import.Parser do
           headers = Enum.map(header_row, &String.trim/1)
           rows = Enum.map(data_rows, fn row -> Enum.map(row, &String.trim/1) end)
           rows = reject_empty_rows(rows)
+          {headers, rows} = reject_empty_columns(headers, rows)
 
           {:ok,
            %{
@@ -172,4 +177,47 @@ defmodule PhoenixKitCatalogue.Import.Parser do
       Enum.all?(row, fn cell -> cell == "" or is_nil(cell) end)
     end)
   end
+
+  # Strips columns that are completely empty — header is blank AND every
+  # data cell at that column index is blank. Spreadsheet exports often
+  # include leading or trailing empty columns that survive XLSX parsing
+  # as `""` cells; without removing them we'd render a column of
+  # truncated empty `<td>`s in the preview, generate a phantom mapping
+  # card with an empty header, and let the user "skip" a non-column.
+  #
+  # Columns with a real header but all-blank data are kept — that's a
+  # valid (if optional) column that may carry no data in this file.
+  defp reject_empty_columns(headers, rows) do
+    total_cols = max(length(headers), max_row_length(rows))
+
+    if total_cols == 0 do
+      {headers, rows}
+    else
+      kept =
+        for idx <- 0..(total_cols - 1),
+            not (blank_cell?(Enum.at(headers, idx)) and column_blank?(rows, idx)),
+            do: idx
+
+      new_headers = Enum.map(kept, fn idx -> Enum.at(headers, idx, "") end)
+      new_rows = Enum.map(rows, &project_columns(&1, kept))
+
+      {new_headers, new_rows}
+    end
+  end
+
+  defp project_columns(row, kept_indices) do
+    Enum.map(kept_indices, fn idx -> Enum.at(row, idx, "") end)
+  end
+
+  defp blank_cell?(nil), do: true
+  defp blank_cell?(""), do: true
+  defp blank_cell?(s) when is_binary(s), do: String.trim(s) == ""
+  defp blank_cell?(_), do: false
+
+  defp column_blank?(rows, idx) do
+    Enum.all?(rows, fn row -> blank_cell?(Enum.at(row, idx)) end)
+  end
+
+  defp max_row_length([]), do: 0
+  defp max_row_length(rows), do: rows |> Enum.map(&length/1) |> Enum.max()
 end

--- a/lib/phoenix_kit_catalogue/schemas/item.ex
+++ b/lib/phoenix_kit_catalogue/schemas/item.ex
@@ -19,6 +19,10 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
     field(:description, :string)
     field(:sku, :string)
     field(:base_price, :decimal)
+    # Per-item markup override. `nil` means "inherit from the parent
+    # catalogue's markup_percentage" (the pre-V97 default behavior); any
+    # Decimal (including 0) overrides the catalogue's value for this item.
+    field(:markup_percentage, :decimal)
     field(:unit, :string, default: "piece")
     field(:status, :string, default: "active")
     field(:data, :map, default: %{})
@@ -49,6 +53,7 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
     :description,
     :sku,
     :base_price,
+    :markup_percentage,
     :unit,
     :status,
     :category_uuid,
@@ -65,27 +70,61 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
     |> validate_inclusion(:status, @statuses)
     |> validate_inclusion(:unit, @units)
     |> validate_number(:base_price, greater_than_or_equal_to: 0)
+    |> validate_number(:markup_percentage, greater_than_or_equal_to: 0)
     |> foreign_key_constraint(:catalogue_uuid)
     |> foreign_key_constraint(:category_uuid)
   end
 
   @doc """
-  Calculates the sale price for an item given a markup percentage.
+  Calculates the sale price for an item.
 
-  Returns `nil` if the item has no base price.
-  The markup_percentage should be a Decimal (e.g., `Decimal.new("15.0")` for 15%).
+  `catalogue_markup` is the fallback markup used when the item has no
+  override of its own. The item's `markup_percentage` takes precedence
+  if set (including an explicit `0`, which means "sell at base price
+  even if the catalogue has a markup"). A `nil` catalogue_markup with a
+  `nil` item override returns the base price unchanged.
+
+  Returns `nil` if the item has no base price. Both percentage values
+  should be `Decimal`s (e.g., `Decimal.new("15.0")` for 15%).
 
   ## Examples
 
-      Item.sale_price(item, Decimal.new("20.0"))  # base_price * 1.20
-      Item.sale_price(item, nil)                   # returns base_price unchanged
+      # Item has no override — inherits catalogue's 20%
+      Item.sale_price(%Item{base_price: Decimal.new("100"), markup_percentage: nil}, Decimal.new("20"))
+      #=> Decimal.new("120.00")
+
+      # Item explicitly overrides to 50% — catalogue markup is ignored
+      Item.sale_price(%Item{base_price: Decimal.new("100"), markup_percentage: Decimal.new("50")}, Decimal.new("20"))
+      #=> Decimal.new("150.00")
+
+      # Item override of 0 means "sell at base price" even if catalogue marks up
+      Item.sale_price(%Item{base_price: Decimal.new("100"), markup_percentage: Decimal.new("0")}, Decimal.new("20"))
+      #=> Decimal.new("100.00")
   """
-  def sale_price(%__MODULE__{base_price: nil}, _markup_percentage), do: nil
+  def sale_price(%__MODULE__{base_price: nil}, _catalogue_markup), do: nil
 
-  def sale_price(%__MODULE__{base_price: base_price}, nil), do: base_price
+  def sale_price(%__MODULE__{base_price: base_price} = item, catalogue_markup) do
+    case effective_markup(item, catalogue_markup) do
+      nil ->
+        base_price
 
-  def sale_price(%__MODULE__{base_price: base_price}, markup_percentage) do
-    multiplier = Decimal.add(Decimal.new("1"), Decimal.div(markup_percentage, Decimal.new("100")))
-    Decimal.mult(base_price, multiplier) |> Decimal.round(2)
+      markup ->
+        multiplier = Decimal.add(Decimal.new("1"), Decimal.div(markup, Decimal.new("100")))
+        base_price |> Decimal.mult(multiplier) |> Decimal.round(2)
+    end
   end
+
+  @doc """
+  Returns the markup percentage that actually applies to an item — the
+  item's own `markup_percentage` if set, otherwise `catalogue_markup`.
+
+  `nil` on both sides means "no markup at all" and the item should be
+  sold at its base price. Callers that only need to *display* which
+  markup is active (without computing a price) can use this directly.
+  """
+  def effective_markup(%__MODULE__{markup_percentage: nil}, catalogue_markup),
+    do: catalogue_markup
+
+  def effective_markup(%__MODULE__{markup_percentage: override}, _catalogue_markup),
+    do: override
 end

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -45,7 +45,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         deleted_count: 0,
         active_item_count: 0,
         search_query: "",
-        search_results: nil
+        search_results: nil,
+        search_offset: 0,
+        search_total: 0,
+        search_has_more: false,
+        search_loading: false
       )
 
     if connected?(socket) do
@@ -77,10 +81,17 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   end
 
   def handle_event("load_more", _params, socket) do
-    if socket.assigns.has_more and not socket.assigns.loading do
-      {:noreply, socket |> assign(:loading, true) |> load_next_batch()}
-    else
-      {:noreply, socket}
+    cond do
+      socket.assigns.search_results != nil and socket.assigns.search_has_more and
+          not socket.assigns.search_loading ->
+        {:noreply, socket |> assign(:search_loading, true) |> load_next_search_batch()}
+
+      is_nil(socket.assigns.search_results) and socket.assigns.has_more and
+          not socket.assigns.loading ->
+        {:noreply, socket |> assign(:loading, true) |> load_next_batch()}
+
+      true ->
+        {:noreply, socket}
     end
   end
 
@@ -88,17 +99,14 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     query = String.trim(query)
 
     if query == "" do
-      {:noreply, assign(socket, search_query: "", search_results: nil)}
+      {:noreply, clear_search(socket)}
     else
-      results =
-        Catalogue.search_items_in_catalogue(socket.assigns.catalogue_uuid, query)
-
-      {:noreply, assign(socket, search_query: query, search_results: results)}
+      {:noreply, run_search(socket, query)}
     end
   end
 
   def handle_event("clear_search", _params, socket) do
-    {:noreply, assign(socket, search_query: "", search_results: nil)}
+    {:noreply, clear_search(socket)}
   end
 
   def handle_event("delete_item", %{"uuid" => uuid}, socket) do
@@ -424,6 +432,111 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     end
   end
 
+  # Runs a fresh search query asynchronously. If a prior search is still
+  # in flight, `start_async/3` cancels it — so fast typing (type-pause-
+  # type-pause) doesn't flash stale intermediate results as each old
+  # request lands out of order. The actual assign happens in
+  # `handle_async(:search, ...)`, guarded by a query equality check.
+  defp run_search(socket, query) do
+    uuid = socket.assigns.catalogue_uuid
+
+    socket
+    |> assign(search_query: query, search_loading: true)
+    |> start_async(:search, fn ->
+      results =
+        Catalogue.search_items_in_catalogue(uuid, query, limit: @per_page, offset: 0)
+
+      total = Catalogue.count_search_items_in_catalogue(uuid, query)
+      {query, results, total}
+    end)
+  end
+
+  @impl true
+  def handle_async(:search, {:ok, {query, results, total}}, socket) do
+    # Only apply if the user is still asking for this query. A late
+    # response for a query the user has already superseded gets dropped.
+    if socket.assigns.search_query == query do
+      {:noreply,
+       assign(socket,
+         search_results: results,
+         search_offset: length(results),
+         search_total: total,
+         search_has_more: length(results) < total,
+         search_loading: false
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_async(:search, {:exit, reason}, socket) do
+    # Cancellations (reason `:shutdown` / `:killed` / `{:shutdown, _}`) are
+    # expected when a newer query supersedes a pending one — the newer
+    # handler owns `search_loading`, so leave the socket alone. For any
+    # other exit (crashed DB query, timeout, raise in the task fn) clear
+    # loading and flash the user so they don't stare at a perpetual
+    # spinner, and log so we can debug without reproducing.
+    case reason do
+      r when r in [:shutdown, :killed] ->
+        {:noreply, socket}
+
+      {:shutdown, _} ->
+        {:noreply, socket}
+
+      other ->
+        Logger.warning("search task exited unexpectedly: #{inspect(other)}")
+
+        {:noreply,
+         socket
+         |> assign(:search_loading, false)
+         |> put_flash(
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Search failed. Please try again.")
+         )}
+    end
+  end
+
+  # Fetches the next page for the current search query and appends it
+  # onto `search_results`.
+  defp load_next_search_batch(socket) do
+    %{
+      catalogue_uuid: uuid,
+      search_query: query,
+      search_results: results,
+      search_offset: offset,
+      search_total: total
+    } = socket.assigns
+
+    page =
+      Catalogue.search_items_in_catalogue(uuid, query,
+        limit: @per_page,
+        offset: offset
+      )
+
+    new_offset = offset + length(page)
+    # `page == []` protects against stale `total` (items concurrently
+    # deleted) keeping `search_has_more` true forever.
+    has_more = page != [] and new_offset < total
+
+    assign(socket,
+      search_results: results ++ page,
+      search_offset: new_offset,
+      search_has_more: has_more,
+      search_loading: false
+    )
+  end
+
+  defp clear_search(socket) do
+    assign(socket,
+      search_query: "",
+      search_results: nil,
+      search_offset: 0,
+      search_total: 0,
+      search_has_more: false,
+      search_loading: false
+    )
+  end
+
   # Drives the cursor walk. Returns the next batch to render, or
   # `:done` when the cursor has nothing left in either phase. Walks:
   # categories (in display order) → uncategorized → done.
@@ -600,27 +713,53 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <%!-- View toggle --%>
         <.view_mode_toggle storage_key="catalogue-detail-items" />
 
-        <%!-- Search results --%>
-        <div :if={@search_results != nil} class="flex flex-col gap-4">
-          <.search_results_summary count={length(@search_results)} query={@search_query} />
+        <%!-- Search results (visible when the user has typed a query) --%>
+        <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
+          <%!-- Status line: spinner while loading, "X of Y results" when settled --%>
+          <div class="flex items-center gap-2">
+            <%= if @search_loading and is_nil(@search_results) do %>
+              <span class="text-sm text-base-content/60">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Searching for \"%{query}\"...", query: @search_query)}
+              </span>
+            <% else %>
+              <.search_results_summary :if={@search_results != nil} count={@search_total} query={@search_query} loaded={length(@search_results)} />
+            <% end %>
+            <span :if={@search_loading} class="loading loading-spinner loading-xs text-base-content/40"></span>
+          </div>
 
-          <.empty_state :if={@search_results == []} message={Gettext.gettext(PhoenixKitWeb.Gettext, "No items match your search.")} />
+          <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitWeb.Gettext, "No items match your search.")} />
 
-          <.item_table
-            :if={@search_results != []}
-            items={@search_results}
-            columns={[:name, :sku, :base_price, :price, :unit, :status]}
-            markup_percentage={@catalogue.markup_percentage}
-            edit_path={&Paths.item_edit/1}
-            cards={true}
-            show_toggle={false}
-            storage_key="catalogue-detail-items"
-            id="catalogue-search-items"
-          />
+          <%!-- Stale results are dimmed while a newer query is in flight to
+               signal that the list is about to update. --%>
+          <div :if={@search_results not in [nil, []]} class={["transition-opacity", @search_loading && "opacity-50"]}>
+            <.item_table
+              items={@search_results}
+              columns={[:name, :sku, :base_price, :price, :unit, :status]}
+              markup_percentage={@catalogue.markup_percentage}
+              edit_path={&Paths.item_edit/1}
+              cards={true}
+              show_toggle={false}
+              storage_key="catalogue-detail-items"
+              id="catalogue-search-items"
+            />
+          </div>
+
+          <%!-- Infinite-scroll sentinel for search results --%>
+          <div
+            :if={@search_has_more and not @search_loading}
+            id="search-load-more-sentinel"
+            phx-hook="InfiniteScroll"
+            data-cursor={"search-#{@search_offset}"}
+            class="py-4"
+          >
+            <div class="flex justify-center">
+              <span class="loading loading-spinner loading-sm text-base-content/30"></span>
+            </div>
+          </div>
         </div>
 
         <%!-- Status tabs --%>
-        <div :if={@deleted_count > 0 and is_nil(@search_results)} class="flex items-center gap-0.5 border-b border-base-200">
+        <div :if={@deleted_count > 0 and is_nil(@search_results) and not @search_loading} class="flex items-center gap-0.5 border-b border-base-200">
           <button
             type="button"
             phx-click="switch_view"
@@ -653,20 +792,20 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
         <%!-- Normal (non-search) view: infinite-scroll cards --%>
         <%!-- Empty states only shown when nothing is loading AND nothing was ever loaded --%>
-        <div :if={is_nil(@search_results) and @loaded_cards == [] and not @has_more and not @loading and @view_mode == "active"} class="card bg-base-100 shadow">
+        <div :if={is_nil(@search_results) and not @search_loading and @loaded_cards == [] and not @has_more and not @loading and @view_mode == "active"} class="card bg-base-100 shadow">
           <div class="card-body items-center text-center py-12">
             <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No categories or items yet. Add a category or item to get started.")}</p>
           </div>
         </div>
 
-        <div :if={is_nil(@search_results) and @loaded_cards == [] and not @has_more and not @loading and @view_mode == "deleted"} class="card bg-base-100 shadow">
+        <div :if={is_nil(@search_results) and not @search_loading and @loaded_cards == [] and not @has_more and not @loading and @view_mode == "deleted"} class="card bg-base-100 shadow">
           <div class="card-body items-center text-center py-12">
             <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No deleted items.")}</p>
           </div>
         </div>
 
         <%!-- Streamed cards (one per category, one for uncategorized). --%>
-        <%= for {card, card_idx} <- Enum.with_index(@loaded_cards), is_nil(@search_results) do %>
+        <%= for {card, card_idx} <- Enum.with_index(@loaded_cards), is_nil(@search_results) and not @search_loading do %>
           <.detail_card
             card={card}
             card_idx={card_idx}
@@ -680,7 +819,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
         <%!-- Infinite-scroll sentinel --%>
         <div
-          :if={is_nil(@search_results) and @has_more}
+          :if={is_nil(@search_results) and not @search_loading and @has_more}
           id="detail-load-more-sentinel"
           phx-hook="InfiniteScroll"
           data-cursor={"#{@cursor.phase}-#{@cursor.category_index}-#{@cursor.item_offset}"}
@@ -691,7 +830,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-        <div :if={is_nil(@search_results) and not @has_more and @loaded_cards != []} class="text-center text-xs text-base-content/40 py-2">
+        <div :if={is_nil(@search_results) and not @search_loading and not @has_more and @loaded_cards != []} class="text-center text-xs text-base-content/40 py-2">
           {Gettext.gettext(PhoenixKitWeb.Gettext, "All items loaded")}
         </div>
       </div>
@@ -723,17 +862,25 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       window.PhoenixKitHooks = window.PhoenixKitHooks || {};
       window.PhoenixKitHooks.InfiniteScroll = window.PhoenixKitHooks.InfiniteScroll || {
         mounted() {
+          this.intersecting = false;
           this.observer = new IntersectionObserver((entries) => {
-            const entry = entries[0];
-            if (entry.isIntersecting) {
+            this.intersecting = entries[0].isIntersecting;
+            if (this.intersecting) {
               this.pushEvent("load_more", {});
             }
           }, { rootMargin: "200px" });
           this.observer.observe(this.el);
         },
         updated() {
-          this.observer.disconnect();
-          this.observer.observe(this.el);
+          // IntersectionObserver only fires on state transitions. When the
+          // viewport is tall or the user jumped via Page Down / resize, the
+          // sentinel stays continuously in view across batches — so the
+          // observer goes silent after the first fire. Re-trigger explicitly
+          // whenever the server patches us while we're still on-screen.
+          // The server's `loading` guard dedupes duplicate events.
+          if (this.intersecting) {
+            this.pushEvent("load_more", {});
+          }
         },
         destroyed() {
           this.observer.disconnect();

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -21,6 +21,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
 
+  @per_page 100
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -34,7 +36,11 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
        catalogue_view_mode: "active",
        deleted_catalogue_count: 0,
        search_query: "",
-       search_results: nil
+       search_results: nil,
+       search_offset: 0,
+       search_total: 0,
+       search_has_more: false,
+       search_loading: false
      )}
   end
 
@@ -46,8 +52,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       socket
       |> assign(:active_tab, action)
       |> assign(:page_title, tab_title(action))
-      |> assign(:search_query, "")
-      |> assign(:search_results, nil)
+      |> clear_search()
       |> load_data(action)
 
     {:noreply, socket}
@@ -275,15 +280,118 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     query = String.trim(query)
 
     if query == "" do
-      {:noreply, assign(socket, search_query: "", search_results: nil)}
+      {:noreply, clear_search(socket)}
     else
-      results = Catalogue.search_items(query)
-      {:noreply, assign(socket, search_query: query, search_results: results)}
+      {:noreply, run_search(socket, query)}
     end
   end
 
   def handle_event("clear_search", _params, socket) do
-    {:noreply, assign(socket, search_query: "", search_results: nil)}
+    {:noreply, clear_search(socket)}
+  end
+
+  def handle_event("load_more", _params, socket) do
+    if socket.assigns.search_results != nil and socket.assigns.search_has_more and
+         not socket.assigns.search_loading do
+      {:noreply, socket |> assign(:search_loading, true) |> load_next_search_batch()}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # ── Search helpers ──────────────────────────────────────────────
+
+  # Runs a fresh search query asynchronously. If a prior search is still
+  # in flight, `start_async/3` cancels it — so fast typing (type-pause-
+  # type-pause) doesn't flash stale intermediate results as each old
+  # request lands out of order. The actual assign happens in
+  # `handle_async(:search, ...)`, guarded by a query equality check.
+  defp run_search(socket, query) do
+    socket
+    |> assign(search_query: query, search_loading: true)
+    |> start_async(:search, fn ->
+      results = Catalogue.search_items(query, limit: @per_page, offset: 0)
+      total = Catalogue.count_search_items(query)
+      {query, results, total}
+    end)
+  end
+
+  @impl true
+  def handle_async(:search, {:ok, {query, results, total}}, socket) do
+    # Only apply if the user is still asking for this query. A late
+    # response for a query the user has already superseded gets dropped.
+    if socket.assigns.search_query == query do
+      {:noreply,
+       assign(socket,
+         search_results: results,
+         search_offset: length(results),
+         search_total: total,
+         search_has_more: length(results) < total,
+         search_loading: false
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_async(:search, {:exit, reason}, socket) do
+    # Cancellations (reason `:shutdown` / `:killed` / `{:shutdown, _}`) are
+    # expected when a newer query supersedes a pending one — the newer
+    # handler owns `search_loading`, so leave the socket alone. For any
+    # other exit (crashed DB query, timeout, raise in the task fn) clear
+    # loading and flash the user so they don't stare at a perpetual
+    # spinner, and log so we can debug without reproducing.
+    case reason do
+      r when r in [:shutdown, :killed] ->
+        {:noreply, socket}
+
+      {:shutdown, _} ->
+        {:noreply, socket}
+
+      other ->
+        Logger.warning("search task exited unexpectedly: #{inspect(other)}")
+
+        {:noreply,
+         socket
+         |> assign(:search_loading, false)
+         |> put_flash(
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Search failed. Please try again.")
+         )}
+    end
+  end
+
+  defp load_next_search_batch(socket) do
+    %{
+      search_query: query,
+      search_results: results,
+      search_offset: offset,
+      search_total: total
+    } = socket.assigns
+
+    page = Catalogue.search_items(query, limit: @per_page, offset: offset)
+    new_offset = offset + length(page)
+    # `page == []` protects against stale `total` (items concurrently
+    # deleted) keeping `search_has_more` true forever.
+    has_more = page != [] and new_offset < total
+
+    assign(socket,
+      search_results: results ++ page,
+      search_offset: new_offset,
+      search_has_more: has_more,
+      search_loading: false
+    )
+  end
+
+  defp clear_search(socket) do
+    assign(socket,
+      search_query: "",
+      search_results: nil,
+      search_offset: 0,
+      search_total: 0,
+      search_has_more: false,
+      search_loading: false
+    )
   end
 
   # ── Render ──────────────────────────────────────────────────────
@@ -331,26 +439,52 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       <%!-- Global search (only on catalogues tab) --%>
       <.search_input :if={@active_tab == :index} query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items across all catalogues...")} />
 
-      <%!-- Search results --%>
-      <div :if={@search_results != nil} class="flex flex-col gap-4">
-        <.search_results_summary count={length(@search_results)} query={@search_query} />
+      <%!-- Search results (visible when the user has typed a query) --%>
+      <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
+        <%!-- Status line: spinner while loading, "X of Y results" when settled --%>
+        <div class="flex items-center gap-2">
+          <%= if @search_loading and is_nil(@search_results) do %>
+            <span class="text-sm text-base-content/60">
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Searching for \"%{query}\"...", query: @search_query)}
+            </span>
+          <% else %>
+            <.search_results_summary :if={@search_results != nil} count={@search_total} query={@search_query} loaded={length(@search_results)} />
+          <% end %>
+          <span :if={@search_loading} class="loading loading-spinner loading-xs text-base-content/40"></span>
+        </div>
 
-        <.empty_state :if={@search_results == []} message={Gettext.gettext(PhoenixKitWeb.Gettext, "No items match your search.")} />
+        <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitWeb.Gettext, "No items match your search.")} />
 
-        <.item_table
-          :if={@search_results != []}
-          items={@search_results}
-          columns={[:name, :sku, :base_price, :catalogue, :category, :manufacturer, :status]}
-          variant="zebra"
-          edit_path={&Paths.item_edit/1}
-          catalogue_path={&Paths.catalogue_detail/1}
-          cards={true}
-          id="global-search-items"
-        />
+        <%!-- Stale results are dimmed while a newer query is in flight to
+             signal that the list is about to update. --%>
+        <div :if={@search_results not in [nil, []]} class={["transition-opacity", @search_loading && "opacity-50"]}>
+          <.item_table
+            items={@search_results}
+            columns={[:name, :sku, :base_price, :catalogue, :category, :manufacturer, :status]}
+            variant="zebra"
+            edit_path={&Paths.item_edit/1}
+            catalogue_path={&Paths.catalogue_detail/1}
+            cards={true}
+            id="global-search-items"
+          />
+        </div>
+
+        <%!-- Infinite-scroll sentinel for global search --%>
+        <div
+          :if={@search_has_more and not @search_loading}
+          id="catalogues-search-load-more-sentinel"
+          phx-hook="InfiniteScroll"
+          data-cursor={"global-search-#{@search_offset}"}
+          class="py-4"
+        >
+          <div class="flex justify-center">
+            <span class="loading loading-spinner loading-sm text-base-content/30"></span>
+          </div>
+        </div>
       </div>
 
       <%!-- Catalogue tab content --%>
-      <div :if={@active_tab == :index and is_nil(@search_results)} class="flex flex-col gap-4">
+      <div :if={@active_tab == :index and is_nil(@search_results) and not @search_loading} class="flex flex-col gap-4">
         <%!-- Status sub-tabs for catalogues --%>
         <div :if={@deleted_catalogue_count > 0} class="flex items-center gap-0.5 border-b border-base-200">
           <button
@@ -427,6 +561,36 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         danger={true}
       />
     </div>
+
+    <script>
+      window.PhoenixKitHooks = window.PhoenixKitHooks || {};
+      window.PhoenixKitHooks.InfiniteScroll = window.PhoenixKitHooks.InfiniteScroll || {
+        mounted() {
+          this.intersecting = false;
+          this.observer = new IntersectionObserver((entries) => {
+            this.intersecting = entries[0].isIntersecting;
+            if (this.intersecting) {
+              this.pushEvent("load_more", {});
+            }
+          }, { rootMargin: "200px" });
+          this.observer.observe(this.el);
+        },
+        updated() {
+          // IntersectionObserver only fires on state transitions. When the
+          // viewport is tall or the user jumped via Page Down / resize, the
+          // sentinel stays continuously in view across batches — so the
+          // observer goes silent after the first fire. Re-trigger explicitly
+          // whenever the server patches us while we're still on-screen.
+          // The server's `loading` guard dedupes duplicate events.
+          if (this.intersecting) {
+            this.pushEvent("load_more", {});
+          }
+        },
+        destroyed() {
+          this.observer.disconnect();
+        }
+      };
+    </script>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -128,16 +128,24 @@ defmodule PhoenixKitCatalogue.Web.Components do
 
   ## Attributes
 
-    * `count` — number of results (required)
+    * `count` — total number of matching results (required)
     * `query` — the search query string (required)
+    * `loaded` — optional count of results currently rendered. When given
+      and less than `count`, the summary shows "X of Y" so users know the
+      list is paging. Omit or pass `nil` for a plain "N results" line.
   """
   attr(:count, :integer, required: true)
   attr(:query, :string, required: true)
+  attr(:loaded, :integer, default: nil)
 
   def search_results_summary(assigns) do
     ~H"""
     <span class="text-sm text-base-content/60">
-      {Gettext.ngettext(PhoenixKitWeb.Gettext, "%{count} result for \"%{query}\"", "%{count} results for \"%{query}\"", @count, count: @count, query: @query)}
+      <%= if is_integer(@loaded) and @loaded < @count do %>
+        {Gettext.gettext(PhoenixKitWeb.Gettext, "Showing %{loaded} of %{count} results for \"%{query}\"", loaded: @loaded, count: @count, query: @query)}
+      <% else %>
+        {Gettext.ngettext(PhoenixKitWeb.Gettext, "%{count} result for \"%{query}\"", "%{count} results for \"%{query}\"", @count, count: @count, query: @query)}
+      <% end %>
     </span>
     """
   end

--- a/lib/phoenix_kit_catalogue/web/events_live.ex
+++ b/lib/phoenix_kit_catalogue/web/events_live.ex
@@ -363,17 +363,25 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
       window.PhoenixKitHooks = window.PhoenixKitHooks || {};
       window.PhoenixKitHooks.InfiniteScroll = window.PhoenixKitHooks.InfiniteScroll || {
         mounted() {
+          this.intersecting = false;
           this.observer = new IntersectionObserver((entries) => {
-            const entry = entries[0];
-            if (entry.isIntersecting) {
+            this.intersecting = entries[0].isIntersecting;
+            if (this.intersecting) {
               this.pushEvent("load_more", {});
             }
           }, { rootMargin: "200px" });
           this.observer.observe(this.el);
         },
         updated() {
-          this.observer.disconnect();
-          this.observer.observe(this.el);
+          // IntersectionObserver only fires on state transitions. When the
+          // viewport is tall or the user jumped via Page Down / resize, the
+          // sentinel stays continuously in view across batches — so the
+          // observer goes silent after the first fire. Re-trigger explicitly
+          // whenever the server patches us while we're still on-screen.
+          // The server's `loading` guard dedupes duplicate events.
+          if (this.intersecting) {
+            this.pushEvent("load_more", {});
+          }
         },
         destroyed() {
           this.observer.disconnect();

--- a/lib/phoenix_kit_catalogue/web/import_live.ex
+++ b/lib/phoenix_kit_catalogue/web/import_live.ex
@@ -10,7 +10,16 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   require Logger
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
-  import PhoenixKitWeb.Components.MultilangForm, only: [mount_multilang: 1, multilang_tabs: 1]
+
+  import PhoenixKitWeb.Components.MultilangForm,
+    only: [
+      mount_multilang: 1,
+      multilang_tabs: 1,
+      merge_translatable_params: 4,
+      translatable_field: 1,
+      multilang_fields_wrapper: 1,
+      get_lang_data: 3
+    ]
 
   @impl true
   def terminate(_reason, socket) do
@@ -26,14 +35,25 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Import.{Executor, Mapper, Parser}
   alias PhoenixKitCatalogue.Paths
-  alias PhoenixKitCatalogue.Schemas.Item
+  alias PhoenixKitCatalogue.Schemas.{Category, Item}
 
   @max_file_size 10_000_000
   @preview_rows 5
+  @category_translatable_fields ["name", "description"]
 
   @impl true
   def mount(_params, _session, socket) do
-    catalogues = if connected?(socket), do: Catalogue.list_catalogues(), else: []
+    # Load on both the HTTP and WebSocket mounts so the picker is
+    # populated on first paint. The three queries (catalogues + two
+    # `GROUP BY catalogue_uuid` count aggregates) are cheap — both
+    # aggregates are single-table scans on indexed columns. If picker
+    # data ever grows expensive, swap to `assign_async` here without
+    # changing the template (it already consumes `catalogues`,
+    # `catalogue_item_counts`, and `catalogue_category_counts`
+    # separately).
+    catalogues = Catalogue.list_catalogues()
+    catalogue_item_counts = Catalogue.item_counts_by_catalogue()
+    catalogue_category_counts = Catalogue.category_counts_by_catalogue()
 
     {:ok,
      socket
@@ -41,6 +61,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
        page_title: Gettext.gettext(PhoenixKitWeb.Gettext, "Import"),
        step: :upload,
        catalogues: catalogues,
+       catalogue_item_counts: catalogue_item_counts,
+       catalogue_category_counts: catalogue_category_counts,
        selected_catalogue: nil,
        # File data
 
@@ -57,6 +79,9 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
        unit_map: %{},
        import_category_mode: :none,
        import_category_uuid: nil,
+       category_match_across_languages: false,
+       new_category: nil,
+       new_category_changeset: nil,
        catalogue_categories: [],
        # Import
        import_plan: nil,
@@ -240,51 +265,37 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   end
 
   def handle_event("continue_to_confirm", _params, socket) do
-    # Validate that name is mapped
-    has_name = Enum.any?(socket.assigns.column_mappings, &(&1.target == :name))
+    cond do
+      not Enum.any?(socket.assigns.column_mappings, &(&1.target == :name)) ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "You must map at least one column to 'Item Name'."
+           )
+         )}
 
-    if has_name do
-      rows = ets_to_rows(socket.assigns.ets_table)
+      socket.assigns.import_category_mode == :create and
+          not new_category_valid?(socket.assigns.new_category_changeset) ->
+        # Force the changeset's :action so errors render under the inline
+        # form fields when the user advances without filling it in.
+        cs = Map.put(socket.assigns.new_category_changeset, :action, :validate)
 
-      import_plan =
-        Mapper.build_import_plan(socket.assigns.column_mappings, rows,
-          unit_map: socket.assigns.unit_map
-        )
+        {:noreply,
+         socket
+         |> assign(:new_category_changeset, cs)
+         |> put_flash(
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Please give the new category a name before continuing."
+           )
+         )}
 
-      file_duplicates = Mapper.detect_file_duplicates(rows)
-
-      import_category =
-        if socket.assigns.import_category_mode == :existing,
-          do: socket.assigns.import_category_uuid,
-          else: nil
-
-      import_lang =
-        if socket.assigns.multilang_enabled, do: socket.assigns.current_lang, else: nil
-
-      existing_duplicates =
-        Mapper.detect_existing_duplicates(import_plan, socket.assigns.selected_catalogue.uuid,
-          category_uuid: import_category,
-          language: import_lang
-        )
-
-      {:noreply,
-       assign(socket,
-         step: :confirm,
-         import_plan: import_plan,
-         duplicate_row_count: file_duplicates,
-         existing_duplicate_count: existing_duplicates,
-         duplicate_mode: :import
-       )}
-    else
-      {:noreply,
-       put_flash(
-         socket,
-         :error,
-         Gettext.gettext(
-           PhoenixKitWeb.Gettext,
-           "You must map at least one column to 'Item Name'."
-         )
-       )}
+      true ->
+        build_confirm_step(socket)
     end
   end
 
@@ -297,9 +308,19 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       socket
       |> maybe_clear_category_column(category_mode)
       |> maybe_set_category_column(params["category_column"])
-      |> assign(import_category_mode: category_mode, import_category_uuid: category_uuid)
+      |> assign(
+        import_category_mode: category_mode,
+        import_category_uuid: category_uuid,
+        category_match_across_languages:
+          params["category_match_across_languages"] in ["true", "on", true]
+      )
+      |> sync_new_category_for_mode(category_mode)
 
     {:noreply, socket}
+  end
+
+  def handle_event("validate_new_category", %{"category" => params}, socket) do
+    {:noreply, apply_new_category_params(socket, params)}
   end
 
   def handle_event("switch_language", %{"lang" => lang_code}, socket) do
@@ -317,54 +338,18 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
   def handle_event("execute_import", _params, socket) do
     catalogue_uuid = socket.assigns.selected_catalogue.uuid
-    import_plan = socket.assigns.import_plan
-    lv_pid = self()
     import_lang = if socket.assigns.multilang_enabled, do: socket.assigns.current_lang, else: nil
 
-    import_category =
-      if socket.assigns.import_category_mode == :existing,
-        do: socket.assigns.import_category_uuid,
-        else: nil
+    case resolve_import_category(socket, catalogue_uuid, import_lang) do
+      {:ok, import_category, socket} ->
+        start_import(socket, catalogue_uuid, import_category, import_lang)
 
-    import_plan =
-      maybe_deduplicate(import_plan, socket.assigns.duplicate_mode, catalogue_uuid,
-        category_uuid: import_category,
-        language: import_lang
-      )
-
-    log_import_started(socket, import_plan)
-
-    Task.start(fn ->
-      try do
-        Executor.execute(import_plan, catalogue_uuid, lv_pid,
-          language: import_lang,
-          category_uuid: import_category,
-          actor_uuid: extract_actor_uuid(socket)
-        )
-      rescue
-        e ->
-          Logger.error("Import failed: #{Exception.message(e)}")
-
-          send(
-            lv_pid,
-            {:import_result,
-             %{
-               created: 0,
-               errors: [{0, Exception.message(e)}],
-               categories_created: 0
-             }}
-          )
-      end
-    end)
-
-    {:noreply,
-     assign(socket,
-       step: :importing,
-       import_progress: 0,
-       import_total: length(import_plan.items)
-     )}
+      {:error, message, socket} ->
+        {:noreply, put_flash(socket, :error, message)}
+    end
   end
 
+  # Resolves the category to pin imported items to, based on the
   # ── Step 6: Done ────────────────────────────────────────────────
 
   def handle_event("import_another", _params, socket) do
@@ -441,6 +426,34 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   end
 
   defp parse_uploaded_file(socket) do
+    cond do
+      # User picked a file but it hasn't finished uploading yet. Don't
+      # call `consume_uploaded_entries` — non-done entries are skipped
+      # but the form submit can disrupt the in-flight XHR, making the
+      # file appear to vanish. Tell the user to wait and leave the
+      # upload alone.
+      Enum.any?(socket.assigns.uploads.import_file.entries, &(not &1.done?)) ->
+        {:noreply,
+         put_flash(
+           socket,
+           :info,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Still uploading — please wait a moment.")
+         )}
+
+      socket.assigns.uploads.import_file.entries == [] ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Please upload a file.")
+         )}
+
+      true ->
+        consume_and_parse(socket)
+    end
+  end
+
+  defp consume_and_parse(socket) do
     uploaded_files =
       consume_uploaded_entries(socket, :import_file, fn %{path: path}, entry ->
         binary = File.read!(path)
@@ -589,8 +602,227 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
   defp parse_category_mode("none"), do: {:none, nil}
   defp parse_category_mode("column"), do: {:column, nil}
+  defp parse_category_mode("create"), do: {:create, nil}
   defp parse_category_mode("existing:" <> uuid), do: {:existing, uuid}
   defp parse_category_mode(_), do: {:none, nil}
+
+  # Seeds a fresh new-category struct + changeset when the user switches
+  # *into* `:create` mode, so the inline form has something to bind to.
+  # Clears them when switching *away* so we don't leak draft input across
+  # mode changes (and so a half-typed category can't accidentally get
+  # created if the user later runs the import in a different mode).
+  defp sync_new_category_for_mode(socket, :create) do
+    if socket.assigns.new_category do
+      socket
+    else
+      catalogue_uuid = socket.assigns.selected_catalogue && socket.assigns.selected_catalogue.uuid
+
+      next_pos =
+        if catalogue_uuid, do: Catalogue.next_category_position(catalogue_uuid), else: 0
+
+      category = %Category{catalogue_uuid: catalogue_uuid, position: next_pos}
+
+      assign(socket,
+        new_category: category,
+        new_category_changeset: Catalogue.change_category(category)
+      )
+    end
+  end
+
+  defp sync_new_category_for_mode(socket, _other) do
+    if socket.assigns.new_category,
+      do: assign(socket, new_category: nil, new_category_changeset: nil),
+      else: socket
+  end
+
+  defp apply_new_category_params(socket, params) do
+    catalogue_uuid = socket.assigns.selected_catalogue && socket.assigns.selected_catalogue.uuid
+
+    params =
+      params
+      |> Map.put_new("catalogue_uuid", catalogue_uuid)
+      |> merge_translatable_params(socket, @category_translatable_fields,
+        changeset: socket.assigns.new_category_changeset
+      )
+
+    changeset =
+      socket.assigns.new_category
+      |> Catalogue.change_category(params)
+      |> Map.put(:action, :validate)
+
+    assign(socket, :new_category_changeset, changeset)
+  end
+
+  defp new_category_valid?(nil), do: false
+
+  defp new_category_valid?(changeset) do
+    # `change_category` doesn't run validations until we apply an action,
+    # so we apply :validate explicitly to get a valid?-ready changeset.
+    changeset |> Map.put(:action, :validate) |> Map.get(:valid?)
+  end
+
+  defp build_confirm_step(socket) do
+    rows = ets_to_rows(socket.assigns.ets_table)
+
+    import_plan =
+      Mapper.build_import_plan(socket.assigns.column_mappings, rows,
+        unit_map: socket.assigns.unit_map
+      )
+
+    file_duplicates = Mapper.detect_file_duplicates(rows)
+
+    # `:create` mode produces a category at execute time, so its uuid
+    # isn't known yet — duplicate detection happens against "no category"
+    # since the new one will be empty by definition.
+    import_category =
+      if socket.assigns.import_category_mode == :existing,
+        do: socket.assigns.import_category_uuid,
+        else: nil
+
+    import_lang =
+      if socket.assigns.multilang_enabled, do: socket.assigns.current_lang, else: nil
+
+    existing_duplicates =
+      Mapper.detect_existing_duplicates(import_plan, socket.assigns.selected_catalogue.uuid,
+        category_uuid: import_category,
+        language: import_lang
+      )
+
+    {:noreply,
+     assign(socket,
+       step: :confirm,
+       import_plan: import_plan,
+       duplicate_row_count: file_duplicates,
+       existing_duplicate_count: existing_duplicates,
+       duplicate_mode: :import
+     )}
+  end
+
+  # Resolves the category to pin imported items to, based on the
+  # current `import_category_mode`. For `:create` mode this is where
+  # the actual category record gets persisted — deferring creation to
+  # execute time means cancelling out of the confirm step doesn't
+  # leave an orphan category behind.
+  defp resolve_import_category(socket, catalogue_uuid, import_lang) do
+    case socket.assigns.import_category_mode do
+      :existing ->
+        {:ok, socket.assigns.import_category_uuid, socket}
+
+      :create ->
+        attrs =
+          socket.assigns.new_category_changeset
+          |> Ecto.Changeset.apply_changes()
+          |> Map.from_struct()
+          |> Map.take([:name, :description, :position, :data])
+          |> Map.put(:catalogue_uuid, catalogue_uuid)
+          |> apply_category_language(import_lang)
+
+        case Catalogue.create_category(attrs, actor_opts(socket)) do
+          {:ok, category} ->
+            {:ok, category.uuid, socket}
+
+          {:error, changeset} ->
+            socket =
+              socket
+              |> assign(:new_category_changeset, Map.put(changeset, :action, :validate))
+              |> assign(:step, :map)
+
+            {:error,
+             Gettext.gettext(
+               PhoenixKitWeb.Gettext,
+               "Could not create the new category. Please check the form and try again."
+             ), socket}
+        end
+
+      _ ->
+        {:ok, nil, socket}
+    end
+  end
+
+  # Wraps the import language onto category attrs the same way
+  # `Executor.apply_language/2` does for items / column-created
+  # categories, so the explicitly-created category lands in the right
+  # `_primary_language` bucket.
+  defp apply_category_language(attrs, nil), do: attrs
+
+  defp apply_category_language(attrs, language) do
+    translatable = %{}
+
+    translatable =
+      if attrs[:name], do: Map.put(translatable, "_name", attrs[:name]), else: translatable
+
+    translatable =
+      if attrs[:description],
+        do: Map.put(translatable, "_description", attrs[:description]),
+        else: translatable
+
+    if map_size(translatable) > 0 do
+      existing_data = attrs[:data] || %{}
+
+      new_data = %{
+        "_primary_language" => language,
+        language => translatable
+      }
+
+      new_data = Map.merge(new_data, Map.drop(existing_data, ["_primary_language"]))
+      Map.put(attrs, :data, new_data)
+    else
+      attrs
+    end
+  end
+
+  defp actor_opts(socket) do
+    case socket.assigns[:phoenix_kit_current_user] do
+      %{uuid: uuid} -> [actor_uuid: uuid, mode: "auto"]
+      _ -> [mode: "auto"]
+    end
+  end
+
+  defp start_import(socket, catalogue_uuid, import_category, import_lang) do
+    import_plan = socket.assigns.import_plan
+    lv_pid = self()
+
+    import_plan =
+      maybe_deduplicate(import_plan, socket.assigns.duplicate_mode, catalogue_uuid,
+        category_uuid: import_category,
+        language: import_lang
+      )
+
+    log_import_started(socket, import_plan)
+
+    match_across_languages = socket.assigns.category_match_across_languages
+
+    Task.start(fn ->
+      try do
+        Executor.execute(import_plan, catalogue_uuid, lv_pid,
+          language: import_lang,
+          category_uuid: import_category,
+          match_categories_across_languages: match_across_languages,
+          actor_uuid: extract_actor_uuid(socket)
+        )
+      rescue
+        e ->
+          Logger.error("Import failed: #{Exception.message(e)}")
+
+          send(
+            lv_pid,
+            {:import_result,
+             %{
+               created: 0,
+               errors: [{0, Exception.message(e)}],
+               categories_created: 0
+             }}
+          )
+      end
+    end)
+
+    {:noreply,
+     assign(socket,
+       step: :importing,
+       import_progress: 0,
+       import_total: length(import_plan.items)
+     )}
+  end
 
   defp maybe_clear_category_column(socket, :column), do: socket
 
@@ -645,6 +877,106 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   end
 
   # ── Step Components ─────────────────────────────────────────────
+
+  # Inline category-creation form, shown when the user picks
+  # "Create a new category" in the Import Into Category dropdown.
+  # Mirrors the standalone CategoryFormLive view but omits its language
+  # tabs (the import wizard already has a top-level switcher) and its
+  # action buttons (the wizard's Continue/Run buttons drive the flow).
+  attr(:changeset, :map, required: true)
+  attr(:multilang_enabled, :boolean, required: true)
+  attr(:current_lang, :string, required: true)
+  attr(:primary_language, :string, required: true)
+
+  defp new_category_form(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :lang_data,
+        get_lang_data(assigns.changeset, assigns.current_lang, assigns.multilang_enabled)
+      )
+
+    ~H"""
+    <form
+      id="new-category-form"
+      phx-change="validate_new_category"
+      phx-submit="continue_to_confirm"
+      class="mt-4 pl-4 border-l-2 border-secondary/20"
+    >
+      <.multilang_fields_wrapper
+        multilang_enabled={@multilang_enabled}
+        current_lang={@current_lang}
+        skeleton_class="flex flex-col gap-6"
+        fields_class="flex flex-col gap-6"
+      >
+        <:skeleton>
+          <div class="space-y-2">
+            <div class="skeleton h-4 w-20"></div>
+            <div class="skeleton h-12 w-full"></div>
+          </div>
+          <div class="space-y-2">
+            <div class="skeleton h-4 w-28"></div>
+            <div class="skeleton h-24 w-full"></div>
+          </div>
+        </:skeleton>
+
+        <.translatable_field
+          field_name="name"
+          form_prefix="category"
+          changeset={@changeset}
+          schema_field={:name}
+          multilang_enabled={@multilang_enabled}
+          current_lang={@current_lang}
+          primary_language={@primary_language}
+          lang_data={@lang_data}
+          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}
+          placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Cabinet Frames")}
+          required
+          class="w-full"
+        />
+
+        <.translatable_field
+          field_name="description"
+          form_prefix="category"
+          changeset={@changeset}
+          schema_field={:description}
+          multilang_enabled={@multilang_enabled}
+          current_lang={@current_lang}
+          primary_language={@primary_language}
+          lang_data={@lang_data}
+          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+          placeholder={
+            Gettext.gettext(
+              PhoenixKitWeb.Gettext,
+              "What kinds of items belong in this category..."
+            )
+          }
+          type="textarea"
+          class="w-full"
+        />
+
+        <div class="form-control">
+          <span class="label-text font-semibold mb-2">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Position")}
+          </span>
+          <input
+            type="number"
+            name="category[position]"
+            value={Ecto.Changeset.get_field(@changeset, :position)}
+            class="input input-bordered w-28 transition-colors focus:input-primary"
+            min="0"
+          />
+          <span class="label-text-alt text-base-content/50 mt-1">
+            {Gettext.gettext(
+              PhoenixKitWeb.Gettext,
+              "Lower numbers appear first."
+            )}
+          </span>
+        </div>
+      </.multilang_fields_wrapper>
+    </form>
+    """
+  end
 
   defp step_badge(assigns) do
     steps = [:upload, :map, :confirm, :importing]
@@ -701,7 +1033,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                   value={cat.uuid}
                   selected={@selected_catalogue && @selected_catalogue.uuid == cat.uuid}
                 >
-                  {cat.name}
+                  {catalogue_picker_label(cat, @catalogue_item_counts, @catalogue_category_counts)}
                 </option>
               </select>
             </label>
@@ -775,18 +1107,35 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             <% end %>
           </div>
 
-          <%!-- Action button --%>
+          <%!-- Action button. Stays disabled while the upload XHR is in
+               flight — clicking submit before the entry is `done?` makes
+               `consume_uploaded_entries` return [] and disrupts the
+               in-flight upload, which looks to the user like the file
+               vanished. --%>
+          <% upload_in_progress? = Enum.any?(@uploads.import_file.entries, &(not &1.done?)) %>
           <button
             type="submit"
             class="btn btn-primary"
-            disabled={if @filename, do: @selected_catalogue == nil, else: @uploads.import_file.entries == [] or @selected_catalogue == nil}
+            disabled={
+              cond do
+                @selected_catalogue == nil -> true
+                @filename -> false
+                @uploads.import_file.entries == [] -> true
+                upload_in_progress? -> true
+                true -> false
+              end
+            }
           >
-            <%= if @filename do %>
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Continue")}
-              <.icon name="hero-arrow-right" class="w-4 h-4" />
-            <% else %>
-              <.icon name="hero-arrow-up-tray" class="w-4 h-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Upload & Parse")}
+            <%= cond do %>
+              <% @filename -> %>
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Continue")}
+                <.icon name="hero-arrow-right" class="w-4 h-4" />
+              <% upload_in_progress? -> %>
+                <span class="loading loading-spinner loading-xs"></span>
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Uploading...")}
+              <% true -> %>
+                <.icon name="hero-arrow-up-tray" class="w-4 h-4" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Upload & Parse")}
             <% end %>
           </button>
         </form>
@@ -858,6 +1207,9 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                 <option value="column" selected={@import_category_mode == :column}>
                   {Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — create categories from column values")}
                 </option>
+                <option value="create" selected={@import_category_mode == :create}>
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new category — fill in the details below")}
+                </option>
                 <option :for={cat <- @catalogue_categories} value={"existing:#{cat.uuid}"} selected={@import_category_mode == :existing and @import_category_uuid == cat.uuid}>
                   {cat.name}
                 </option>
@@ -866,6 +1218,34 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
             <%!-- Column picker for category --%>
             <div :if={@import_category_mode == :column} class="pl-4 border-l-2 border-secondary/20">
+              <%!-- Cross-language match toggle. Only meaningful when
+                   multilang is on — without it there's only ever one
+                   language so "across languages" is a no-op. --%>
+              <label
+                :if={@multilang_enabled}
+                class="flex items-center gap-2 mb-3 cursor-pointer text-xs text-base-content/70"
+              >
+                <input
+                  type="checkbox"
+                  name="category_match_across_languages"
+                  value="true"
+                  checked={@category_match_across_languages}
+                  class="checkbox checkbox-xs checkbox-primary"
+                />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Match across all languages")}
+                <span
+                  class="tooltip tooltip-right tooltip-info"
+                  data-tip={
+                    Gettext.gettext(
+                      PhoenixKitWeb.Gettext,
+                      "By default the importer only matches existing categories by their name in the current import language. Turn this on to also match translations in any other language — useful for multilingual catalogues where the same category is named differently in each language."
+                    )
+                  }
+                >
+                  <.icon name="hero-information-circle" class="w-3.5 h-3.5 text-base-content/40 hover:text-base-content/70" />
+                </span>
+              </label>
+
               <span class="block mb-1 text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Which column contains the category names?")}</span>
               <label class="select select-sm w-full">
                 <select name="category_column">
@@ -891,6 +1271,19 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
               </div>
             </div>
           </form>
+
+          <%!-- Inline new-category form (mirrors the standalone Category
+               creation screen, minus its own buttons + language switcher
+               since the import wizard already provides both at the top).
+               Sits OUTSIDE the mode-picker form so its phx-change doesn't
+               re-fire mode selection on every keystroke. --%>
+          <.new_category_form
+            :if={@import_category_mode == :create and @new_category_changeset}
+            changeset={@new_category_changeset}
+            multilang_enabled={@multilang_enabled}
+            current_lang={@current_lang}
+            primary_language={@primary_language}
+          />
         </div>
 
         <p class="text-sm text-base-content/60">
@@ -945,23 +1338,27 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
         </form>
 
-        <%!-- Data preview --%>
+        <%!-- Data preview. The collapse `<input>` carries an `id` so
+             morphdom preserves the open/closed state across LiveView
+             patches; without it the panel snaps shut on every diff. --%>
         <div class="collapse collapse-arrow bg-base-200/30 border border-base-300">
-          <input type="checkbox" />
+          <input type="checkbox" id="sample-data-collapse" />
           <div class="collapse-title text-sm font-medium">
             <.icon name="hero-table-cells" class="w-4 h-4 inline" />
             {Gettext.gettext(PhoenixKitWeb.Gettext, "Sample Data (first 5 rows)")}
           </div>
           <div class="collapse-content overflow-x-auto">
-            <table class="table table-sm table-zebra">
+            <table class="table table-sm table-zebra [&_th]:border-r [&_th]:border-base-300 [&_td]:border-r [&_td]:border-base-300 [&_th:last-child]:border-r-0 [&_td:last-child]:border-r-0">
               <thead>
                 <tr>
+                  <th class="bg-base-200 font-semibold text-xs w-8 text-base-content/40">#</th>
                   <th :for={header <- @headers} class="bg-base-200 font-semibold text-xs">{header}</th>
                 </tr>
               </thead>
               <tbody>
-                <tr :for={row <- @preview_rows}>
-                  <td :for={cell <- row} class="max-w-[200px] truncate text-xs">{cell}</td>
+                <tr :for={{row, idx} <- Enum.with_index(@preview_rows, 1)}>
+                  <td class="text-xs text-base-content/40 tabular-nums">{idx}</td>
+                  <td :for={cell <- row} title={cell} class="max-w-[200px] truncate text-xs">{cell}</td>
                 </tr>
               </tbody>
             </table>
@@ -1176,6 +1573,31 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   end
 
   # ── Private helpers ─────────────────────────────────────────────
+
+  # Builds the label shown for one catalogue in the Target Catalogue
+  # picker. Counts are passed in as separate `%{uuid => count}` maps so
+  # the picker stays a thin renderer over data the LiveView already
+  # has — no per-option DB lookups, no N+1.
+  defp catalogue_picker_label(cat, item_counts, category_counts) do
+    items = Map.get(item_counts, cat.uuid, 0)
+    categories = Map.get(category_counts, cat.uuid, 0)
+
+    items_label =
+      Gettext.ngettext(PhoenixKitWeb.Gettext, "%{count} item", "%{count} items", items,
+        count: items
+      )
+
+    categories_label =
+      Gettext.ngettext(
+        PhoenixKitWeb.Gettext,
+        "%{count} category",
+        "%{count} categories",
+        categories,
+        count: categories
+      )
+
+    "#{cat.name} · #{categories_label} · #{items_label}"
+  end
 
   defp translate_target("— Skip —"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "— Skip —")
   defp translate_target("Item Name"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Item Name")

--- a/lib/phoenix_kit_catalogue/web/import_live.ex
+++ b/lib/phoenix_kit_catalogue/web/import_live.ex
@@ -35,7 +35,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Import.{Executor, Mapper, Parser}
   alias PhoenixKitCatalogue.Paths
-  alias PhoenixKitCatalogue.Schemas.{Category, Item}
+  alias PhoenixKitCatalogue.Schemas.{Category, Item, Manufacturer, Supplier}
 
   @max_file_size 10_000_000
   @preview_rows 5
@@ -54,6 +54,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     catalogues = Catalogue.list_catalogues()
     catalogue_item_counts = Catalogue.item_counts_by_catalogue()
     catalogue_category_counts = Catalogue.category_counts_by_catalogue()
+    manufacturers = Catalogue.list_manufacturers(status: "active")
+    suppliers = Catalogue.list_suppliers(status: "active")
 
     {:ok,
      socket
@@ -63,6 +65,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
        catalogues: catalogues,
        catalogue_item_counts: catalogue_item_counts,
        catalogue_category_counts: catalogue_category_counts,
+       manufacturers: manufacturers,
+       suppliers: suppliers,
        selected_catalogue: nil,
        # File data
 
@@ -83,6 +87,14 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
        new_category: nil,
        new_category_changeset: nil,
        catalogue_categories: [],
+       import_manufacturer_mode: :none,
+       import_manufacturer_uuid: nil,
+       new_manufacturer: nil,
+       new_manufacturer_changeset: nil,
+       import_supplier_mode: :none,
+       import_supplier_uuid: nil,
+       new_supplier: nil,
+       new_supplier_changeset: nil,
        # Import
        import_plan: nil,
        import_result: nil,
@@ -129,7 +141,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     if socket.assigns.ets_table, do: :ets.delete(socket.assigns.ets_table)
 
     {:noreply,
-     assign(socket,
+     socket
+     |> assign(
        filename: nil,
        file_binary: nil,
        headers: [],
@@ -141,7 +154,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
        unit_map: %{},
        ets_table: nil,
        import_plan: nil
-     )}
+     )
+     |> reset_picker_state()}
   end
 
   def handle_event("parse_file", params, socket) do
@@ -183,7 +197,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         {unit_values, unit_map} = detect_unit_values(mappings, data.rows)
 
         {:noreply,
-         assign(socket,
+         socket
+         |> assign(
            headers: data.headers,
            preview_rows: Enum.take(data.rows, @preview_rows),
            row_count: data.row_count,
@@ -191,7 +206,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
            column_mappings: mappings,
            unit_values: unit_values,
            unit_map: unit_map
-         )}
+         )
+         |> reset_picker_state()}
 
       {:error, reason} ->
         Logger.warning("Import sheet parse error: #{reason}")
@@ -273,14 +289,12 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
            :error,
            Gettext.gettext(
              PhoenixKitWeb.Gettext,
-             "You must map at least one column to 'Item Name'."
+             "You must map at least one column to 'Item Name'. Scroll down to the column mapping section and pick the column that holds item names."
            )
          )}
 
       socket.assigns.import_category_mode == :create and
-          not new_category_valid?(socket.assigns.new_category_changeset) ->
-        # Force the changeset's :action so errors render under the inline
-        # form fields when the user advances without filling it in.
+          not new_record_valid?(socket.assigns.new_category_changeset) ->
         cs = Map.put(socket.assigns.new_category_changeset, :action, :validate)
 
         {:noreply,
@@ -294,6 +308,36 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
            )
          )}
 
+      socket.assigns.import_manufacturer_mode == :create and
+          not new_record_valid?(socket.assigns.new_manufacturer_changeset) ->
+        cs = Map.put(socket.assigns.new_manufacturer_changeset, :action, :validate)
+
+        {:noreply,
+         socket
+         |> assign(:new_manufacturer_changeset, cs)
+         |> put_flash(
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Please give the new manufacturer a name before continuing."
+           )
+         )}
+
+      socket.assigns.import_supplier_mode == :create and
+          not new_record_valid?(socket.assigns.new_supplier_changeset) ->
+        cs = Map.put(socket.assigns.new_supplier_changeset, :action, :validate)
+
+        {:noreply,
+         socket
+         |> assign(:new_supplier_changeset, cs)
+         |> put_flash(
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Please give the new supplier a name before continuing."
+           )
+         )}
+
       true ->
         build_confirm_step(socket)
     end
@@ -302,12 +346,12 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   # ── Step 4: Confirm ─────────────────────────────────────────────
 
   def handle_event("select_import_category", params, socket) do
-    {category_mode, category_uuid} = parse_category_mode(params["category_mode"])
+    {category_mode, category_uuid} = parse_picker_mode(params["category_mode"])
 
     socket =
       socket
-      |> maybe_clear_category_column(category_mode)
-      |> maybe_set_category_column(params["category_column"])
+      |> maybe_clear_picker_column(:import_category_mode, category_mode)
+      |> maybe_set_picker_column(:import_category_mode, params["category_column"])
       |> assign(
         import_category_mode: category_mode,
         import_category_uuid: category_uuid,
@@ -321,6 +365,40 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
   def handle_event("validate_new_category", %{"category" => params}, socket) do
     {:noreply, apply_new_category_params(socket, params)}
+  end
+
+  def handle_event("select_import_manufacturer", params, socket) do
+    {mode, uuid} = parse_picker_mode(params["manufacturer_mode"])
+
+    socket =
+      socket
+      |> maybe_clear_picker_column(:import_manufacturer_mode, mode)
+      |> maybe_set_picker_column(:import_manufacturer_mode, params["manufacturer_column"])
+      |> assign(import_manufacturer_mode: mode, import_manufacturer_uuid: uuid)
+      |> sync_new_manufacturer_for_mode(mode)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("validate_new_manufacturer", %{"manufacturer" => params}, socket) do
+    {:noreply, apply_new_manufacturer_params(socket, params)}
+  end
+
+  def handle_event("select_import_supplier", params, socket) do
+    {mode, uuid} = parse_picker_mode(params["supplier_mode"])
+
+    socket =
+      socket
+      |> maybe_clear_picker_column(:import_supplier_mode, mode)
+      |> maybe_set_picker_column(:import_supplier_mode, params["supplier_column"])
+      |> assign(import_supplier_mode: mode, import_supplier_uuid: uuid)
+      |> sync_new_supplier_for_mode(mode)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("validate_new_supplier", %{"supplier" => params}, socket) do
+    {:noreply, apply_new_supplier_params(socket, params)}
   end
 
   def handle_event("switch_language", %{"lang" => lang_code}, socket) do
@@ -340,16 +418,39 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     catalogue_uuid = socket.assigns.selected_catalogue.uuid
     import_lang = if socket.assigns.multilang_enabled, do: socket.assigns.current_lang, else: nil
 
-    case resolve_import_category(socket, catalogue_uuid, import_lang) do
-      {:ok, import_category, socket} ->
-        start_import(socket, catalogue_uuid, import_category, import_lang)
+    # Wrap the three :create-mode resolutions in a single transaction
+    # so a failure on the second or third doesn't leave the first as
+    # an orphan record. Modes other than :create are read-only inside
+    # the transaction (they just look up the picked uuid), so this is
+    # a no-op cost when nobody is creating anything.
+    txn =
+      PhoenixKit.RepoHelper.repo().transaction(fn ->
+        with {:ok, c_uuid, s1} <- resolve_import_category(socket, catalogue_uuid, import_lang),
+             {:ok, m_uuid, s2} <- resolve_import_manufacturer(s1),
+             {:ok, s_uuid, s3} <- resolve_import_supplier(s2) do
+          {c_uuid, m_uuid, s_uuid, s3}
+        else
+          {:error, message, socket} ->
+            PhoenixKit.RepoHelper.repo().rollback({:error, message, socket})
+        end
+      end)
 
-      {:error, message, socket} ->
+    case txn do
+      {:ok, {category_uuid, manufacturer_uuid, supplier_uuid, socket}} ->
+        start_import(
+          socket,
+          catalogue_uuid,
+          category_uuid,
+          manufacturer_uuid,
+          supplier_uuid,
+          import_lang
+        )
+
+      {:error, {:error, message, socket}} ->
         {:noreply, put_flash(socket, :error, message)}
     end
   end
 
-  # Resolves the category to pin imported items to, based on the
   # ── Step 6: Done ────────────────────────────────────────────────
 
   def handle_event("import_another", _params, socket) do
@@ -375,6 +476,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
        import_total: 0,
        ets_table: nil
      )
+     |> reset_picker_state()
      |> allow_upload(:import_file,
        accept: ~w(.xlsx .csv),
        max_entries: 1,
@@ -551,7 +653,17 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     end
   end
 
-  @unique_targets [:name, :description, :sku, :base_price, :markup_percentage, :unit, :category]
+  @unique_targets [
+    :name,
+    :description,
+    :sku,
+    :base_price,
+    :markup_percentage,
+    :unit,
+    :category,
+    :manufacturer,
+    :supplier
+  ]
 
   defp update_column_mappings(mappings, changed_idx, new_target) do
     Enum.map(mappings, fn m ->
@@ -600,11 +712,42 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     assign(socket, :unit_map, unit_map)
   end
 
-  defp parse_category_mode("none"), do: {:none, nil}
-  defp parse_category_mode("column"), do: {:column, nil}
-  defp parse_category_mode("create"), do: {:create, nil}
-  defp parse_category_mode("existing:" <> uuid), do: {:existing, uuid}
-  defp parse_category_mode(_), do: {:none, nil}
+  # Resets every picker's mode/uuid/inline-create state back to its
+  # initial defaults. Called whenever the underlying file or sheet
+  # changes (sheet switch, file replace, "Import another"), because the
+  # picker assigns reference column-mapping shapes specific to the
+  # previously-loaded data — leaving them in place after a fresh parse
+  # would either point at columns that no longer exist or surface
+  # stale `:column`-mode UI tied to the old sheet.
+  defp reset_picker_state(socket) do
+    assign(socket,
+      import_category_mode: :none,
+      import_category_uuid: nil,
+      category_match_across_languages: false,
+      new_category: nil,
+      new_category_changeset: nil,
+      import_manufacturer_mode: :none,
+      import_manufacturer_uuid: nil,
+      new_manufacturer: nil,
+      new_manufacturer_changeset: nil,
+      import_supplier_mode: :none,
+      import_supplier_uuid: nil,
+      new_supplier: nil,
+      new_supplier_changeset: nil,
+      duplicate_row_count: 0,
+      existing_duplicate_count: 0,
+      duplicate_mode: :import
+    )
+  end
+
+  # Generic mode parser used by all three pickers (category,
+  # manufacturer, supplier) — they share the same `none / column /
+  # create / existing:<uuid>` vocabulary, so one parser suffices.
+  defp parse_picker_mode("none"), do: {:none, nil}
+  defp parse_picker_mode("column"), do: {:column, nil}
+  defp parse_picker_mode("create"), do: {:create, nil}
+  defp parse_picker_mode("existing:" <> uuid), do: {:existing, uuid}
+  defp parse_picker_mode(_), do: {:none, nil}
 
   # Seeds a fresh new-category struct + changeset when the user switches
   # *into* `:create` mode, so the inline form has something to bind to.
@@ -653,11 +796,71 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     assign(socket, :new_category_changeset, changeset)
   end
 
-  defp new_category_valid?(nil), do: false
+  # ── Manufacturer / Supplier inline-create state ─────────────────
 
-  defp new_category_valid?(changeset) do
-    # `change_category` doesn't run validations until we apply an action,
-    # so we apply :validate explicitly to get a valid?-ready changeset.
+  # Same idea as `sync_new_category_for_mode/2` but for the
+  # manufacturer picker. Manufacturers aren't multilingual so the
+  # changeset starts empty and we don't need any
+  # `merge_translatable_params` machinery on validate.
+  defp sync_new_manufacturer_for_mode(socket, :create) do
+    if socket.assigns.new_manufacturer do
+      socket
+    else
+      manufacturer = %Manufacturer{}
+
+      assign(socket,
+        new_manufacturer: manufacturer,
+        new_manufacturer_changeset: Catalogue.change_manufacturer(manufacturer)
+      )
+    end
+  end
+
+  defp sync_new_manufacturer_for_mode(socket, _other) do
+    if socket.assigns.new_manufacturer,
+      do: assign(socket, new_manufacturer: nil, new_manufacturer_changeset: nil),
+      else: socket
+  end
+
+  defp apply_new_manufacturer_params(socket, params) do
+    changeset =
+      socket.assigns.new_manufacturer
+      |> Catalogue.change_manufacturer(params)
+      |> Map.put(:action, :validate)
+
+    assign(socket, :new_manufacturer_changeset, changeset)
+  end
+
+  defp sync_new_supplier_for_mode(socket, :create) do
+    if socket.assigns.new_supplier do
+      socket
+    else
+      supplier = %Supplier{}
+
+      assign(socket,
+        new_supplier: supplier,
+        new_supplier_changeset: Catalogue.change_supplier(supplier)
+      )
+    end
+  end
+
+  defp sync_new_supplier_for_mode(socket, _other) do
+    if socket.assigns.new_supplier,
+      do: assign(socket, new_supplier: nil, new_supplier_changeset: nil),
+      else: socket
+  end
+
+  defp apply_new_supplier_params(socket, params) do
+    changeset =
+      socket.assigns.new_supplier
+      |> Catalogue.change_supplier(params)
+      |> Map.put(:action, :validate)
+
+    assign(socket, :new_supplier_changeset, changeset)
+  end
+
+  defp new_record_valid?(nil), do: false
+
+  defp new_record_valid?(changeset) do
     changeset |> Map.put(:action, :validate) |> Map.get(:valid?)
   end
 
@@ -778,13 +981,94 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     end
   end
 
-  defp start_import(socket, catalogue_uuid, import_category, import_lang) do
+  # ── Manufacturer / Supplier resolution at execute time ─────────
+
+  # Same `:create` deferral pattern as `resolve_import_category/3`:
+  # the inline-create form's record isn't persisted until the user
+  # actually clicks Run, so cancelling the confirm step doesn't leave
+  # an orphan manufacturer.
+  defp resolve_import_manufacturer(socket) do
+    case socket.assigns.import_manufacturer_mode do
+      :existing ->
+        {:ok, socket.assigns.import_manufacturer_uuid, socket}
+
+      :create ->
+        attrs =
+          socket.assigns.new_manufacturer_changeset
+          |> Ecto.Changeset.apply_changes()
+          |> Map.from_struct()
+          |> Map.take([:name, :description, :website, :contact_info, :logo_url, :notes])
+
+        case Catalogue.create_manufacturer(attrs, actor_opts(socket)) do
+          {:ok, manufacturer} ->
+            {:ok, manufacturer.uuid, socket}
+
+          {:error, changeset} ->
+            socket =
+              socket
+              |> assign(:new_manufacturer_changeset, Map.put(changeset, :action, :validate))
+              |> assign(:step, :map)
+
+            {:error,
+             Gettext.gettext(
+               PhoenixKitWeb.Gettext,
+               "Could not create the new manufacturer. Please check the form and try again."
+             ), socket}
+        end
+
+      _ ->
+        {:ok, nil, socket}
+    end
+  end
+
+  defp resolve_import_supplier(socket) do
+    case socket.assigns.import_supplier_mode do
+      :existing ->
+        {:ok, socket.assigns.import_supplier_uuid, socket}
+
+      :create ->
+        attrs =
+          socket.assigns.new_supplier_changeset
+          |> Ecto.Changeset.apply_changes()
+          |> Map.from_struct()
+          |> Map.take([:name, :description, :website, :contact_info, :notes])
+
+        case Catalogue.create_supplier(attrs, actor_opts(socket)) do
+          {:ok, supplier} ->
+            {:ok, supplier.uuid, socket}
+
+          {:error, changeset} ->
+            socket =
+              socket
+              |> assign(:new_supplier_changeset, Map.put(changeset, :action, :validate))
+              |> assign(:step, :map)
+
+            {:error,
+             Gettext.gettext(
+               PhoenixKitWeb.Gettext,
+               "Could not create the new supplier. Please check the form and try again."
+             ), socket}
+        end
+
+      _ ->
+        {:ok, nil, socket}
+    end
+  end
+
+  defp start_import(
+         socket,
+         catalogue_uuid,
+         category_uuid,
+         manufacturer_uuid,
+         supplier_uuid,
+         import_lang
+       ) do
     import_plan = socket.assigns.import_plan
     lv_pid = self()
 
     import_plan =
       maybe_deduplicate(import_plan, socket.assigns.duplicate_mode, catalogue_uuid,
-        category_uuid: import_category,
+        category_uuid: category_uuid,
         language: import_lang
       )
 
@@ -796,7 +1080,9 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       try do
         Executor.execute(import_plan, catalogue_uuid, lv_pid,
           language: import_lang,
-          category_uuid: import_category,
+          category_uuid: category_uuid,
+          manufacturer_uuid: manufacturer_uuid,
+          supplier_uuid: supplier_uuid,
           match_categories_across_languages: match_across_languages,
           actor_uuid: extract_actor_uuid(socket)
         )
@@ -810,7 +1096,10 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
              %{
                created: 0,
                errors: [{0, Exception.message(e)}],
-               categories_created: 0
+               categories_created: 0,
+               manufacturers_created: 0,
+               suppliers_created: 0,
+               manufacturer_supplier_links_created: 0
              }}
           )
       end
@@ -824,30 +1113,41 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
      )}
   end
 
-  defp maybe_clear_category_column(socket, :column), do: socket
+  # Whenever a picker leaves `:column` mode, clear any column that was
+  # previously assigned to that picker's target so it doesn't keep
+  # carrying that role into the import plan. (The category picker
+  # historically did this; same logic applies to manufacturer/supplier.)
+  defp maybe_clear_picker_column(socket, _picker_mode_assign, :column), do: socket
 
-  defp maybe_clear_category_column(socket, _category_mode) do
-    if socket.assigns.import_category_mode == :column do
-      mappings = clear_category_from_mappings(socket.assigns.column_mappings)
+  defp maybe_clear_picker_column(socket, picker_mode_assign, _new_mode) do
+    if socket.assigns[picker_mode_assign] == :column do
+      target = picker_target(picker_mode_assign)
+      mappings = clear_target_from_mappings(socket.assigns.column_mappings, target)
       assign(socket, :column_mappings, mappings)
     else
       socket
     end
   end
 
-  defp clear_category_from_mappings(mappings) do
+  defp clear_target_from_mappings(mappings, target) do
     Enum.map(mappings, fn m ->
-      if m.target == :category, do: %{m | target: :skip}, else: m
+      if m.target == target, do: %{m | target: :skip}, else: m
     end)
   end
 
-  defp maybe_set_category_column(socket, col) when is_binary(col) and col != "" do
+  defp maybe_set_picker_column(socket, picker_mode_assign, col)
+       when is_binary(col) and col != "" do
     col_idx = String.to_integer(col)
-    mappings = update_column_mappings(socket.assigns.column_mappings, col_idx, :category)
+    target = picker_target(picker_mode_assign)
+    mappings = update_column_mappings(socket.assigns.column_mappings, col_idx, target)
     assign(socket, :column_mappings, mappings)
   end
 
-  defp maybe_set_category_column(socket, _), do: socket
+  defp maybe_set_picker_column(socket, _picker_mode_assign, _), do: socket
+
+  defp picker_target(:import_category_mode), do: :category
+  defp picker_target(:import_manufacturer_mode), do: :manufacturer
+  defp picker_target(:import_supplier_mode), do: :supplier
 
   # ── Render ──────────────────────────────────────────────────────
 
@@ -877,6 +1177,174 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   end
 
   # ── Step Components ─────────────────────────────────────────────
+
+  # Generic picker block for manufacturer / supplier — same vocabulary
+  # as the category picker (none / column / create / existing) but
+  # without multilang noise. The component is a thin renderer over the
+  # mode + chosen-uuid + column-mapping state held by the LiveView; the
+  # caller wires the labels and event names so the same shell drives
+  # both pickers.
+  attr(:label, :string, required: true)
+  attr(:form_id, :string, required: true)
+  attr(:on_change, :string, required: true)
+  attr(:mode_field, :string, required: true)
+  attr(:column_field, :string, required: true)
+  attr(:mode, :atom, required: true)
+  attr(:uuid, :string, default: nil)
+  attr(:options, :list, required: true)
+  attr(:column_mappings, :list, required: true)
+  attr(:ets_table, :any, required: true)
+  attr(:target, :atom, required: true)
+  attr(:none_label, :string, required: true)
+  attr(:column_label, :string, required: true)
+  attr(:create_label, :string, required: true)
+  attr(:column_picker_prompt, :string, required: true)
+  attr(:preview_label, :string, required: true)
+
+  defp party_picker(assigns) do
+    ~H"""
+    <div class="form-control w-full max-w-md">
+      <span class="block mb-2 text-sm font-medium">{@label}</span>
+      <form id={@form_id} phx-change={@on_change} class="space-y-3">
+        <label class="select w-full">
+          <select name={@mode_field}>
+            <option value="none" selected={@mode == :none}>{@none_label}</option>
+            <option value="column" selected={@mode == :column}>{@column_label}</option>
+            <option value="create" selected={@mode == :create}>{@create_label}</option>
+            <option
+              :for={opt <- @options}
+              value={"existing:#{opt.uuid}"}
+              selected={@mode == :existing and @uuid == opt.uuid}
+            >
+              {opt.name}
+            </option>
+          </select>
+        </label>
+
+        <div :if={@mode == :column} class="pl-4 border-l-2 border-secondary/20">
+          <% available = available_picker_columns(@column_mappings, @target) %>
+          <span class="block mb-1 text-xs text-base-content/60">{@column_picker_prompt}</span>
+          <%= if available == [] do %>
+            <p class="text-xs text-warning bg-warning/10 border border-warning/30 rounded-lg px-3 py-2">
+              {Gettext.gettext(
+                PhoenixKitWeb.Gettext,
+                "All columns are already mapped. Free one up by setting it to '— Skip —' in the column mapping section below, or by switching another picker (Category, Manufacturer, or Supplier) out of 'Use a column' mode."
+              )}
+            </p>
+          <% else %>
+            <label class="select select-sm w-full">
+              <select name={@column_field}>
+                <option value="" disabled selected={not has_mapping?(@column_mappings, @target)}>
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
+                </option>
+                <%!-- Only offer columns that are unmapped (`:skip`),
+                     already this picker's target, or used as a custom
+                     `{:data, _}` field. Hiding columns already mapped
+                     to another unique target (`:name`, `:sku`, etc.)
+                     prevents the picker from silently clobbering an
+                     auto-detected mapping the user still relies on. --%>
+                <option
+                  :for={mapping <- available}
+                  value={mapping.column_index}
+                  selected={mapping.target == @target}
+                >
+                  {mapping.header}
+                </option>
+              </select>
+            </label>
+          <% end %>
+          <div :if={has_mapping?(@column_mappings, @target)} class="mt-2">
+            <span class="text-xs text-base-content/60">{@preview_label}</span>
+            <div class="flex flex-wrap gap-1 mt-1">
+              <% picked = Enum.find(@column_mappings, &(&1.target == @target)) %>
+              <span
+                :for={val <- unique_column_values_from_ets(@ets_table, picked.column_index)}
+                class="badge badge-secondary badge-outline badge-xs"
+              >
+                {val}
+              </span>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    """
+  end
+
+  # Inline create form for manufacturer / supplier. Both schemas have
+  # the same shape (plain `name` + a few optional text fields), so one
+  # component covers both via `form_prefix` switching between
+  # `manufacturer` and `supplier`.
+  attr(:form_id, :string, required: true)
+  attr(:form_prefix, :string, required: true)
+  attr(:on_change, :string, required: true)
+  attr(:changeset, :map, required: true)
+  attr(:name_placeholder, :string, required: true)
+
+  defp new_party_form(assigns) do
+    ~H"""
+    <form
+      id={@form_id}
+      phx-change={@on_change}
+      phx-submit="continue_to_confirm"
+      class="mt-2 pl-4 border-l-2 border-secondary/20 max-w-md"
+    >
+      <div class="flex flex-col gap-4">
+        <div class="form-control">
+          <span class="label-text font-semibold mb-2">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} *
+          </span>
+          <input
+            type="text"
+            name={"#{@form_prefix}[name]"}
+            value={Ecto.Changeset.get_field(@changeset, :name) || ""}
+            placeholder={@name_placeholder}
+            class="input input-bordered w-full transition-colors focus:input-primary"
+            required
+          />
+          <span :for={err <- field_errors(@changeset, :name)} class="text-error text-xs mt-1">
+            {err}
+          </span>
+        </div>
+
+        <div class="form-control">
+          <span class="label-text font-semibold mb-2">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+          </span>
+          <textarea
+            name={"#{@form_prefix}[description]"}
+            class="textarea textarea-bordered w-full transition-colors focus:textarea-primary"
+            rows="2"
+          >{Ecto.Changeset.get_field(@changeset, :description) || ""}</textarea>
+        </div>
+
+        <div class="form-control">
+          <span class="label-text font-semibold mb-2">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}
+          </span>
+          <input
+            type="url"
+            name={"#{@form_prefix}[website]"}
+            value={Ecto.Changeset.get_field(@changeset, :website) || ""}
+            placeholder="https://..."
+            class="input input-bordered w-full transition-colors focus:input-primary"
+          />
+        </div>
+      </div>
+    </form>
+    """
+  end
+
+  defp field_errors(changeset, field) do
+    changeset
+    |> Map.get(:errors, [])
+    |> Keyword.get_values(field)
+    |> Enum.map(fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
 
   # Inline category-creation form, shown when the user picks
   # "Create a new category" in the Import Into Category dropdown.
@@ -1149,7 +1617,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   defp map_step(assigns) do
     all_targets =
       Mapper.available_targets()
-      |> Enum.reject(fn {t, _} -> t == :category end)
+      |> Enum.reject(fn {t, _} -> t in [:category, :manufacturer, :supplier] end)
       |> Enum.map(fn {target, label} -> {target, translate_target(label)} end)
 
     allowed_units = Item.allowed_units()
@@ -1246,21 +1714,31 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                 </span>
               </label>
 
+              <% available_category_cols = available_picker_columns(@column_mappings, :category) %>
               <span class="block mb-1 text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Which column contains the category names?")}</span>
-              <label class="select select-sm w-full">
-                <select name="category_column">
-                  <option value="" disabled selected={not has_mapping?(@column_mappings, :category)}>
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
-                  </option>
-                  <option
-                    :for={mapping <- @column_mappings}
-                    value={mapping.column_index}
-                    selected={mapping.target == :category}
-                  >
-                    {mapping.header}
-                  </option>
-                </select>
-              </label>
+              <%= if available_category_cols == [] do %>
+                <p class="text-xs text-warning bg-warning/10 border border-warning/30 rounded-lg px-3 py-2">
+                  {Gettext.gettext(
+                    PhoenixKitWeb.Gettext,
+                    "All columns are already mapped. Free one up by setting it to '— Skip —' in the column mapping section below, or by switching another picker (Category, Manufacturer, or Supplier) out of 'Use a column' mode."
+                  )}
+                </p>
+              <% else %>
+                <label class="select select-sm w-full">
+                  <select name="category_column">
+                    <option value="" disabled selected={not has_mapping?(@column_mappings, :category)}>
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
+                    </option>
+                    <option
+                      :for={mapping <- available_category_cols}
+                      value={mapping.column_index}
+                      selected={mapping.target == :category}
+                    >
+                      {mapping.header}
+                    </option>
+                  </select>
+                </label>
+              <% end %>
               <%!-- Show preview of categories that will be created --%>
               <div :if={has_mapping?(@column_mappings, :category)} class="mt-2">
                 <span class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Categories that will be created:")}</span>
@@ -1285,6 +1763,64 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             primary_language={@primary_language}
           />
         </div>
+
+        <%!-- Manufacturer selector --%>
+        <.party_picker
+          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Set Manufacturer")}
+          form_id="manufacturer-form"
+          on_change="select_import_manufacturer"
+          mode_field="manufacturer_mode"
+          column_field="manufacturer_column"
+          mode={@import_manufacturer_mode}
+          uuid={@import_manufacturer_uuid}
+          options={@manufacturers}
+          column_mappings={@column_mappings}
+          ets_table={@ets_table}
+          target={:manufacturer}
+          none_label={Gettext.gettext(PhoenixKitWeb.Gettext, "No manufacturer — items imported without a maker")}
+          column_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — create or match manufacturers from column values")}
+          create_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new manufacturer — fill in the details below")}
+          column_picker_prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Which column contains the manufacturer names?")}
+          preview_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturers that will be created or matched:")}
+        />
+
+        <.new_party_form
+          :if={@import_manufacturer_mode == :create and @new_manufacturer_changeset}
+          form_id="new-manufacturer-form"
+          form_prefix="manufacturer"
+          on_change="validate_new_manufacturer"
+          changeset={@new_manufacturer_changeset}
+          name_placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Blum")}
+        />
+
+        <%!-- Supplier selector --%>
+        <.party_picker
+          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Link to Supplier")}
+          form_id="supplier-form"
+          on_change="select_import_supplier"
+          mode_field="supplier_mode"
+          column_field="supplier_column"
+          mode={@import_supplier_mode}
+          uuid={@import_supplier_uuid}
+          options={@suppliers}
+          column_mappings={@column_mappings}
+          ets_table={@ets_table}
+          target={:supplier}
+          none_label={Gettext.gettext(PhoenixKitWeb.Gettext, "No supplier — leave manufacturers unlinked")}
+          column_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — link per-row supplier to row's manufacturer")}
+          create_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new supplier — link to all touched manufacturers")}
+          column_picker_prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Which column contains the supplier names?")}
+          preview_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Suppliers that will be created or matched:")}
+        />
+
+        <.new_party_form
+          :if={@import_supplier_mode == :create and @new_supplier_changeset}
+          form_id="new-supplier-form"
+          form_prefix="supplier"
+          on_change="validate_new_supplier"
+          changeset={@new_supplier_changeset}
+          name_placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Acme Distributors")}
+        />
 
         <p class="text-sm text-base-content/60">
           {Gettext.gettext(PhoenixKitWeb.Gettext, "Choose where each column should be imported to.")}
@@ -1370,7 +1906,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             <.icon name="hero-arrow-left" class="w-4 h-4" />
             {Gettext.gettext(PhoenixKitWeb.Gettext, "Back")}
           </button>
-          <button class="btn btn-primary btn-sm" phx-click="continue_to_confirm">
+          <button
+            class="btn btn-primary btn-sm"
+            phx-click="continue_to_confirm"
+            phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Validating...")}
+          >
             {Gettext.gettext(PhoenixKitWeb.Gettext, "Continue to Confirm")}
             <.icon name="hero-arrow-right" class="w-4 h-4" />
           </button>
@@ -1489,7 +2029,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             <.icon name="hero-arrow-left" class="w-4 h-4" />
             {Gettext.gettext(PhoenixKitWeb.Gettext, "Back to Mapping")}
           </button>
-          <button class="btn btn-primary btn-sm" phx-click="execute_import">
+          <button
+            class="btn btn-primary btn-sm"
+            phx-click="execute_import"
+            phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Starting import...")}
+          >
             <.icon name="hero-play" class="w-4 h-4" />
             {Gettext.gettext(PhoenixKitWeb.Gettext, "Import %{count} Items", count: @import_plan.stats.valid)}
           </button>
@@ -1611,6 +2155,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   defp translate_target("Unit of Measure"),
     do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unit of Measure")
 
+  defp translate_target("Manufacturer"),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")
+
+  defp translate_target("Supplier"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Supplier")
+
   defp translate_target("Create Categories"),
     do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Categories")
 
@@ -1621,6 +2170,9 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
   defp translate_error("Invalid price: " <> val),
     do: Gettext.gettext(PhoenixKitWeb.Gettext, "Invalid price: %{value}", value: val)
+
+  defp translate_error("Invalid markup: " <> val),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Invalid markup: %{value}", value: val)
 
   defp translate_error(msg), do: msg
 
@@ -1661,6 +2213,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   defp target_to_string(:markup_percentage), do: "markup_percentage"
   defp target_to_string(:unit), do: "unit"
   defp target_to_string(:category), do: "category"
+  defp target_to_string(:manufacturer), do: "manufacturer"
+  defp target_to_string(:supplier), do: "supplier"
   defp target_to_string({:data, name}), do: "data:#{name}"
 
   defp parse_target("skip"), do: :skip
@@ -1671,11 +2225,36 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   defp parse_target("markup_percentage"), do: :markup_percentage
   defp parse_target("unit"), do: :unit
   defp parse_target("category"), do: :category
+  defp parse_target("manufacturer"), do: :manufacturer
+  defp parse_target("supplier"), do: :supplier
   defp parse_target("data:" <> name), do: {:data, name}
   defp parse_target(_), do: :skip
 
   defp has_mapping?(mappings, target) do
     Enum.any?(mappings, &(&1.target == target))
+  end
+
+  # Columns the picker is allowed to offer in its column dropdown.
+  # We hide columns already mapped to *another* unique target so a
+  # picker selection can't silently steal a column from `:name` /
+  # `:sku` / etc. — losing those mappings would surface as a
+  # "must map at least one column to 'Item Name'" error at the
+  # confirm step with no clue why.
+  #
+  # We always keep:
+  #   - the column already mapped to this picker's target (so it
+  #     stays visible/selectable for re-selection)
+  #   - unmapped columns (`:skip`) — the natural candidates
+  #   - custom-data columns (`{:data, _}`) — non-unique by definition
+  defp available_picker_columns(mappings, picker_target) do
+    Enum.filter(mappings, fn m ->
+      cond do
+        m.target == picker_target -> true
+        m.target == :skip -> true
+        match?({:data, _}, m.target) -> true
+        true -> false
+      end
+    end)
   end
 
   defp error_to_string(:too_large),
@@ -1732,15 +2311,29 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       actor_uuid: extract_actor_uuid(socket),
       resource_type: "catalogue",
       resource_uuid: catalogue && catalogue.uuid,
-      metadata: %{
-        "catalogue_name" => (catalogue && catalogue.name) || "",
-        "items_created" => result[:created] || 0,
-        "categories_created" => result[:categories_created] || 0,
-        "errors" => length(result[:errors] || []),
-        "filename" => socket.assigns[:filename] || ""
-      }
+      metadata: import_log_metadata(socket, catalogue, result)
     }
   end
+
+  defp import_log_metadata(socket, catalogue, result) do
+    %{
+      "catalogue_name" => catalogue_name(catalogue),
+      "filename" => socket.assigns[:filename] || "",
+      "items_created" => count_field(result, :created),
+      "categories_created" => count_field(result, :categories_created),
+      "manufacturers_created" => count_field(result, :manufacturers_created),
+      "suppliers_created" => count_field(result, :suppliers_created),
+      "manufacturer_supplier_links_created" =>
+        count_field(result, :manufacturer_supplier_links_created),
+      "errors" => length(result[:errors] || [])
+    }
+  end
+
+  defp catalogue_name(nil), do: ""
+  defp catalogue_name(%{name: name}) when is_binary(name), do: name
+  defp catalogue_name(_), do: ""
+
+  defp count_field(result, key), do: result[key] || 0
 
   defp extract_actor_uuid(socket) do
     case socket.assigns[:phoenix_kit_current_user] do

--- a/lib/phoenix_kit_catalogue/web/import_live.ex
+++ b/lib/phoenix_kit_catalogue/web/import_live.ex
@@ -199,7 +199,15 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
     # Unique targets: if another column already has this target (except :skip and :data),
     # reset the old column to :skip
-    unique_targets = [:name, :description, :sku, :base_price, :unit, :category]
+    unique_targets = [
+      :name,
+      :description,
+      :sku,
+      :base_price,
+      :markup_percentage,
+      :unit,
+      :category
+    ]
 
     mappings =
       Enum.map(socket.assigns.column_mappings, fn m ->
@@ -530,7 +538,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     end
   end
 
-  @unique_targets [:name, :description, :sku, :base_price, :unit, :category]
+  @unique_targets [:name, :description, :sku, :base_price, :markup_percentage, :unit, :category]
 
   defp update_column_mappings(mappings, changed_idx, new_target) do
     Enum.map(mappings, fn m ->
@@ -1019,6 +1027,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                 <th :if={has_mapping?(@column_mappings, :name)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}</th>
                 <th :if={has_mapping?(@column_mappings, :sku)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Article Code")}</th>
                 <th :if={has_mapping?(@column_mappings, :base_price)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Price")}</th>
+                <th :if={has_mapping?(@column_mappings, :markup_percentage)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Markup %")}</th>
                 <th :if={has_mapping?(@column_mappings, :unit)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}</th>
                 <th :if={has_mapping?(@column_mappings, :category)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}</th>
               </tr>
@@ -1029,6 +1038,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                 <td :if={has_mapping?(@column_mappings, :name)}>{item[:name]}</td>
                 <td :if={has_mapping?(@column_mappings, :sku)}>{item[:sku]}</td>
                 <td :if={has_mapping?(@column_mappings, :base_price)}>{item[:base_price]}</td>
+                <td :if={has_mapping?(@column_mappings, :markup_percentage)}>{item[:markup_percentage]}</td>
                 <td :if={has_mapping?(@column_mappings, :unit)}>{item[:unit]}</td>
                 <td :if={has_mapping?(@column_mappings, :category)}>{item[:_category_name]}</td>
               </tr>
@@ -1226,6 +1236,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   defp target_to_string(:description), do: "description"
   defp target_to_string(:sku), do: "sku"
   defp target_to_string(:base_price), do: "base_price"
+  defp target_to_string(:markup_percentage), do: "markup_percentage"
   defp target_to_string(:unit), do: "unit"
   defp target_to_string(:category), do: "category"
   defp target_to_string({:data, name}), do: "data:#{name}"
@@ -1235,6 +1246,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   defp parse_target("description"), do: :description
   defp parse_target("sku"), do: :sku
   defp parse_target("base_price"), do: :base_price
+  defp parse_target("markup_percentage"), do: :markup_percentage
   defp parse_target("unit"), do: :unit
   defp parse_target("category"), do: :category
   defp parse_target("data:" <> name), do: {:data, name}

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -18,6 +18,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   @preserve_fields %{
     "sku" => :sku,
     "base_price" => :base_price,
+    "markup_percentage" => :markup_percentage,
     "unit" => :unit,
     "status" => :status,
     "category_uuid" => :category_uuid,
@@ -76,6 +77,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       action: action,
       item: item,
       catalogue_uuid: catalogue_uuid,
+      catalogue_markup: catalogue_markup_for(catalogue_uuid),
       changeset: changeset,
       categories: categories,
       manufacturers: Catalogue.list_manufacturers(status: "active"),
@@ -92,6 +94,20 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   # Always assigns `needs_primary_translation` and `item_primary_language`
   # — even when multilang is disabled — so the render path can reference
   # them unconditionally without crashing on a missing key.
+  # Loads just the catalogue's markup so the form can show it as a hint
+  # next to the per-item override field. Returns nil if the item isn't
+  # scoped to a catalogue yet (shouldn't happen in practice, since
+  # create/edit always run inside a catalogue), in which case the hint
+  # is simply omitted.
+  defp catalogue_markup_for(nil), do: nil
+
+  defp catalogue_markup_for(catalogue_uuid) do
+    case Catalogue.get_catalogue(catalogue_uuid) do
+      %{markup_percentage: markup} -> markup
+      _ -> nil
+    end
+  end
+
   defp adjust_multilang_for_item(socket, item) do
     if socket.assigns.multilang_enabled do
       check_item_primary_language(socket, item)
@@ -374,6 +390,28 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                       <option value="running_meter" selected={Ecto.Changeset.get_field(@changeset, :unit) == "running_meter"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Running meter")}</option>
                     </select>
                   </label>
+                </div>
+                <div class="form-control">
+                  <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Override")}</span>
+                  <div class="relative">
+                    <input
+                      type="number"
+                      name="item[markup_percentage]"
+                      value={Ecto.Changeset.get_field(@changeset, :markup_percentage)}
+                      class="input input-bordered w-full transition-colors focus:input-primary pr-8"
+                      step="0.01"
+                      min="0"
+                      placeholder={
+                        if @catalogue_markup,
+                          do: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{markup}%", markup: Decimal.to_string(@catalogue_markup, :normal)),
+                          else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue markup")
+                      }
+                    />
+                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/40 text-sm">%</span>
+                  </div>
+                  <span class="label-text-alt text-base-content/50 mt-1">
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Leave blank to inherit the catalogue's markup. Set (including 0) to override just this item.")}
+                  </span>
                 </div>
               </div>
 

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -1003,6 +1003,59 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("10"))
     end
 
+    test "reports both catalogue_markup and item_markup, with item override winning" do
+      cat = create_catalogue(%{name: "Cat 20%", markup_percentage: 20})
+      category = create_category(cat)
+
+      item =
+        create_item(%{
+          name: "Override Panel",
+          base_price: "100.00",
+          markup_percentage: "50",
+          category_uuid: category.uuid
+        })
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert Decimal.equal?(pricing.catalogue_markup, Decimal.new("20"))
+      assert Decimal.equal?(pricing.item_markup, Decimal.new("50"))
+      # Effective markup is the item's override
+      assert Decimal.equal?(pricing.markup_percentage, Decimal.new("50"))
+      assert Decimal.equal?(pricing.price, Decimal.new("150.00"))
+    end
+
+    test "item_markup is nil when there is no override" do
+      cat = create_catalogue(%{name: "Cat 10%", markup_percentage: 10})
+      category = create_category(cat)
+      item = create_item(%{name: "Inheritor", base_price: "100.00", category_uuid: category.uuid})
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert is_nil(pricing.item_markup)
+      assert Decimal.equal?(pricing.catalogue_markup, Decimal.new("10"))
+      assert Decimal.equal?(pricing.markup_percentage, Decimal.new("10"))
+    end
+
+    test "item_markup of 0 overrides a non-zero catalogue markup" do
+      cat = create_catalogue(%{name: "Cat 25%", markup_percentage: 25})
+      category = create_category(cat)
+
+      item =
+        create_item(%{
+          name: "No Markup For Me",
+          base_price: "100.00",
+          markup_percentage: "0",
+          category_uuid: category.uuid
+        })
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert Decimal.equal?(pricing.catalogue_markup, Decimal.new("25"))
+      assert Decimal.equal?(pricing.item_markup, Decimal.new("0"))
+      assert Decimal.equal?(pricing.markup_percentage, Decimal.new("0"))
+      assert Decimal.equal?(pricing.price, Decimal.new("100.00"))
+    end
+
     test "falls back to 0% markup when the catalogue association is unloaded and preload fails" do
       # Simulate "catalogue couldn't be loaded" by constructing a detached
       # struct: no catalogue preload, no uuid that the DB knows about.
@@ -1142,6 +1195,103 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       create_item(%{name: "Birch Veneer", category_uuid: category.uuid})
 
       assert Catalogue.search_items_in_catalogue(cat.uuid, "oak") == []
+    end
+
+    test "respects :limit and :offset for paging" do
+      cat = create_catalogue()
+      category = create_category(cat)
+
+      for i <- 1..5 do
+        create_item(%{name: "Oak Panel #{i}", category_uuid: category.uuid})
+      end
+
+      page_1 = Catalogue.search_items_in_catalogue(cat.uuid, "oak", limit: 2, offset: 0)
+      page_2 = Catalogue.search_items_in_catalogue(cat.uuid, "oak", limit: 2, offset: 2)
+      page_3 = Catalogue.search_items_in_catalogue(cat.uuid, "oak", limit: 2, offset: 4)
+
+      assert length(page_1) == 2
+      assert length(page_2) == 2
+      assert length(page_3) == 1
+
+      # Pages must be disjoint — stable uuid tie-breaker guarantees this
+      all_uuids =
+        (page_1 ++ page_2 ++ page_3) |> Enum.map(& &1.uuid)
+
+      assert length(Enum.uniq(all_uuids)) == 5
+    end
+
+    test "ordering is stable across pages when names collide" do
+      cat = create_catalogue()
+      category = create_category(cat)
+
+      for _ <- 1..6, do: create_item(%{name: "Twin", category_uuid: category.uuid})
+
+      # Fetch in two different page shapes, compare uuid order
+      one_shot = Catalogue.search_items_in_catalogue(cat.uuid, "twin", limit: 10)
+
+      paged =
+        Catalogue.search_items_in_catalogue(cat.uuid, "twin", limit: 3, offset: 0) ++
+          Catalogue.search_items_in_catalogue(cat.uuid, "twin", limit: 3, offset: 3)
+
+      assert Enum.map(one_shot, & &1.uuid) == Enum.map(paged, & &1.uuid)
+    end
+  end
+
+  describe "count_search_items_in_catalogue/2" do
+    test "returns the total matching count regardless of limit" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      for i <- 1..7, do: create_item(%{name: "Oak #{i}", category_uuid: category.uuid})
+
+      assert Catalogue.count_search_items_in_catalogue(cat.uuid, "oak") == 7
+    end
+
+    test "excludes deleted items and items in deleted categories" do
+      cat = create_catalogue()
+      active_cat = create_category(cat, %{name: "Active"})
+      trashed_cat = create_category(cat, %{name: "Trashed"})
+
+      create_item(%{name: "Oak visible", category_uuid: active_cat.uuid})
+      trashed_item = create_item(%{name: "Oak trashed", category_uuid: active_cat.uuid})
+
+      _hidden_cat_item =
+        create_item(%{name: "Oak in deleted cat", category_uuid: trashed_cat.uuid})
+
+      Catalogue.trash_item(trashed_item)
+      Catalogue.trash_category(trashed_cat)
+
+      assert Catalogue.count_search_items_in_catalogue(cat.uuid, "oak") == 1
+    end
+
+    test "returns 0 when no matches" do
+      cat = create_catalogue()
+      assert Catalogue.count_search_items_in_catalogue(cat.uuid, "nothing") == 0
+    end
+  end
+
+  describe "count_search_items/1" do
+    test "counts across all non-deleted catalogues" do
+      cat1 = create_catalogue(%{name: "K"})
+      cat2 = create_catalogue(%{name: "B"})
+      c1 = create_category(cat1)
+      c2 = create_category(cat2)
+      create_item(%{name: "Oak A", category_uuid: c1.uuid})
+      create_item(%{name: "Oak B", category_uuid: c2.uuid})
+
+      assert Catalogue.count_search_items("oak") == 2
+    end
+  end
+
+  describe "count_search_items_in_category/2" do
+    test "counts only items in the given category" do
+      cat = create_catalogue()
+      c1 = create_category(cat, %{name: "A"})
+      c2 = create_category(cat, %{name: "B"})
+      create_item(%{name: "Oak A", category_uuid: c1.uuid})
+      create_item(%{name: "Oak B", category_uuid: c1.uuid})
+      create_item(%{name: "Oak C", category_uuid: c2.uuid})
+
+      assert Catalogue.count_search_items_in_category(c1.uuid, "oak") == 2
     end
   end
 

--- a/test/import/executor_test.exs
+++ b/test/import/executor_test.exs
@@ -300,6 +300,154 @@ defmodule PhoenixKitCatalogue.Import.ExecutorTest do
       assert item.data["color"] == "Natural Oak"
       assert item.data["original_unit"] == "TK"
     end
+
+    # ── Manufacturer / Supplier ─────────────────────────────────
+
+    test "column mode: gets-or-creates manufacturers and assigns per item" do
+      cat = create_catalogue()
+      {:ok, _existing} = Catalogue.create_manufacturer(%{name: "Blum"})
+
+      plan = %{
+        items: [
+          %{name: "Hinge", _manufacturer_name: "Blum"},
+          %{name: "Drawer Slide", _manufacturer_name: "Hettich"},
+          %{name: "Door Handle", _manufacturer_name: "Blum"}
+        ],
+        categories_to_create: [],
+        manufacturers_to_create: ["Blum", "Hettich"],
+        suppliers_to_create: [],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 3, valid: 3, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self())
+
+      # Only Hettich is new — Blum already existed.
+      assert result.created == 3
+      assert result.manufacturers_created == 1
+
+      items = Catalogue.list_items() |> PhoenixKit.RepoHelper.repo().preload(:manufacturer)
+      blum = Enum.find(Catalogue.list_manufacturers(), &(&1.name == "Blum"))
+      hettich = Enum.find(Catalogue.list_manufacturers(), &(&1.name == "Hettich"))
+
+      assert Enum.find(items, &(&1.name == "Hinge")).manufacturer_uuid == blum.uuid
+      assert Enum.find(items, &(&1.name == "Drawer Slide")).manufacturer_uuid == hettich.uuid
+      assert Enum.find(items, &(&1.name == "Door Handle")).manufacturer_uuid == blum.uuid
+    end
+
+    test "fixed manufacturer_uuid: pins all items, skips column lookup" do
+      cat = create_catalogue()
+      {:ok, mfr} = Catalogue.create_manufacturer(%{name: "Pinned"})
+
+      plan = %{
+        items: [
+          # Even with placeholder set, fixed uuid wins.
+          %{name: "A", _manufacturer_name: "ignored"},
+          %{name: "B"}
+        ],
+        categories_to_create: [],
+        manufacturers_to_create: [],
+        suppliers_to_create: [],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 2, valid: 2, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self(), manufacturer_uuid: mfr.uuid)
+
+      assert result.created == 2
+      assert result.manufacturers_created == 0
+      items = Catalogue.list_items()
+      assert Enum.all?(items, &(&1.manufacturer_uuid == mfr.uuid))
+    end
+
+    test "column mode: per-row supplier links to per-row manufacturer (M:N)" do
+      cat = create_catalogue()
+
+      plan = %{
+        items: [
+          %{name: "A", _manufacturer_name: "Blum", _supplier_name: "Acme"},
+          %{name: "B", _manufacturer_name: "Hettich", _supplier_name: "Globex"},
+          # Same pair as row 1 → no duplicate link (idempotent).
+          %{name: "C", _manufacturer_name: "Blum", _supplier_name: "Acme"}
+        ],
+        categories_to_create: [],
+        manufacturers_to_create: ["Blum", "Hettich"],
+        suppliers_to_create: ["Acme", "Globex"],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 3, valid: 3, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self())
+
+      assert result.created == 3
+      assert result.manufacturers_created == 2
+      assert result.suppliers_created == 2
+      # 2 unique (mfr, sup) pairs.
+      assert result.manufacturer_supplier_links_created == 2
+
+      blum = Enum.find(Catalogue.list_manufacturers(), &(&1.name == "Blum"))
+      acme = Enum.find(Catalogue.list_suppliers(), &(&1.name == "Acme"))
+
+      assert acme.uuid in (Catalogue.list_suppliers_for_manufacturer(blum.uuid)
+                           |> Enum.map(& &1.uuid))
+    end
+
+    test "fixed supplier_uuid: links the supplier to every manufacturer the import touched" do
+      cat = create_catalogue()
+      {:ok, sup} = Catalogue.create_supplier(%{name: "Single Source"})
+
+      plan = %{
+        items: [
+          %{name: "A", _manufacturer_name: "Blum"},
+          %{name: "B", _manufacturer_name: "Hettich"},
+          %{name: "C", _manufacturer_name: "Blum"}
+        ],
+        categories_to_create: [],
+        manufacturers_to_create: ["Blum", "Hettich"],
+        suppliers_to_create: [],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 3, valid: 3, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self(), supplier_uuid: sup.uuid)
+
+      # 2 distinct manufacturers touched → 2 links to the fixed supplier.
+      assert result.manufacturer_supplier_links_created == 2
+
+      mfrs = Catalogue.list_manufacturers_for_supplier(sup.uuid)
+      assert length(mfrs) == 2
+    end
+
+    test "rows with no manufacturer don't trigger a M:N link even if supplier is set" do
+      cat = create_catalogue()
+      {:ok, sup} = Catalogue.create_supplier(%{name: "Single Source"})
+
+      plan = %{
+        items: [
+          # No manufacturer for this row, but a supplier is named.
+          %{name: "Orphan", _supplier_name: "Single Source"}
+        ],
+        categories_to_create: [],
+        manufacturers_to_create: [],
+        suppliers_to_create: ["Single Source"],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 1, valid: 1, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self())
+
+      assert result.created == 1
+      # No manufacturer ⇒ no link to make.
+      assert result.manufacturer_supplier_links_created == 0
+      # ...and the existing supplier was matched by name (not duplicated).
+      assert result.suppliers_created == 0
+      assert Catalogue.list_manufacturers_for_supplier(sup.uuid) == []
+    end
   end
 
   defp create_category(catalogue, attrs \\ %{}) do

--- a/test/import/executor_test.exs
+++ b/test/import/executor_test.exs
@@ -114,6 +114,150 @@ defmodule PhoenixKitCatalogue.Import.ExecutorTest do
       assert item.data["et"]["_name"] == "Estonian Item"
     end
 
+    test "applies language to created categories the same way as items" do
+      cat = create_catalogue()
+
+      plan = %{
+        items: [%{name: "Konks", _category_name: "Konksud"}],
+        categories_to_create: ["Konksud"],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 1, valid: 1, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self(), language: "et")
+      assert result.created == 1
+      assert result.categories_created == 1
+
+      [category] = Catalogue.list_categories_for_catalogue(cat.uuid)
+      # Bare `name` field still holds the imported string for fallback.
+      assert category.name == "Konksud"
+      # ...AND multilang data is set so the category renders correctly
+      # in mixed-language UIs.
+      assert category.data["_primary_language"] == "et"
+      assert category.data["et"]["_name"] == "Konksud"
+    end
+
+    test "matches existing category by translated name when importing in same language" do
+      cat = create_catalogue()
+
+      # Pre-existing category with English primary AND an Estonian translation.
+      {:ok, _existing} =
+        Catalogue.create_category(%{
+          name: "Hooks",
+          catalogue_uuid: cat.uuid,
+          data: %{
+            "_primary_language" => "en",
+            "en" => %{"_name" => "Hooks"},
+            "et" => %{"_name" => "Konksud"}
+          }
+        })
+
+      plan = %{
+        items: [%{name: "Konks", _category_name: "Konksud"}],
+        categories_to_create: ["Konksud"],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 1, valid: 1, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self(), language: "et")
+
+      # Reused the existing category, didn't create a new one.
+      assert result.created == 1
+      assert result.categories_created == 0
+
+      categories = Catalogue.list_categories_for_catalogue(cat.uuid)
+      assert length(categories) == 1
+      [category] = categories
+      assert category.name == "Hooks"
+    end
+
+    test "without :match_categories_across_languages, only the current language is matched" do
+      cat = create_catalogue()
+
+      # Category whose ONLY translation is in `de` — bare name is also "Hooks".
+      {:ok, _existing} =
+        Catalogue.create_category(%{
+          name: "Hooks",
+          catalogue_uuid: cat.uuid,
+          data: %{"_primary_language" => "en", "de" => %{"_name" => "Haken"}}
+        })
+
+      plan = %{
+        items: [%{name: "Konks", _category_name: "Haken"}],
+        categories_to_create: ["Haken"],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 1, valid: 1, invalid: 0}
+      }
+
+      # Importing in et — neither the et translation (none) nor bare name
+      # ("Hooks") matches "Haken", and we're not allowed to peek into
+      # `de`, so a NEW category gets created.
+      result = Executor.execute(plan, cat.uuid, self(), language: "et")
+
+      assert result.categories_created == 1
+      assert length(Catalogue.list_categories_for_catalogue(cat.uuid)) == 2
+    end
+
+    test "with :match_categories_across_languages, matches against any language's translation" do
+      cat = create_catalogue()
+
+      {:ok, _existing} =
+        Catalogue.create_category(%{
+          name: "Hooks",
+          catalogue_uuid: cat.uuid,
+          data: %{"_primary_language" => "en", "de" => %{"_name" => "Haken"}}
+        })
+
+      plan = %{
+        items: [%{name: "Konks", _category_name: "Haken"}],
+        categories_to_create: ["Haken"],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 1, valid: 1, invalid: 0}
+      }
+
+      # Same setup as above, but with the cross-language flag on we
+      # match the German translation and reuse the existing category.
+      result =
+        Executor.execute(plan, cat.uuid, self(),
+          language: "et",
+          match_categories_across_languages: true
+        )
+
+      assert result.categories_created == 0
+      assert length(Catalogue.list_categories_for_catalogue(cat.uuid)) == 1
+    end
+
+    test "matches existing category by bare name as fallback when no translation set" do
+      cat = create_catalogue()
+
+      # Pre-existing English-primary category with NO Estonian translation yet.
+      {:ok, _existing} =
+        Catalogue.create_category(%{
+          name: "Hooks",
+          catalogue_uuid: cat.uuid,
+          data: %{"_primary_language" => "en", "en" => %{"_name" => "Hooks"}}
+        })
+
+      plan = %{
+        items: [%{name: "Hook A", _category_name: "Hooks"}],
+        categories_to_create: ["Hooks"],
+        custom_fields: [],
+        errors: [],
+        stats: %{total: 1, valid: 1, invalid: 0}
+      }
+
+      result = Executor.execute(plan, cat.uuid, self(), language: "et")
+
+      # Matched by bare `name` since there's no et translation to match against.
+      assert result.created == 1
+      assert result.categories_created == 0
+      assert length(Catalogue.list_categories_for_catalogue(cat.uuid)) == 1
+    end
+
     test "reuses existing categories instead of creating duplicates" do
       cat = create_catalogue()
       {:ok, _existing_cat} = Catalogue.create_category(%{name: "Hooks", catalogue_uuid: cat.uuid})

--- a/test/import/mapper_test.exs
+++ b/test/import/mapper_test.exs
@@ -44,6 +44,24 @@ defmodule PhoenixKitCatalogue.Import.MapperTest do
       assert markup.target == :markup_percentage
     end
 
+    test "detects manufacturer columns by common synonyms" do
+      headers = ["Name", "Manufacturer", "Tootja", "Hersteller"]
+      mappings = Mapper.auto_detect_mappings(headers)
+
+      # First match wins (auto_detect_mappings doesn't double-assign)
+      manufacturer_targets = Enum.filter(mappings, &(&1.target == :manufacturer))
+      assert length(manufacturer_targets) == 1
+      assert hd(manufacturer_targets).header == "Manufacturer"
+    end
+
+    test "detects supplier columns by common synonyms" do
+      headers = ["Name", "Supplier"]
+      mappings = Mapper.auto_detect_mappings(headers)
+
+      supplier = Enum.find(mappings, &(&1.header == "Supplier"))
+      assert supplier.target == :supplier
+    end
+
     test "skips unknown headers" do
       headers = ["Random Column", "Another One"]
       mappings = Mapper.auto_detect_mappings(headers)
@@ -265,6 +283,48 @@ defmodule PhoenixKitCatalogue.Import.MapperTest do
       plan = Mapper.build_import_plan(mappings, [["Item", "abc"]])
       assert plan.stats.invalid == 1
       assert [{1, "Invalid markup: abc"}] = plan.errors
+    end
+
+    test "extracts unique manufacturer names" do
+      mappings = [
+        %{column_index: 0, header: "Name", target: :name},
+        %{column_index: 1, header: "Maker", target: :manufacturer}
+      ]
+
+      rows = [
+        ["A", "Blum"],
+        ["B", "Hettich"],
+        ["C", "Blum"],
+        # Trimmed and de-duplicated
+        ["D", "  Blum  "]
+      ]
+
+      plan = Mapper.build_import_plan(mappings, rows)
+      assert plan.manufacturers_to_create == ["Blum", "Hettich"]
+      # The per-item placeholder is set so the executor can resolve later
+      [item | _] = plan.items
+      assert item[:_manufacturer_name] == "Blum"
+    end
+
+    test "extracts unique supplier names" do
+      mappings = [
+        %{column_index: 0, header: "Name", target: :name},
+        %{column_index: 1, header: "Source", target: :supplier}
+      ]
+
+      plan =
+        Mapper.build_import_plan(mappings, [
+          ["A", "Acme"],
+          ["B", "Globex"],
+          ["C", ""]
+        ])
+
+      assert plan.suppliers_to_create == ["Acme", "Globex"]
+
+      [a, _b, c] = plan.items
+      assert a[:_supplier_name] == "Acme"
+      # Blank cells leave no placeholder so the row gets no supplier link.
+      refute Map.has_key?(c, :_supplier_name)
     end
   end
 

--- a/test/import/mapper_test.exs
+++ b/test/import/mapper_test.exs
@@ -36,6 +36,14 @@ defmodule PhoenixKitCatalogue.Import.MapperTest do
       assert :base_price in targets
     end
 
+    test "detects markup columns by common synonyms" do
+      headers = ["Name", "SKU", "Markup", "Price"]
+      mappings = Mapper.auto_detect_mappings(headers)
+
+      markup = Enum.find(mappings, &(&1.header == "Markup"))
+      assert markup.target == :markup_percentage
+    end
+
     test "skips unknown headers" do
       headers = ["Random Column", "Another One"]
       mappings = Mapper.auto_detect_mappings(headers)
@@ -214,6 +222,50 @@ defmodule PhoenixKitCatalogue.Import.MapperTest do
       item = List.first(plan.items)
       refute Map.has_key?(item, :internal)
     end
+
+    test "parses markup_percentage when mapped" do
+      mappings = [
+        %{column_index: 0, header: "Name", target: :name},
+        %{column_index: 1, header: "Markup", target: :markup_percentage}
+      ]
+
+      rows = [
+        ["Override Item", "50"],
+        ["Zero Override", "0"],
+        ["Inherit", ""]
+      ]
+
+      plan = Mapper.build_import_plan(mappings, rows)
+      assert plan.stats.valid == 3
+
+      [override, zero, inherit] = plan.items
+      assert Decimal.equal?(override.markup_percentage, Decimal.new("50"))
+      assert Decimal.equal?(zero.markup_percentage, Decimal.new("0"))
+      # Blank cell → no override key set, so the changeset will leave NULL
+      refute Map.has_key?(inherit, :markup_percentage)
+    end
+
+    test "parses markup with comma-decimal notation" do
+      mappings = [
+        %{column_index: 0, header: "Name", target: :name},
+        %{column_index: 1, header: "Markup", target: :markup_percentage}
+      ]
+
+      plan = Mapper.build_import_plan(mappings, [["Item", "12,5"]])
+      assert plan.stats.valid == 1
+      assert Decimal.equal?(hd(plan.items).markup_percentage, Decimal.new("12.5"))
+    end
+
+    test "rejects unparseable markup values" do
+      mappings = [
+        %{column_index: 0, header: "Name", target: :name},
+        %{column_index: 1, header: "Markup", target: :markup_percentage}
+      ]
+
+      plan = Mapper.build_import_plan(mappings, [["Item", "abc"]])
+      assert plan.stats.invalid == 1
+      assert [{1, "Invalid markup: abc"}] = plan.errors
+    end
   end
 
   describe "unique_column_values/2" do
@@ -237,8 +289,67 @@ defmodule PhoenixKitCatalogue.Import.MapperTest do
       assert :name in target_atoms
       assert :sku in target_atoms
       assert :base_price in target_atoms
+      assert :markup_percentage in target_atoms
       assert :unit in target_atoms
       assert :category in target_atoms
+    end
+  end
+
+  describe "item_matches_existing?/3 (markup)" do
+    test "items differ when one has an override and the other inherits" do
+      import_item = %{
+        name: "X",
+        base_price: Decimal.new("100"),
+        markup_percentage: Decimal.new("50")
+      }
+
+      existing = %{
+        name: "X",
+        sku: nil,
+        base_price: Decimal.new("100"),
+        markup_percentage: nil,
+        unit: "piece",
+        category_uuid: nil,
+        data: %{}
+      }
+
+      refute Mapper.item_matches_existing?(import_item, existing)
+    end
+
+    test "items match when both inherit" do
+      import_item = %{name: "X", base_price: Decimal.new("100")}
+
+      existing = %{
+        name: "X",
+        sku: nil,
+        base_price: Decimal.new("100"),
+        markup_percentage: nil,
+        unit: "piece",
+        category_uuid: nil,
+        data: %{}
+      }
+
+      assert Mapper.item_matches_existing?(import_item, existing)
+    end
+
+    test "items match when both override to the same value" do
+      import_item = %{
+        name: "X",
+        base_price: Decimal.new("100"),
+        markup_percentage: Decimal.new("25")
+      }
+
+      existing = %{
+        name: "X",
+        sku: nil,
+        base_price: Decimal.new("100"),
+        markup_percentage: Decimal.new("25"),
+        unit: "piece",
+        category_uuid: nil,
+        data: %{}
+      }
+
+      assert Mapper.item_matches_existing?(import_item, existing)
     end
   end
 end

--- a/test/import/parser_test.exs
+++ b/test/import/parser_test.exs
@@ -66,6 +66,48 @@ defmodule PhoenixKitCatalogue.Import.ParserTest do
     test "rejects unsupported format" do
       assert {:error, _msg} = Parser.parse("data", "test.pdf")
     end
+
+    test "strips a fully empty leading column" do
+      # Common spreadsheet quirk: a leading blank column survives export
+      # as empty cells in every row. Without stripping, the importer
+      # would render a phantom unnamed column in the preview and a
+      # phantom mapping card.
+      csv = ",Name,SKU\n,Oak,OAK-1\n,Birch,BV-1\n"
+      assert {:ok, result} = Parser.parse(csv, "test.csv")
+      assert result.headers == ["Name", "SKU"]
+      assert List.first(result.rows) == ["Oak", "OAK-1"]
+    end
+
+    test "strips a fully empty middle column" do
+      csv = "Name,,SKU\nOak,,OAK-1\nBirch,,BV-1\n"
+      assert {:ok, result} = Parser.parse(csv, "test.csv")
+      assert result.headers == ["Name", "SKU"]
+      assert List.first(result.rows) == ["Oak", "OAK-1"]
+    end
+
+    test "strips a fully empty trailing column" do
+      csv = "Name,SKU,\nOak,OAK-1,\nBirch,BV-1,\n"
+      assert {:ok, result} = Parser.parse(csv, "test.csv")
+      assert result.headers == ["Name", "SKU"]
+    end
+
+    test "keeps a column with a header but all-empty data" do
+      # A real header (e.g., "Notes") with no content yet is still a
+      # legitimate column the user might map.
+      csv = "Name,Notes\nOak,\nBirch,\n"
+      assert {:ok, result} = Parser.parse(csv, "test.csv")
+      assert result.headers == ["Name", "Notes"]
+      assert List.first(result.rows) == ["Oak", ""]
+    end
+
+    test "keeps a column with empty header but data present" do
+      # Empty-header but data-bearing columns are malformed but not
+      # noise; we keep them so the user can rename or skip in the UI.
+      csv = "Name,\nOak,extra\nBirch,more\n"
+      assert {:ok, result} = Parser.parse(csv, "test.csv")
+      assert result.headers == ["Name", ""]
+      assert List.first(result.rows) == ["Oak", "extra"]
+    end
   end
 
   describe "parse/3 with XLSX" do

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -296,6 +296,53 @@ defmodule PhoenixKitCatalogue.SchemasTest do
 
       assert cs.valid?
     end
+
+    test "accepts nil markup_percentage (means inherit from catalogue)" do
+      cs =
+        Item.changeset(%Item{}, %{
+          name: "x",
+          catalogue_uuid: @valid_catalogue_uuid,
+          markup_percentage: nil
+        })
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :markup_percentage) == nil
+    end
+
+    test "accepts empty-string markup_percentage from form params (normalized to nil)" do
+      cs =
+        Item.changeset(%Item{}, %{
+          "name" => "x",
+          "catalogue_uuid" => @valid_catalogue_uuid,
+          "markup_percentage" => ""
+        })
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :markup_percentage) == nil
+    end
+
+    test "accepts zero markup_percentage (explicit override to sell at base)" do
+      cs =
+        Item.changeset(%Item{}, %{
+          name: "x",
+          catalogue_uuid: @valid_catalogue_uuid,
+          markup_percentage: 0
+        })
+
+      assert cs.valid?
+    end
+
+    test "rejects negative markup_percentage" do
+      cs =
+        Item.changeset(%Item{}, %{
+          name: "x",
+          catalogue_uuid: @valid_catalogue_uuid,
+          markup_percentage: -5
+        })
+
+      refute cs.valid?
+      assert errors_on(cs)[:markup_percentage]
+    end
   end
 
   describe "Item.sale_price/2" do
@@ -321,9 +368,53 @@ defmodule PhoenixKitCatalogue.SchemasTest do
       assert Decimal.equal?(result, Decimal.new("38.33"))
     end
 
-    test "handles zero markup" do
+    test "handles zero catalogue markup" do
       item = %Item{base_price: Decimal.new("50")}
       assert Decimal.equal?(Item.sale_price(item, Decimal.new("0")), Decimal.new("50"))
+    end
+
+    test "item markup_percentage overrides catalogue markup" do
+      item = %Item{base_price: Decimal.new("100"), markup_percentage: Decimal.new("50")}
+      # Catalogue says 20, but item overrides to 50 → 100 * 1.50
+      assert Decimal.equal?(Item.sale_price(item, Decimal.new("20")), Decimal.new("150.00"))
+    end
+
+    test "item markup of 0 overrides a non-zero catalogue markup" do
+      # "0 means sell at base price, even if the catalogue has a markup"
+      item = %Item{base_price: Decimal.new("100"), markup_percentage: Decimal.new("0")}
+      assert Decimal.equal?(Item.sale_price(item, Decimal.new("20")), Decimal.new("100"))
+    end
+
+    test "item falls back to catalogue markup when override is nil" do
+      item = %Item{base_price: Decimal.new("100"), markup_percentage: nil}
+      assert Decimal.equal?(Item.sale_price(item, Decimal.new("25")), Decimal.new("125.00"))
+    end
+
+    test "both nil → base price unchanged" do
+      item = %Item{base_price: Decimal.new("77"), markup_percentage: nil}
+      assert Decimal.equal?(Item.sale_price(item, nil), Decimal.new("77"))
+    end
+  end
+
+  describe "Item.effective_markup/2" do
+    test "returns the item's override when set" do
+      item = %Item{markup_percentage: Decimal.new("50")}
+      assert Decimal.equal?(Item.effective_markup(item, Decimal.new("20")), Decimal.new("50"))
+    end
+
+    test "returns the item's override even when it's zero" do
+      item = %Item{markup_percentage: Decimal.new("0")}
+      assert Decimal.equal?(Item.effective_markup(item, Decimal.new("20")), Decimal.new("0"))
+    end
+
+    test "falls back to catalogue when item override is nil" do
+      item = %Item{markup_percentage: nil}
+      assert Decimal.equal?(Item.effective_markup(item, Decimal.new("20")), Decimal.new("20"))
+    end
+
+    test "returns nil when both are nil" do
+      item = %Item{markup_percentage: nil}
+      assert Item.effective_markup(item, nil) == nil
     end
   end
 

--- a/test/support/postgres/migrations/20260415011000_add_item_markup_override.exs
+++ b/test/support/postgres/migrations/20260415011000_add_item_markup_override.exs
@@ -1,0 +1,22 @@
+defmodule PhoenixKitCatalogue.Test.Repo.Migrations.AddItemMarkupOverride do
+  @moduledoc """
+  Mirrors core PhoenixKit's V97 migration for the catalogue module's
+  local test DB: adds a nullable `markup_percentage DECIMAL(7, 2)` column
+  to `phoenix_kit_cat_items`. `NULL` = inherit the catalogue's markup,
+  any value (including `0`) overrides it.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:phoenix_kit_cat_items) do
+      add_if_not_exists(:markup_percentage, :decimal, precision: 7, scale: 2)
+    end
+  end
+
+  def down do
+    alter table(:phoenix_kit_cat_items) do
+      remove_if_exists(:markup_percentage, :decimal)
+    end
+  end
+end

--- a/test/web/catalogue_detail_live_test.exs
+++ b/test/web/catalogue_detail_live_test.exs
@@ -348,7 +348,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
 
       {:ok, view, _html} = live(conn, url(catalogue.uuid))
 
-      html_after = render_change(view, "search", %{"query" => "oak"})
+      render_change(view, "search", %{"query" => "oak"})
+      # Search runs via start_async — wait for handle_async to land before asserting.
+      html_after = render_async(view)
 
       # Search results visible
       assert html_after =~ "Oak panel"
@@ -363,7 +365,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
 
       {:ok, view, _html} = live(conn, url(catalogue.uuid))
 
-      _after_search = render_change(view, "search", %{"query" => "anything"})
+      render_change(view, "search", %{"query" => "anything"})
+      _after_search = render_async(view)
       html_after = render_change(view, "search", %{"query" => ""})
 
       # Back to the normal view
@@ -376,10 +379,51 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       fixture_item(%{name: "Item", category_uuid: category.uuid})
 
       {:ok, view, _html} = live(conn, url(catalogue.uuid))
-      _ = render_change(view, "search", %{"query" => "nothing matches"})
+      render_change(view, "search", %{"query" => "nothing matches"})
+      _ = render_async(view)
       html_after = render_click(view, "clear_search", %{})
 
       assert html_after =~ "Item"
+    end
+
+    test "shows a loading indicator for the first search before results land", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      fixture_item(%{name: "Oak panel", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, url(catalogue.uuid))
+      html_pending = render_change(view, "search", %{"query" => "oak"})
+
+      # While the async task is still running, the user sees a "Searching"
+      # indicator — not stale data or silence.
+      assert html_pending =~ "Searching for"
+      assert html_pending =~ "loading-spinner"
+
+      html_after = render_async(view)
+
+      # Once the async lands, the spinner is gone and results are visible.
+      refute html_after =~ "Searching for"
+      assert html_after =~ "Oak panel"
+    end
+
+    test "dims previous results while a newer query is loading", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      fixture_item(%{name: "Oak panel", category_uuid: category.uuid})
+      fixture_item(%{name: "Pine board", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, url(catalogue.uuid))
+
+      # First search settles.
+      render_change(view, "search", %{"query" => "oak"})
+      _ = render_async(view)
+
+      # Second search fires — while pending, prior "oak" results are dimmed.
+      html_pending = render_change(view, "search", %{"query" => "pine"})
+
+      assert html_pending =~ "opacity-50"
+      # Spinner visible next to the summary
+      assert html_pending =~ "loading-spinner"
     end
   end
 end

--- a/test/web/catalogues_live_test.exs
+++ b/test/web/catalogues_live_test.exs
@@ -131,7 +131,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLiveTest do
       fixture_item(%{name: "Pine Board", category_uuid: category.uuid})
 
       {:ok, view, _html} = live(conn, @base)
-      html = render_change(view, "search", %{"query" => "oak"})
+      render_change(view, "search", %{"query" => "oak"})
+      # Search runs via start_async — wait for handle_async to land before asserting.
+      html = render_async(view)
 
       assert html =~ "Oak Panel"
       refute html =~ "Pine Board"
@@ -141,7 +143,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLiveTest do
       fixture_catalogue(%{name: "Back to normal"})
 
       {:ok, view, _html} = live(conn, @base)
-      _ = render_change(view, "search", %{"query" => "zzz_no_match"})
+      render_change(view, "search", %{"query" => "zzz_no_match"})
+      _ = render_async(view)
       html = render_click(view, "clear_search", %{})
 
       assert html =~ "Back to normal"

--- a/test/web/components_test.exs
+++ b/test/web/components_test.exs
@@ -85,6 +85,31 @@ defmodule PhoenixKitCatalogue.Web.ComponentsTest do
       html = render_component(&search_results_summary/1, count: 0, query: "nothing")
       assert html =~ "0" or html =~ "nothing"
     end
+
+    test "shows \"X of Y\" when loaded is less than count" do
+      html =
+        render_component(&search_results_summary/1, count: 237, query: "oak", loaded: 100)
+
+      assert html =~ "100"
+      assert html =~ "237"
+      assert html =~ "oak"
+    end
+
+    test "falls back to plain count when loaded equals count" do
+      html =
+        render_component(&search_results_summary/1, count: 5, query: "oak", loaded: 5)
+
+      assert html =~ "5"
+      refute html =~ "of"
+    end
+
+    test "falls back to plain count when loaded is nil" do
+      html =
+        render_component(&search_results_summary/1, count: 5, query: "oak", loaded: nil)
+
+      assert html =~ "5"
+      refute html =~ "of"
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

  Three coherent feature additions to the catalogue module since the v0.1.8 release:

  1. **Paged search with infinite scroll + per-item markup override**
     ([77f9c40](../commit/77f9c40))
  2. **Import wizard improvements** — language-aware categories, inline category
     creation, upload race-condition fix, sample-data rendering polish
     ([9c0be24](../commit/9c0be24))
  3. **Manufacturer + supplier pickers** in the import wizard
     ([1fe4cd6](../commit/1fe4cd6))

  ## Search API

  - `:limit` + `:offset` opts on all three search functions (global,
    per-catalogue, per-category) with stable `name, uuid` ordering for
    deterministic paging
  - New `count_search_items*` companions for accurate "X of Y" totals
  - `CatalogueDetailLive` and `CataloguesLive` stream search results through
    the same `InfiniteScroll` sentinel that drives the category walk
  - Searches run via `start_async` with a query-equality guard in
    `handle_async`, so out-of-order or superseded responses are dropped
  - Visible loading state during searches: "Searching for ..." on first
    search, dimmed prior results + spinner on subsequent queries
  - `IntersectionObserver` hook now tracks `intersecting` state and re-fires
    on `updated()` — fixes the "loads forever" bug on tall viewports / Page
    Down where the observer goes silent because intersection state never
    transitions

  ## Per-item markup override

  - Items get a nullable `markup_percentage` column (V97 in core
    phoenix_kit — see linked PR there); `NULL` inherits the catalogue's
    markup, any value (including `0`) overrides it
  - `Item.sale_price/2` keeps its signature but transparently honors the
    override; new `Item.effective_markup/2` helper exposes which markup
    applies
  - `Catalogue.item_pricing/1` returns `catalogue_markup`, `item_markup`,
    and the effective `markup_percentage` so price is internally consistent
  - Item form gains a "Markup Override" field with the catalogue's current
    markup as the placeholder/inherit hint
  - Import wizard: new `:markup_percentage` target with synonym detection
    (markup/margin/naceenka/juurdehindlus/aufschlag/...), preview column,
    blank-cell = inherit, invalid value = row error

  ## Import wizard — categories

  - Auto-created categories now apply the import language the same way
    items do (`data._primary_language` + `data.<lang>._name`), driven by
    the wizard's existing top-level language switcher
  - Get-or-create lookup is language-aware: matches existing categories
    by their translation in the current import language, with the bare
    name as fallback for categories without a translation set
  - New "Match across all languages" toggle in `:column` mode (with hover
    tooltip) for consolidating multilingual catalogues
  - New `:create` mode in "Import Into Category" — inline form mirroring
    the standalone Category creation screen (without its own buttons /
    language switcher); record persisted at execute time so cancelling the
    confirm step doesn't leave orphans

  ## Import wizard — manufacturer + supplier (new)

  - Mirrors the category picker for both: same four-mode vocabulary
    (`:none` / `:column` / `:create` / `:existing`) shared via a generic
    `<.party_picker>` and `<.new_party_form>` component
  - Items get `manufacturer_uuid` directly; suppliers attach through the
    existing M:N join because items don't have a supplier FK
  - Three-phase executor: get-or-create supporting records → insert items
    resolving per-row uuids → M:N linking (per-row pairs from `:column`
    mode merged with fixed-supplier→all-touched-manufacturers expansion);
    idempotent via the unique constraint
  - The three `:create` resolves wrap in a single `Repo.transaction` so a
    failure on the second/third doesn't leave the first as an orphan
  - `available_picker_columns/2` filters each picker's column dropdown so
    one can't silently clobber a sibling's column mapping
  - Empty-pool warning panel guides the user to either skip a column in
    the mapping cards OR switch a sibling picker out of `:column` mode
  - `reset_picker_state/1` on sheet switch / file replace / "Import another"

  ## Import wizard — bug fixes & polish

  - Upload button stays disabled while the upload XHR is in flight
    (label switches to "Uploading..." with a spinner); server-side guard
    in `parse_file` against partial entries — fixes the "click during
    upload erases the file" bug
  - Catalogue picker loads on first HTTP mount (no empty-dropdown flash);
    options now show counts: "Kitchen · 5 categories · 47 items"
  - Parser strips fully-empty columns (header AND every data cell blank),
    fixing phantom mapping cards / broken table render for spreadsheets
    with leading or trailing empty columns (e.g. FENIX 2025)
  - Sample data table: `#` row-number column, `title={cell}` hover tooltip
    on truncated cells, stable `id` on the collapse so morphdom preserves
    open state, vertical column borders for legibility
  - `phx-disable-with` on Continue + Run buttons

  ## Dependencies

  - Requires V97 migration in core phoenix_kit (separate PR linked there)
    for the per-item `markup_percentage` column.