### PR TITLE
Add smart catalogues, extract context submodules, harden admin LVs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,12 +46,13 @@ This is a **PhoenixKit module** that implements the `PhoenixKit.Module` behaviou
 
 ### Core Schemas (all use UUIDv7 primary keys)
 
-- **Catalogue** (`phoenix_kit_cat_catalogues`) — top-level groupings with name, description, markup_percentage (default 0%), status (active/archived/deleted)
+- **Catalogue** (`phoenix_kit_cat_catalogues`) — top-level groupings with name, description, `markup_percentage` (default 0, NOT NULL), `discount_percentage` (default 0, NOT NULL, V102), `kind` (`"standard"` | `"smart"`, default `"standard"`, NOT NULL, V102), status (active/archived/deleted). A **smart catalogue** holds items whose cost is a rule-driven function of other catalogues (see "Smart catalogues" section below).
 - **Category** (`phoenix_kit_cat_categories`) — subdivisions within a catalogue with position ordering, status (active/deleted)
-- **Item** (`phoenix_kit_cat_items`) — individual products with SKU, base_price, unit of measure, manufacturer link, status (active/deleted). **Belongs directly to a catalogue via `catalogue_uuid`** (required), with an optional `category_uuid` for grouping. Items without a category are "uncategorized within a catalogue" — still scoped to that catalogue. Sale price computed via catalogue's `markup_percentage` unless the item has its own `markup_percentage` override (nullable column, V97): `NULL` inherits from the catalogue, any Decimal (including `0`) overrides it. `Item.sale_price(item, catalogue_markup)` and `Item.effective_markup(item, catalogue_markup)` both honor the override transparently
+- **Item** (`phoenix_kit_cat_items`) — individual products with SKU, base_price, unit of measure, manufacturer link, status (active/deleted). **Belongs directly to a catalogue via `catalogue_uuid`** (required), with an optional `category_uuid` for grouping. Items without a category are "uncategorized within a catalogue" — still scoped to that catalogue. Has two nullable percentage overrides (`markup_percentage` added V97, `discount_percentage` added V102) with identical inherit-or-override semantics: `NULL` inherits from the catalogue, any Decimal (including `0`) overrides it. `Item.effective_markup/2` and `Item.effective_discount/2` resolve which value applies
 - **Manufacturer** (`phoenix_kit_cat_manufacturers`) — company directory with name, website, logo, status (active/inactive)
 - **Supplier** (`phoenix_kit_cat_suppliers`) — delivery companies with name, website, status (active/inactive)
 - **ManufacturerSupplier** (`phoenix_kit_cat_manufacturer_suppliers`) — many-to-many join table
+- **CatalogueRule** (`phoenix_kit_cat_item_catalogue_rules`, V102) — one row per `(item, referenced_catalogue)` for smart-catalogue items. Nullable `value` + `unit` plus `position` for UI ordering. At the **data layer**, `CatalogueRule.effective/2` still falls back to `item.default_value` / `item.default_unit` when a leg is NULL (kept for backward compat with pre-existing rows). At the **UI layer**, only `value` surfaces inheritance — the rules picker displays an `Inherit: N` placeholder for a blank value; `unit` is always explicit per row and does **not** read from `item.default_unit`. `UNIQUE(item_uuid, referenced_catalogue_uuid)` and `ON DELETE CASCADE` on both FKs — deleting a catalogue wipes every rule that references it, so warn the user first via `list_items_referencing_catalogue/1`.
 
 ### Items and catalogue scoping
 
@@ -71,13 +72,44 @@ This is a **PhoenixKit module** that implements the `PhoenixKit.Module` behaviou
 - **Permanent delete** follows same downward cascade but removes from DB; uncategorized items of the catalogue are removed too
 - All cascading operations wrapped in `Repo.transaction/1`
 
+### Pricing
+
+Two independent percentage legs apply on top of `base_price`, each with a catalogue-wide default plus an optional per-item override. The chain is `base → markup → discount` (multiplicative, in order):
+
+```
+sale_price  = base_price * (1 + effective_markup   / 100)   # "retail / crossed-out price"
+final_price = sale_price  * (1 -  effective_discount / 100)   # "what the customer pays"
+```
+
+- **Catalogue-wide columns** — `Catalogue.markup_percentage` (V89) and `Catalogue.discount_percentage` (V102): `DECIMAL(7, 2) NOT NULL DEFAULT 0`. Changeset validates `0..1000` for markup and `0..100` for discount.
+- **Per-item overrides** — `Item.markup_percentage` (V97) and `Item.discount_percentage` (V102): nullable `DECIMAL(7, 2)`. `NULL` inherits the catalogue's value; any set Decimal (including `0`) overrides. `0` is load-bearing — it means "sell at base / no discount" even when the catalogue has a non-zero value.
+- **Pure helpers on `Item`** — `sale_price/2`, `final_price/3`, `effective_markup/2`, `effective_discount/2`, `discount_amount/3`. All return `nil` when `base_price` is `nil`; results rounded to 2 decimals.
+- **`Catalogue.item_pricing/1`** is the one-stop API for pricing UIs. Returns a map with every field: `base_price`, `catalogue_markup`, `item_markup`, `markup_percentage` (effective), `sale_price` (post-markup), `catalogue_discount`, `item_discount`, `discount_percentage` (effective), `discount_amount`, `final_price` (post-discount). Resolves both catalogue columns in a single preload; on preload failure, logs a warning and falls back to `{0, 0}` so templates never crash.
+- **`:discount` and `:final_price` columns on `item_table`** — opt-in display columns; the component needs both `markup_percentage` and `discount_percentage` attrs when either is listed. `:discount` shows the effective percentage (honoring overrides); `:final_price` is the post-discount price. Existing `:price` column stays as the post-markup sale price.
+- **Naming:** `Catalogue.item_pricing/1` renamed `:price` to `:sale_price` in 0.1.11 to pair with the new `:final_price`. `Item.sale_price/2` (the pure helper) kept its name — it's still the pre-discount computation.
+
+### Smart catalogues
+
+A smart catalogue (`Catalogue.kind == "smart"`) holds items whose cost is a function of *other* catalogues. Classic example: a "Services" smart catalogue with a "Delivery" item that says "5% of Kitchen, 3% of Plumbing, plus $20 flat of Hardware". **This module stores the user's intent; downstream consumers do the math.**
+
+- **Data model**: `Catalogue.kind` (`"standard"` default / `"smart"`) + `Item.default_value`, `Item.default_unit` (both nullable; only `default_value` participates in UI inheritance — see below) + the `CatalogueRule` table. The parent catalogue of a rule row is *always* the one containing the item; the rule points to the *referenced* catalogue via `referenced_catalogue_uuid`.
+- **Inherit semantics differ by leg**. `value` inherits: a rule's NULL `value` falls back to `item.default_value` at math time, and the picker surfaces this via an `Inherit: N` placeholder. `unit` does **not** inherit in the UI — each rule row's unit is self-contained, toggling a row on seeds `unit: "percent"` explicitly. `CatalogueRule.effective(rule, item)` still inherits both legs at the data layer (backward compat for rows stored with NULL `unit`); new UI writes always populate `unit` directly.
+- **Unit vocabulary is open**. V1 recognizes `"percent"` and `"flat"`; the column is `VARCHAR(20)` so new units don't need a migration. `CatalogueRule.changeset` permits `percent`/`flat`/`nil`; `Item.changeset` validates `default_unit` against the same list — extend both if you add a unit. Consumers validate whatever they accept.
+- **Replace-all API**: `Catalogue.put_catalogue_rules(item, specs, opts)` takes a list of rule specs (`%{referenced_catalogue_uuid:, value:, unit:, position:}`), runs a single `Ecto.Multi` transaction that deletes missing rows, inserts new ones, and updates overlapping ones, and logs one `smart_rules.synced` activity with `added`/`updated`/`removed` counts. Duplicate `referenced_catalogue_uuid` in the input → `{:error, {:duplicate_referenced_catalogue, uuid}}` before any write.
+- **Read API**: `list_catalogue_rules/1` (preloads `referenced_catalogue`), `catalogue_rule_map/1` (same, keyed for O(1) lookup), `get_catalogue_rule/2` (single row). For the reverse direction, `list_items_referencing_catalogue/1` and `catalogue_reference_count/1` surface "which smart items use this catalogue?" — useful for warning before a catalogue delete.
+- **Self- and smart-to-smart references are intentionally allowed.** Consumers handle cycles at math time. Referencing a deleted catalogue: the rule row stays (FK still valid — soft-delete sets status, not FK); `list_catalogue_rules/1`'s preloaded `referenced_catalogue` carries the `status` so the UI can dim or warn on deleted references.
+- **Form flow**: `ItemFormLive` branches on `catalogue.kind`. Smart items show the `catalogue_rules_picker` + Default Value/Unit inputs; the LV owns `working_rules` as `%{uuid => %{value, unit}}` and calls `put_catalogue_rules/3` after the item saves. `CatalogueFormLive` exposes the Kind selector at create time.
+- **Component**: `catalogue_rules_picker/1` renders a checkbox + numeric input + unit dropdown per candidate catalogue; unchecked rows keep their inputs disabled but visible. Event names are customizable via attrs (`on_toggle`/`on_set_value`/`on_set_unit`/`on_clear`). The value input's placeholder shows `Inherit: N` when `item_default_value` is set. **There is no `item_default_unit` attr** — the unit dropdown reads only from the rule itself, falling back to the first entry of the `units` attr (default `"percent"`) when the rule has no unit. Changing the item's `default_unit` therefore never alters any rule row's visible unit.
+- **Smart items don't use `base_price` / `markup_percentage` / `discount_percentage`.** Those columns still exist on the row (shared Item schema) but the smart item form doesn't surface them and the convention is to leave them `nil`. A smart item's intrinsic standalone fee lives in `default_value` + `default_unit`. For ruleless smart items, `default_value: 50, default_unit: "flat"` means "this item costs $50 flat". When rules exist, `default_value` still acts as a fallback for any rule row whose `value` is blank (the data-layer inheritance surfaced via the `Inherit: N` placeholder); `default_unit` is *not* a UI fallback for rule rows — each row's unit is explicit.
+- **No math on our side.** `Catalogue.item_pricing/1` and `Item.final_price/3` work purely off `base_price` + markup + discount and do not consult rules or defaults — they're the standard-item pricing helpers. Smart-item consumers read `list_catalogue_rules/1` + the item's `default_value`/`default_unit` and do their own math.
+
 ### Activity Logging
 
 Every mutating operation in `Catalogue` context is logged via `PhoenixKit.Activity.log/1`:
 
 - **Pattern**: Private `log_activity/1` helper guarded by `Code.ensure_loaded?(PhoenixKit.Activity)` with rescue to `Logger.warning`. Activity logging failures never crash the primary operation.
 - **Actor tracking**: All mutating functions accept `opts \\ []` keyword list. Pass `actor_uuid: user.uuid` to attribute the action.
-- **Actions logged**: `manufacturer.created/updated/deleted`, `supplier.created/updated/deleted`, `catalogue.created/updated/deleted/trashed/restored/permanently_deleted`, `category.created/updated/deleted/trashed/restored/permanently_deleted/moved/positions_swapped`, `item.created/updated/deleted/trashed/restored/permanently_deleted/moved/bulk_trashed`, `manufacturer.suppliers_synced`, `supplier.manufacturers_synced`, `import.started`, `import.completed`
+- **Actions logged**: `manufacturer.created/updated/deleted`, `supplier.created/updated/deleted`, `catalogue.created/updated/deleted/trashed/restored/permanently_deleted`, `category.created/updated/deleted/trashed/restored/permanently_deleted/moved/positions_swapped`, `item.created/updated/deleted/trashed/restored/permanently_deleted/moved/bulk_trashed`, `manufacturer.suppliers_synced`, `supplier.manufacturers_synced`, `smart_rules.synced` (with `added`/`updated`/`removed`/`total` counts), `import.started`, `import.completed`
 - **Mode**: `"manual"` for user actions, `"auto"` for import-created items/categories
 - **LiveViews**: Extract actor UUID via `actor_opts(socket)` private helper reading `socket.assigns[:phoenix_kit_current_user]`
 
@@ -92,15 +124,29 @@ Multi-step file import wizard for bulk item creation from XLSX/CSV files.
 
 ### Search API
 
-Three search functions, each paired with an unbounded count function. Results page through the same `InfiniteScroll` sentinel that drives the category walk in `CatalogueDetailLive`.
+One unified search function plus two scoped convenience wrappers, each paired with an unbounded count function. All share a private `search_items_base/2` query builder, so behavior is consistent: items in deleted catalogues/categories are always excluded; deterministic paging via trailing `asc: i.uuid`.
 
-| List function | Count function | Scope |
-|---------------|---------------|-------|
-| `search_items/2` | `count_search_items/1` | All non-deleted catalogues |
-| `search_items_in_catalogue/3` | `count_search_items_in_catalogue/2` | One catalogue |
-| `search_items_in_category/3` | `count_search_items_in_category/2` | One category |
+| List function | Count function | Scope behavior |
+|---------------|---------------|---------------|
+| `search_items/2` | `count_search_items/2` | Accepts `:catalogue_uuids` and `:category_uuids` scope filters. Neither given → global. Either/both → AND-composed. A narrowed `:category_uuids` implicitly excludes uncategorized items. |
+| `search_items_in_catalogue/3` | `count_search_items_in_catalogue/2` | Thin wrapper around `search_items/2` with `catalogue_uuids: [catalogue_uuid]`. Orders by `asc_nulls_last: c.position, asc: i.name, asc: i.uuid` to walk categories in display order (important for the detail view UX). |
+| `search_items_in_category/3` | `count_search_items_in_category/2` | Thin wrapper around `search_items/2` with `category_uuids: [category_uuid]`. |
 
-All list functions take `:limit` (default 50) and `:offset` (default 0) in `opts`. Sort order is deterministic for paging — each query appends `asc: i.uuid` as the final tie-breaker. Count functions run the same `where` clauses but with `select: count(i.uuid)` and no `:limit`/`:offset`/`:order_by`/`:preload`, so they return the full matching total regardless of the current page.
+All list functions take `:limit` (default 50) and `:offset` (default 0) in `opts`. Count functions accept the same scope filters but ignore `:limit`/`:offset` — they return the unbounded total.
+
+**Composing scope with `list_catalogues_by_name_prefix/2`** — the natural pattern for "search only a subset of catalogues":
+
+```elixir
+uuids =
+  "Kit"
+  |> Catalogue.list_catalogues_by_name_prefix()
+  |> Enum.map(& &1.uuid)
+
+Catalogue.search_items("oak", catalogue_uuids: uuids)
+Catalogue.count_search_items("oak", catalogue_uuids: uuids)
+```
+
+The `scope_selector/1` component in `web/components.ex` renders a disclosure with catalogue/category checkbox lists and emits toggle events (customizable names) — the LV owns the selected-UUIDs state and feeds them straight into the search options.
 
 **LiveView usage pattern** (see `CatalogueDetailLive.run_search/2` and `load_next_search_batch/1`): fetch first page + total on search, render a sentinel while `search_has_more = loaded < total`, append pages via the shared `InfiniteScroll` hook. `search_results_summary` accepts an optional `loaded` attr to render "Showing X of Y" while paging.
 
@@ -109,9 +155,26 @@ All list functions take `:limit` (default 50) and `:offset` (default 0) in `opts
 ### Web Layer
 
 - **Admin** (9 LiveViews): CataloguesLive (index for catalogues/manufacturers/suppliers), CatalogueDetailLive, CatalogueFormLive, CategoryFormLive, ItemFormLive, ManufacturerFormLive, SupplierFormLive, ImportLive (multi-step import wizard), EventsLive (activity log with infinite scroll)
-- **Components** (`PhoenixKitCatalogue.Web.Components`): Reusable components — `item_table`, `search_input`, `search_results_summary`, `empty_state`, `view_mode_toggle`. All features opt-in via attrs. All text localized via `Gettext.gettext(PhoenixKitWeb.Gettext, ...)`. Components never crash — unknown columns, unloaded associations, nil values, and bad function arguments produce "—" placeholders and Logger warnings.
+- **Components** (`PhoenixKitCatalogue.Web.Components`): Reusable components — `item_table`, `search_input`, `search_results_summary`, `scope_selector`, `catalogue_rules_picker` (smart catalogue rule editor), `empty_state`, `view_mode_toggle`. All features opt-in via attrs. All text localized via `Gettext.gettext(PhoenixKitWeb.Gettext, ...)`. Components never crash — unknown columns, unloaded associations, nil values, and bad function arguments produce "—" placeholders and Logger warnings. `scope_selector` is the partner of the scoped search API: it renders a disclosure with catalogue/category checkbox lists and emits customizable toggle/clear events — the LV owns the selected-UUIDs state and feeds them into `Catalogue.search_items/2`'s `:catalogue_uuids` / `:category_uuids` opts.
 - **Routes**: Admin routes auto-generated from `admin_tabs/0`
 - **Paths**: Centralized path helpers in `Paths` module — always use these instead of hardcoding URLs
+
+### Form conventions (0.1.12+)
+
+All form LiveViews (`catalogue_form_live`, `item_form_live`, `manufacturer_form_live`, `supplier_form_live`, `category_form_live`) use **PhoenixKit's component-style field bindings**, not raw `<input name="x">` markup. The pattern:
+
+- `<.form for={@form} action="#" phx-change="validate" phx-submit="save">` — `@form` comes from `to_form(changeset)`
+- Fields: `<.input field={@form[:sku]} type="text" label="SKU" />`, `<.select field={@form[:status]} options={[{label, value}, ...]} />`, `<.textarea field={@form[:description]} />`
+- Each LV has a private `assign_changeset/2` helper that assigns **both** `:changeset` (for `<.translatable_field>`, which needs the raw changeset) and `:form = to_form(changeset)` (for the component-style inputs). Every mount / validate / save-error path goes through that helper so the two assigns can never drift apart.
+- Inline daisyUI modifiers ride on the `class` attr: `<.select field={@form[:x]} class="transition-colors focus-within:select-primary" />`, `<.input ... class="font-mono" />`. The attr is threaded onto the styled element itself (input/select/textarea/checkbox), not the outer wrapper — matches the Phoenix 1.7 generator convention. `<.input>` also has `wrapper_class` for the outer `<div phx-feedback-for>` when needed.
+
+**Multilang wrapper boundary**: only translatable fields (name, description) live inside `<.multilang_fields_wrapper>`. Pricing, classification, status, actions, and smart-catalogue rules all render as **siblings outside** the wrapper. See phoenix_kit's `AGENTS.md > Multilang Form Components > Wrapper scope rule` — the wrapper's id includes `current_lang` so everything inside re-mounts on a language switch; keeping it tiny means only name+description pay that cost. Skeleton/fields visibility is flipped client-side by `switch_lang_js/2` — do **not** pass `switching_lang={@switching_lang}` to the wrapper; the attr is no longer read and doing so trips an "undefined attribute" warning against the vendored `deps/phoenix_kit` cache.
+
+**Smart item form branches on `catalogue.kind`**: the whole "Pricing & Identification" section (SKU, Base Price, Unit, Markup Override, Discount Override) and the whole "Classification" section (Category, Manufacturer) are hidden when kind == `"smart"`. Smart items show only name/description + a Catalogue Rules section with the `<.catalogue_rules_picker>` component + a Default Value / Default Unit pair. Smart items never use `base_price` / `markup_percentage` / `discount_percentage` — the intrinsic fee lives in `default_value` + `default_unit`.
+
+**Move card also branches**: standard items get "Move to Another Category" (dropdown of `list_all_categories()` results, calls `move_item_to_category/3`); smart items get "Move to Another Smart Catalogue" (dropdown filtered to other smart catalogues via `list_catalogues(kind: :smart)`, calls `move_item_to_catalogue/3` which clears the category and sets the new catalogue). Each card only renders when its target list is non-empty.
+
+**`import_live.ex` is a principled exception** — it uses raw `<select name={"mapping[#{i}]"}>` because its column-mapping UI has runtime-constructed field names that `%Phoenix.HTML.FormField{}` can't model, and it assigns `:current_lang` directly in its own `handle_event("switch_language", ...)` instead of going through `handle_switch_language/2` (so the debounced skeleton UX doesn't apply to the import wizard's language picker, which is semantically different — it's picking "which language is this spreadsheet in?", not "which translation am I editing?"). Don't try to refactor the import wizard into the component-style pattern without rethinking its shape.
 
 ### Settings Keys
 
@@ -122,12 +185,24 @@ All list functions take `:limit` (default 50) and `:offset` (default 0) in `opts
 ```
 lib/phoenix_kit_catalogue.ex                    # Main module (PhoenixKit.Module behaviour)
 lib/phoenix_kit_catalogue/
-├── catalogue.ex                               # Context module (all CRUD, soft-delete, move ops, activity logging)
+├── catalogue.ex                               # Public context — thin API; delegates to catalogue/*.ex submodules
+├── catalogue/                                 # Extracted submodules (internal API; callers stay on `Catalogue.*`)
+│   ├── activity_log.ex                        # Guarded + rescued `PhoenixKit.Activity.log` wrapper
+│   ├── counts.ex                              # item_count_*, category_counts_*, uncategorized_count_*
+│   ├── helpers.ex                             # fetch_attr, sanitize_like, shared polymorphic accessors
+│   ├── links.ex                               # Manufacturer↔Supplier M2M CRUD + sync
+│   ├── manufacturers.ex                       # Manufacturer CRUD with activity logging
+│   ├── pub_sub.ex                             # Single topic + broadcast helpers ({:catalogue_data_changed, kind, uuid})
+│   ├── rules.ex                               # Smart-catalogue rule CRUD + put_catalogue_rules/3 replace-all
+│   ├── search.ex                              # search_items/2 + scoped wrappers, count_*
+│   ├── suppliers.ex                           # Supplier CRUD with activity logging
+│   └── translations.ex                        # Multilang read/write against schema.data JSONB
 ├── paths.ex                                   # Centralized URL path helpers
 ├── schemas/
-│   ├── cat_catalogue.ex                       # Catalogue schema + changeset
+│   ├── cat_catalogue.ex                       # Catalogue schema + changeset (kind: standard|smart)
+│   ├── catalogue_rule.ex                      # Smart-catalogue rule row (item → referenced catalogue)
 │   ├── category.ex                            # Category schema + changeset
-│   ├── item.ex                                # Item schema + changeset
+│   ├── item.ex                                # Item schema + changeset (default_value/default_unit)
 │   ├── manufacturer.ex                        # Manufacturer schema + changeset
 │   ├── manufacturer_supplier.ex               # Join table schema
 │   └── supplier.ex                            # Supplier schema + changeset
@@ -159,13 +234,21 @@ lib/phoenix_kit_catalogue/
 - **Navigation paths** — always use `PhoenixKit.Utils.Routes.path/1` for navigation within the PhoenixKit ecosystem
 - **LiveViews use `Phoenix.LiveView` directly** — do not use `PhoenixKitWeb` macros (`use PhoenixKitWeb, :live_view`) in this standalone package; import helpers explicitly
 - **`enabled?/0` MUST rescue** — the function must rescue all errors and return `false` as fallback (DB may not be available at boot)
-- **Single context module** — all business logic lives in `PhoenixKitCatalogue.Catalogue`; schemas are data-only with changesets
+- **Single public context** — callers go through `PhoenixKitCatalogue.Catalogue` for all business logic. Internally the context is broken into `PhoenixKitCatalogue.Catalogue.{Rules, Search, Manufacturers, Suppliers, Links, Counts, Translations, PubSub, ActivityLog, Helpers}` submodules for organization — they are an implementation detail, and `Catalogue` re-exports the public surface via `defdelegate`. **Do not** call submodules directly from LiveViews or external consumers; add new APIs to `Catalogue` and delegate inward. Schemas stay data-only with changesets.
 - **Multilang fields** — name and description fields use PhoenixKit's `Multilang` module for i18n support
 - **Soft-delete via status field** — catalogues, categories, and items use `status: "deleted"` for soft-delete; manufacturers and suppliers use hard-delete only
 
 ### Commit Message Rules
 
 Start with action verbs: `Add`, `Update`, `Fix`, `Remove`, `Merge`.
+
+## Tailwind CSS Scanning
+
+This module implements `css_sources/0` returning `[:phoenix_kit_catalogue]` so PhoenixKit's installer adds the correct `@source` directive to the parent's `app.css`. Without this, Tailwind purges classes unique to this module's templates. CSS-source discovery is automatic at compile time via the `:phoenix_kit_css_sources` compiler — see `phoenix_kit/AGENTS.md > Tailwind CSS Scanning for External Modules`.
+
+## JavaScript Hooks
+
+All shared DOM hooks (RowMenu, TableCardView, SortableGrid, InfiniteScroll) come from `phoenix_kit`'s bundled `priv/static/assets/phoenix_kit.js`, which exports `window.PhoenixKitHooks` and is already spread into the parent LiveSocket by `mix phoenix_kit.install`. This module does not ship its own external hooks. Any colocated hooks declared with `:type={Phoenix.LiveView.ColocatedHook}` inside our HEEx are bundled automatically.
 
 ## Database & Migrations
 
@@ -224,6 +307,8 @@ The version must be updated in **three places** when bumping:
 3. `test/phoenix_kit_catalogue_test.exs` — `assert PhoenixKitCatalogue.version() == "x.y.z"` (version compliance test)
 
 ### Changelog
+
+> **Maintainer-owned:** `CHANGELOG.md` entries are written by the project maintainer, not by agents. If you bump `mix.exs` `@version` and the CHANGELOG hasn't caught up yet, that's intentional — flag the gap to the user and stop. Do not auto-write entries.
 
 Update `CHANGELOG.md` before releasing. Each version gets a section:
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@ Designed for manufacturing companies (e.g. kitchen/furniture producers) that nee
 
 ## Features
 
-- **Catalogues** — top-level groupings with configurable markup percentage for pricing
+- **Catalogues** — top-level groupings with configurable markup and discount percentage for pricing
 - **Categories** — subdivisions within a catalogue with manual position ordering
-- **Items** — individual products with SKU, base price, computed sale price, unit of measure
+- **Items** — individual products with SKU, base price, unit of measure, and computed `sale_price` (post-markup) + `final_price` (post-discount)
 - **Manufacturers** — company directory with many-to-many supplier linking
 - **Suppliers** — delivery companies linked to manufacturers
-- **Pricing** — base price per item + markup percentage per catalogue = computed sale price, with an optional per-item markup override
+- **Pricing chain** — `base → markup → discount`: per-catalogue defaults plus optional per-item override on each leg (`nil` inherits, any value including `0` overrides)
+- **Smart catalogues** — a `kind: "smart"` catalogue holds items that reference *other* catalogues with a value + unit (e.g. "5% of Kitchen, $20 flat of Hardware"); rules live in `phoenix_kit_cat_item_catalogue_rules` and inherit from per-item defaults when null
 - **Search** — case-insensitive search by name, description, or SKU (per-category, per-catalogue, and global)
 - **Soft-delete** — catalogues, categories, and items support trash/restore with cascading
 - **Multilingual** — all translatable fields use PhoenixKit's multilang system
 - **Move operations** — move categories between catalogues, items between categories
 - **Card/table views** — all tables support card view toggle, persisted per user in localStorage
-- **Reusable components** — `item_table`, `search_input`, `view_mode_toggle`, `empty_state` with gettext localization and graceful error handling
+- **Reusable components** — `item_table`, `search_input`, `view_mode_toggle`, `empty_state`, `scope_selector`, `catalogue_rules_picker` with gettext localization
 - **Zero-config discovery** — auto-discovered by PhoenixKit via beam scanning
 
 ## Installation
@@ -48,22 +49,29 @@ Manufacturer (1) ──< ManufacturerSupplier >── (1) Supplier
      └──────────────────────────────┐
                                     │
 Catalogue (1) ──> Category (many) ──> Item (many)
-                   │                   ├── belongs_to Category (optional)
-                   │                   └── belongs_to Manufacturer (optional)
-                   └── position-ordered, soft-deletable
+  (kind=          │                   ├── belongs_to Category (optional)
+   standard|      │                   ├── belongs_to Manufacturer (optional)
+   smart)         │                   └── has_many CatalogueRule (smart only)
+                  │                                  │
+                  │                                  └── references another Catalogue
+                  │                                       with (value, unit, position)
+                  └── position-ordered, soft-deletable
 ```
 
 All tables use UUIDv7 primary keys and are prefixed with `phoenix_kit_cat_*`.
 
-### Status Values
+### Status & kind values
 
-| Entity       | Statuses                                  |
-|-------------|-------------------------------------------|
-| Catalogue   | `active`, `archived`, `deleted`           |
-| Category    | `active`, `deleted`                       |
-| Item        | `active`, `inactive`, `discontinued`, `deleted` |
-| Manufacturer| `active`, `inactive`                      |
-| Supplier    | `active`, `inactive`                      |
+| Entity       | Statuses                                                  |
+|-------------|-----------------------------------------------------------|
+| Catalogue   | `active`, `archived`, `deleted` (plus `kind`: `standard` \| `smart`) |
+| Category    | `active`, `deleted`                                       |
+| Item        | `active`, `inactive`, `discontinued`, `deleted`           |
+| Manufacturer| `active`, `inactive`                                      |
+| Supplier    | `active`, `inactive`                                      |
+| CatalogueRule | (no status — rows are deleted directly when removed)    |
+
+`kind` is an enum at the DB layer (`CHECK (kind IN ('standard', 'smart'))`). `unit` on rules is open-ended VARCHAR; v1 ships with `"percent"` and `"flat"` but consumers can introduce new units without a migration.
 
 ## Soft-Delete System
 
@@ -94,6 +102,8 @@ alias PhoenixKitCatalogue.Catalogue
 # ── Catalogues ────────────────────────────────────────
 Catalogue.list_catalogues()                        # excludes deleted
 Catalogue.list_catalogues(status: "deleted")       # only deleted
+Catalogue.list_catalogues_by_name_prefix("Kit")    # case-insensitive prefix match
+Catalogue.list_catalogues_by_name_prefix("Kit", limit: 5, status: "archived")
 Catalogue.create_catalogue(%{name: "Kitchen"})
 Catalogue.update_catalogue(cat, %{name: "New Name"})
 Catalogue.trash_catalogue(cat)                     # soft-delete (cascades down)
@@ -121,12 +131,53 @@ Catalogue.restore_item(item)                       # cascades up to category + c
 Catalogue.permanently_delete_item(item)            # hard-delete
 Catalogue.trash_items_in_category(cat_uuid)        # bulk soft-delete
 Catalogue.move_item_to_category(item, new_cat_uuid)
-Catalogue.item_pricing(item)                       # %{base_price, catalogue_markup, item_markup, markup_percentage, price}
+Catalogue.item_pricing(item)
+# => %{
+#   base_price:, catalogue_markup:, item_markup:, markup_percentage:, sale_price:,
+#   catalogue_discount:, item_discount:, discount_percentage:, discount_amount:, final_price:
+# }
 
-# Per-item markup override (nullable — defaults to inherit from catalogue)
-Catalogue.create_item(%{name: "Special Oak", base_price: 100, markup_percentage: 50, catalogue_uuid: cat.uuid})
-Item.sale_price(item, catalogue.markup_percentage)  # honors item override if set
-Item.effective_markup(item, catalogue.markup_percentage) # returns the override or the fallback
+# ── Smart catalogues ─────────────────────────────────
+{:ok, services} = Catalogue.create_catalogue(%{name: "Services", kind: "smart"})
+Catalogue.list_catalogues(kind: :smart)
+
+{:ok, delivery} = Catalogue.create_item(%{
+  name: "Delivery",
+  catalogue_uuid: services.uuid,
+  default_value: 5,        # fallback if a rule row has no value
+  default_unit: "percent"  # fallback if a rule row has no unit
+})
+
+# Replace-all rules — one row per referenced catalogue
+{:ok, rules} = Catalogue.put_catalogue_rules(delivery, [
+  %{referenced_catalogue_uuid: kitchen.uuid, value: 10, unit: "percent"},
+  %{referenced_catalogue_uuid: hardware.uuid, value: 20, unit: "flat"},
+  %{referenced_catalogue_uuid: plumbing.uuid}  # inherits defaults: 5 percent
+])
+
+Catalogue.list_catalogue_rules(delivery)
+Catalogue.catalogue_rule_map(delivery)          # %{uuid => %CatalogueRule{}}
+Catalogue.list_items_referencing_catalogue(kitchen.uuid)
+Catalogue.catalogue_reference_count(kitchen.uuid)
+
+# Resolve a single rule's effective {value, unit} (with item-default fallback)
+CatalogueRule.effective(rule, delivery)
+
+# Per-item overrides (nullable — `nil` inherits from catalogue, any value including 0 overrides)
+Catalogue.create_item(%{
+  name: "Special Oak",
+  base_price: 100,
+  markup_percentage: 50,     # override catalogue's markup
+  discount_percentage: 0,    # explicit "no discount" even if catalogue has one
+  catalogue_uuid: cat.uuid
+})
+
+# Pure helpers on Item (no Repo hits — caller supplies the catalogue leg values)
+Item.sale_price(item, catalogue.markup_percentage)                              # post-markup
+Item.final_price(item, catalogue.markup_percentage, catalogue.discount_percentage)  # post-discount
+Item.discount_amount(item, catalogue.markup_percentage, catalogue.discount_percentage)
+Item.effective_markup(item, catalogue.markup_percentage)
+Item.effective_discount(item, catalogue.discount_percentage)
 Catalogue.swap_category_positions(cat_a, cat_b)    # atomic position swap
 
 # ── Manufacturers ─────────────────────────────────────
@@ -147,16 +198,28 @@ Catalogue.list_suppliers_for_manufacturer(m_uuid)
 Catalogue.list_manufacturers_for_supplier(s_uuid)
 
 # ── Search ────────────────────────────────────────────
-Catalogue.search_items("oak")                      # global across all catalogues
+Catalogue.search_items("oak")                                    # global across all catalogues
 Catalogue.search_items("oak", limit: 10)
-Catalogue.search_items("oak", limit: 100, offset: 100)   # paging
-Catalogue.search_items_in_catalogue(cat_uuid, "panel")
-Catalogue.search_items_in_category(cat_uuid, "oak") # within one category
+Catalogue.search_items("oak", limit: 100, offset: 100)           # paging
+Catalogue.search_items("oak", catalogue_uuids: [a, b])           # only these catalogues
+Catalogue.search_items("oak", category_uuids: [c1, c2])          # only these categories
+Catalogue.search_items("oak", catalogue_uuids: [a], category_uuids: [c1])  # AND
+Catalogue.search_items_in_catalogue(cat_uuid, "panel")           # convenience wrapper
+Catalogue.search_items_in_category(cat_uuid, "oak")              # convenience wrapper
 
-# Unbounded total for paging / summaries
+# Unbounded total for paging / summaries (accepts the same scope filters)
 Catalogue.count_search_items("oak")
+Catalogue.count_search_items("oak", catalogue_uuids: [a, b])
 Catalogue.count_search_items_in_catalogue(cat_uuid, "panel")
 Catalogue.count_search_items_in_category(cat_uuid, "oak")
+
+# Compose with the prefix lookup
+uuids =
+  "Kit"
+  |> Catalogue.list_catalogues_by_name_prefix()
+  |> Enum.map(& &1.uuid)
+
+Catalogue.search_items("oak", catalogue_uuids: uuids)
 
 # ── Counts ────────────────────────────────────────────
 Catalogue.item_count_for_catalogue(cat_uuid)       # active items
@@ -197,7 +260,7 @@ Data-driven item table with opt-in columns, actions, and card view:
 />
 ```
 
-Available columns: `:name`, `:sku`, `:base_price`, `:price`, `:unit`, `:status`, `:category`, `:catalogue`, `:manufacturer`
+Available columns: `:name`, `:sku`, `:base_price`, `:price` (post-markup), `:discount`, `:final_price` (post-discount), `:unit`, `:status`, `:category`, `:catalogue`, `:manufacturer`. Pass `markup_percentage={@cat.markup_percentage}` when using `:price` or `:final_price`; pass `discount_percentage={@cat.discount_percentage}` when using `:discount` or `:final_price`.
 
 Unknown columns render as "—" with a logger warning. Unloaded associations, nil values, and invalid markup types are handled gracefully — the component never crashes the page.
 
@@ -218,6 +281,35 @@ Global table/card toggle that syncs all tables sharing the same `storage_key`:
 <.item_table cards={true} show_toggle={false} storage_key="my-items" id="table-1" ... />
 <.item_table cards={true} show_toggle={false} storage_key="my-items" id="table-2" ... />
 ```
+
+### `scope_selector/1`
+
+Disclosure with catalogue/category checkbox lists for narrowing a search. Pairs with `Catalogue.search_items/2`'s `:catalogue_uuids` / `:category_uuids`:
+
+```heex
+<.scope_selector
+  catalogues={@scope_catalogues}
+  categories={@scope_categories}
+  selected_catalogue_uuids={@selected_catalogue_uuids}
+  selected_category_uuids={@selected_category_uuids}
+/>
+```
+
+Emits four events (names customizable via attrs): `toggle_catalogue_scope`, `toggle_category_scope`, `clear_catalogue_scope`, `clear_category_scope`. The LV owns the selected-UUIDs lists and feeds them into the search opts. Either `catalogues` or `categories` can be empty — the corresponding section is omitted.
+
+### `catalogue_rules_picker/1`
+
+Smart-catalogue rule editor — one row per candidate catalogue with a checkbox, a numeric value input, and a unit dropdown. Pairs with `Catalogue.put_catalogue_rules/3`:
+
+```heex
+<.catalogue_rules_picker
+  catalogues={@candidate_catalogues}
+  rules={@working_rules}
+  item_default_value={@item_default_value}
+/>
+```
+
+Emits four customizable events: `toggle_catalogue_rule`, `set_catalogue_rule_value`, `set_catalogue_rule_unit`, `clear_catalogue_rules`. The LV owns `working_rules` as a `%{referenced_catalogue_uuid => %{value, unit}}` map and calls `put_catalogue_rules/3` on save. Rows with blank values show `Inherit: N` as placeholder when an item default is set. The per-row unit dropdown is self-contained — toggling a row on defaults its unit to `"percent"` and the item's `default_unit` does not cascade into rule rows.
 
 ### `search_results_summary/1` and `empty_state/1`
 

--- a/lib/phoenix_kit_catalogue.ex
+++ b/lib/phoenix_kit_catalogue.ex
@@ -61,7 +61,7 @@ defmodule PhoenixKitCatalogue do
   # ===========================================================================
 
   @impl PhoenixKit.Module
-  def version, do: "0.1.6"
+  def version, do: "0.1.12"
 
   @impl PhoenixKit.Module
   def css_sources, do: [:phoenix_kit_catalogue]

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -40,418 +40,102 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
   import Ecto.Query, warn: false
 
-  alias PhoenixKitCatalogue.Schemas.{
-    Catalogue,
-    Category,
-    Item,
-    Manufacturer,
-    ManufacturerSupplier,
-    Supplier
+  alias PhoenixKitCatalogue.Catalogue.{
+    ActivityLog,
+    Counts,
+    Helpers,
+    Links,
+    Manufacturers,
+    PubSub,
+    Rules,
+    Search,
+    Suppliers,
+    Translations
   }
 
-  alias PhoenixKit.Utils.Multilang
+  alias PhoenixKitCatalogue.Schemas.{Catalogue, Category, Item}
 
   require Logger
 
-  @module_key "catalogue"
-
   defp repo, do: PhoenixKit.RepoHelper.repo()
 
+  # `log_activity/1` was extracted to `PhoenixKitCatalogue.Catalogue.ActivityLog`
+  # so the per-section submodules can share it without circular imports.
+  # Internal callers in the remaining sections still use this thin
+  # alias for diff churn minimization.
+  # `log_activity/1` writes an audit-log entry **and** fans out a
+  # `{:catalogue_data_changed, kind, uuid}` event so list LVs subscribed
+  # via `PubSub.subscribe/0` re-fetch. The two are coupled here because
+  # every write in this module that's worth auditing is also worth
+  # signalling — keeping them paired prevents accidental "I logged but
+  # forgot to broadcast" drift. Submodules under
+  # `PhoenixKitCatalogue.Catalogue.*` call `ActivityLog.log/1` and
+  # `PubSub.broadcast/2` directly to keep their dependencies explicit.
   defp log_activity(attrs) do
-    if Code.ensure_loaded?(PhoenixKit.Activity) do
-      PhoenixKit.Activity.log(Map.put(attrs, :module, @module_key))
-    end
-  rescue
-    e ->
-      Logger.warning("[Catalogue] Failed to log activity: #{Exception.message(e)}")
+    ActivityLog.log(attrs)
+    broadcast_for(attrs)
   end
+
+  defp broadcast_for(%{resource_type: "catalogue", resource_uuid: uuid}),
+    do: PubSub.broadcast(:catalogue, uuid)
+
+  defp broadcast_for(%{resource_type: "category", resource_uuid: uuid}),
+    do: PubSub.broadcast(:category, uuid)
+
+  defp broadcast_for(%{resource_type: "item", resource_uuid: uuid}),
+    do: PubSub.broadcast(:item, uuid)
+
+  defp broadcast_for(%{resource_type: "manufacturer", resource_uuid: uuid}),
+    do: PubSub.broadcast(:manufacturer, uuid)
+
+  defp broadcast_for(%{resource_type: "supplier", resource_uuid: uuid}),
+    do: PubSub.broadcast(:supplier, uuid)
+
+  defp broadcast_for(%{resource_type: "smart_rule", resource_uuid: uuid}),
+    do: PubSub.broadcast(:smart_rule, uuid)
+
+  defp broadcast_for(_attrs), do: :ok
 
   # ═══════════════════════════════════════════════════════════════════
-  # Manufacturers
+  # Manufacturers — see PhoenixKitCatalogue.Catalogue.Manufacturers
   # ═══════════════════════════════════════════════════════════════════
 
-  @doc """
-  Lists all manufacturers, ordered by name.
-
-  ## Options
-
-    * `:status` — filter by status (e.g. `"active"`, `"inactive"`).
-      When nil (default), returns all manufacturers.
-
-  ## Examples
-
-      Catalogue.list_manufacturers()
-      Catalogue.list_manufacturers(status: "active")
-  """
-  def list_manufacturers(opts \\ []) do
-    query = from(m in Manufacturer, order_by: [asc: :name])
-
-    query =
-      case Keyword.get(opts, :status) do
-        nil -> query
-        status -> where(query, [m], m.status == ^status)
-      end
-
-    repo().all(query)
-  end
-
-  @doc "Fetches a manufacturer by UUID. Returns `nil` if not found."
-  def get_manufacturer(uuid), do: repo().get(Manufacturer, uuid)
-
-  @doc "Fetches a manufacturer by UUID. Raises `Ecto.NoResultsError` if not found."
-  def get_manufacturer!(uuid), do: repo().get!(Manufacturer, uuid)
-
-  @doc """
-  Creates a manufacturer.
-
-  ## Required attributes
-
-    * `:name` — manufacturer name (1-255 chars)
-
-  ## Optional attributes
-
-    * `:description`, `:website`, `:contact_info`, `:logo_url`, `:notes`
-    * `:status` — `"active"` (default) or `"inactive"`
-    * `:data` — flexible JSON map
-
-  ## Examples
-
-      Catalogue.create_manufacturer(%{name: "Blum", website: "https://blum.com"})
-  """
-  def create_manufacturer(attrs, opts \\ []) do
-    case %Manufacturer{} |> Manufacturer.changeset(attrs) |> repo().insert() do
-      {:ok, manufacturer} = ok ->
-        log_activity(%{
-          action: "manufacturer.created",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "manufacturer",
-          resource_uuid: manufacturer.uuid,
-          metadata: %{"name" => manufacturer.name}
-        })
-
-        ok
-
-      error ->
-        error
-    end
-  end
-
-  @doc "Updates a manufacturer with the given attributes."
-  def update_manufacturer(%Manufacturer{} = manufacturer, attrs, opts \\ []) do
-    case manufacturer |> Manufacturer.changeset(attrs) |> repo().update() do
-      {:ok, updated} = ok ->
-        log_activity(%{
-          action: "manufacturer.updated",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "manufacturer",
-          resource_uuid: updated.uuid,
-          metadata: %{"name" => updated.name}
-        })
-
-        ok
-
-      error ->
-        error
-    end
-  end
-
-  @doc "Hard-deletes a manufacturer from the database."
-  def delete_manufacturer(%Manufacturer{} = manufacturer, opts \\ []) do
-    case repo().delete(manufacturer) do
-      {:ok, _} = ok ->
-        log_activity(%{
-          action: "manufacturer.deleted",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "manufacturer",
-          resource_uuid: manufacturer.uuid,
-          metadata: %{"name" => manufacturer.name}
-        })
-
-        ok
-
-      error ->
-        error
-    end
-  end
-
-  @doc "Returns a changeset for tracking manufacturer changes."
-  def change_manufacturer(%Manufacturer{} = manufacturer, attrs \\ %{}) do
-    Manufacturer.changeset(manufacturer, attrs)
-  end
+  defdelegate list_manufacturers(opts \\ []), to: Manufacturers
+  defdelegate get_manufacturer(uuid), to: Manufacturers
+  defdelegate get_manufacturer!(uuid), to: Manufacturers
+  defdelegate create_manufacturer(attrs, opts \\ []), to: Manufacturers
+  defdelegate update_manufacturer(manufacturer, attrs, opts \\ []), to: Manufacturers
+  defdelegate delete_manufacturer(manufacturer, opts \\ []), to: Manufacturers
+  defdelegate change_manufacturer(manufacturer, attrs \\ %{}), to: Manufacturers
 
   # ═══════════════════════════════════════════════════════════════════
-  # Suppliers
+  # Suppliers — see PhoenixKitCatalogue.Catalogue.Suppliers
   # ═══════════════════════════════════════════════════════════════════
 
-  @doc """
-  Lists all suppliers, ordered by name.
-
-  ## Options
-
-    * `:status` — filter by status (e.g. `"active"`, `"inactive"`).
-
-  ## Examples
-
-      Catalogue.list_suppliers()
-      Catalogue.list_suppliers(status: "active")
-  """
-  def list_suppliers(opts \\ []) do
-    query = from(s in Supplier, order_by: [asc: :name])
-
-    query =
-      case Keyword.get(opts, :status) do
-        nil -> query
-        status -> where(query, [s], s.status == ^status)
-      end
-
-    repo().all(query)
-  end
-
-  @doc "Fetches a supplier by UUID. Returns `nil` if not found."
-  def get_supplier(uuid), do: repo().get(Supplier, uuid)
-
-  @doc "Fetches a supplier by UUID. Raises `Ecto.NoResultsError` if not found."
-  def get_supplier!(uuid), do: repo().get!(Supplier, uuid)
-
-  @doc """
-  Creates a supplier.
-
-  ## Required attributes
-
-    * `:name` — supplier name (1-255 chars)
-
-  ## Optional attributes
-
-    * `:description`, `:website`, `:contact_info`, `:notes`
-    * `:status` — `"active"` (default) or `"inactive"`
-    * `:data` — flexible JSON map
-
-  ## Examples
-
-      Catalogue.create_supplier(%{name: "Regional Distributors"})
-  """
-  def create_supplier(attrs, opts \\ []) do
-    case %Supplier{} |> Supplier.changeset(attrs) |> repo().insert() do
-      {:ok, supplier} = ok ->
-        log_activity(%{
-          action: "supplier.created",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "supplier",
-          resource_uuid: supplier.uuid,
-          metadata: %{"name" => supplier.name}
-        })
-
-        ok
-
-      error ->
-        error
-    end
-  end
-
-  @doc "Updates a supplier with the given attributes."
-  def update_supplier(%Supplier{} = supplier, attrs, opts \\ []) do
-    case supplier |> Supplier.changeset(attrs) |> repo().update() do
-      {:ok, updated} = ok ->
-        log_activity(%{
-          action: "supplier.updated",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "supplier",
-          resource_uuid: updated.uuid,
-          metadata: %{"name" => updated.name}
-        })
-
-        ok
-
-      error ->
-        error
-    end
-  end
-
-  @doc "Hard-deletes a supplier from the database."
-  def delete_supplier(%Supplier{} = supplier, opts \\ []) do
-    case repo().delete(supplier) do
-      {:ok, _} = ok ->
-        log_activity(%{
-          action: "supplier.deleted",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "supplier",
-          resource_uuid: supplier.uuid,
-          metadata: %{"name" => supplier.name}
-        })
-
-        ok
-
-      error ->
-        error
-    end
-  end
-
-  @doc "Returns a changeset for tracking supplier changes."
-  def change_supplier(%Supplier{} = supplier, attrs \\ %{}) do
-    Supplier.changeset(supplier, attrs)
-  end
+  defdelegate list_suppliers(opts \\ []), to: Suppliers
+  defdelegate get_supplier(uuid), to: Suppliers
+  defdelegate get_supplier!(uuid), to: Suppliers
+  defdelegate create_supplier(attrs, opts \\ []), to: Suppliers
+  defdelegate update_supplier(supplier, attrs, opts \\ []), to: Suppliers
+  defdelegate delete_supplier(supplier, opts \\ []), to: Suppliers
+  defdelegate change_supplier(supplier, attrs \\ %{}), to: Suppliers
 
   # ═══════════════════════════════════════════════════════════════════
-  # Manufacturer ↔ Supplier links
+  # Manufacturer ↔ Supplier links — see PhoenixKitCatalogue.Catalogue.Links
   # ═══════════════════════════════════════════════════════════════════
 
-  @doc """
-  Creates a many-to-many link between a manufacturer and a supplier.
+  defdelegate link_manufacturer_supplier(manufacturer_uuid, supplier_uuid), to: Links
+  defdelegate unlink_manufacturer_supplier(manufacturer_uuid, supplier_uuid), to: Links
+  defdelegate list_suppliers_for_manufacturer(manufacturer_uuid), to: Links
+  defdelegate list_manufacturers_for_supplier(supplier_uuid), to: Links
+  defdelegate linked_supplier_uuids(manufacturer_uuid), to: Links
+  defdelegate linked_manufacturer_uuids(supplier_uuid), to: Links
 
-  Returns `{:error, changeset}` if the link already exists (unique constraint).
-  """
-  def link_manufacturer_supplier(manufacturer_uuid, supplier_uuid) do
-    %ManufacturerSupplier{}
-    |> ManufacturerSupplier.changeset(%{
-      manufacturer_uuid: manufacturer_uuid,
-      supplier_uuid: supplier_uuid
-    })
-    |> repo().insert()
-  end
+  defdelegate sync_manufacturer_suppliers(manufacturer_uuid, supplier_uuids, opts \\ []),
+    to: Links
 
-  @doc """
-  Removes the link between a manufacturer and a supplier.
-
-  Returns `{:error, :not_found}` if the link doesn't exist.
-  """
-  def unlink_manufacturer_supplier(manufacturer_uuid, supplier_uuid) do
-    query =
-      from(ms in ManufacturerSupplier,
-        where: ms.manufacturer_uuid == ^manufacturer_uuid and ms.supplier_uuid == ^supplier_uuid
-      )
-
-    case repo().one(query) do
-      nil -> {:error, :not_found}
-      record -> repo().delete(record)
-    end
-  end
-
-  @doc "Lists all suppliers linked to a manufacturer, ordered by name."
-  def list_suppliers_for_manufacturer(manufacturer_uuid) do
-    from(s in Supplier,
-      join: ms in ManufacturerSupplier,
-      on: ms.supplier_uuid == s.uuid,
-      where: ms.manufacturer_uuid == ^manufacturer_uuid,
-      order_by: [asc: s.name]
-    )
-    |> repo().all()
-  end
-
-  @doc "Lists all manufacturers linked to a supplier, ordered by name."
-  def list_manufacturers_for_supplier(supplier_uuid) do
-    from(m in Manufacturer,
-      join: ms in ManufacturerSupplier,
-      on: ms.manufacturer_uuid == m.uuid,
-      where: ms.supplier_uuid == ^supplier_uuid,
-      order_by: [asc: m.name]
-    )
-    |> repo().all()
-  end
-
-  @doc "Returns a list of supplier UUIDs linked to a manufacturer."
-  def linked_supplier_uuids(manufacturer_uuid) do
-    from(ms in ManufacturerSupplier,
-      where: ms.manufacturer_uuid == ^manufacturer_uuid,
-      select: ms.supplier_uuid
-    )
-    |> repo().all()
-  end
-
-  @doc "Returns a list of manufacturer UUIDs linked to a supplier."
-  def linked_manufacturer_uuids(supplier_uuid) do
-    from(ms in ManufacturerSupplier,
-      where: ms.supplier_uuid == ^supplier_uuid,
-      select: ms.manufacturer_uuid
-    )
-    |> repo().all()
-  end
-
-  @doc """
-  Syncs the supplier links for a manufacturer to match the given list of supplier UUIDs.
-
-  Adds missing links and removes extra ones via set difference.
-  Returns `{:ok, :synced}` on success or `{:error, reason}` on the first failure.
-  """
-  def sync_manufacturer_suppliers(manufacturer_uuid, supplier_uuids, opts \\ [])
-      when is_list(supplier_uuids) do
-    current = linked_supplier_uuids(manufacturer_uuid) |> MapSet.new()
-    desired = MapSet.new(supplier_uuids)
-    added = MapSet.difference(desired, current)
-    removed = MapSet.difference(current, desired)
-
-    result =
-      repo().transaction(fn ->
-        Enum.each(added, &ok_or_rollback(link_manufacturer_supplier(manufacturer_uuid, &1)))
-        Enum.each(removed, &ok_or_rollback(unlink_manufacturer_supplier(manufacturer_uuid, &1)))
-        :synced
-      end)
-
-    with {:ok, :synced} <- result do
-      if MapSet.size(added) > 0 or MapSet.size(removed) > 0 do
-        log_activity(%{
-          action: "manufacturer.suppliers_synced",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "manufacturer",
-          resource_uuid: manufacturer_uuid,
-          metadata: %{
-            "added_count" => MapSet.size(added),
-            "removed_count" => MapSet.size(removed)
-          }
-        })
-      end
-
-      result
-    end
-  end
-
-  @doc """
-  Syncs the manufacturer links for a supplier to match the given list of manufacturer UUIDs.
-
-  Adds missing links and removes extra ones via set difference.
-  Returns `{:ok, :synced}` on success or `{:error, reason}` on the first failure.
-  """
-  def sync_supplier_manufacturers(supplier_uuid, manufacturer_uuids, opts \\ [])
-      when is_list(manufacturer_uuids) do
-    current = linked_manufacturer_uuids(supplier_uuid) |> MapSet.new()
-    desired = MapSet.new(manufacturer_uuids)
-    added = MapSet.difference(desired, current)
-    removed = MapSet.difference(current, desired)
-
-    result =
-      repo().transaction(fn ->
-        Enum.each(added, &ok_or_rollback(link_manufacturer_supplier(&1, supplier_uuid)))
-        Enum.each(removed, &ok_or_rollback(unlink_manufacturer_supplier(&1, supplier_uuid)))
-        :synced
-      end)
-
-    with {:ok, :synced} <- result do
-      if MapSet.size(added) > 0 or MapSet.size(removed) > 0 do
-        log_activity(%{
-          action: "supplier.manufacturers_synced",
-          mode: "manual",
-          actor_uuid: opts[:actor_uuid],
-          resource_type: "supplier",
-          resource_uuid: supplier_uuid,
-          metadata: %{
-            "added_count" => MapSet.size(added),
-            "removed_count" => MapSet.size(removed)
-          }
-        })
-      end
-
-      result
-    end
-  end
-
-  defp ok_or_rollback({:ok, _}), do: :ok
-  defp ok_or_rollback({:error, reason}), do: repo().rollback(reason)
+  defdelegate sync_supplier_manufacturers(supplier_uuid, manufacturer_uuids, opts \\ []),
+    to: Links
 
   # ═══════════════════════════════════════════════════════════════════
   # Catalogues
@@ -465,12 +149,16 @@ defmodule PhoenixKitCatalogue.Catalogue do
     * `:status` — when provided, returns only catalogues with this exact status
       (e.g. `"active"`, `"archived"`, `"deleted"`).
       When nil (default), returns all non-deleted catalogues.
+    * `:kind` — when provided, filters to a specific kind (`:standard`, `:smart`,
+      or their string equivalents). When nil (default), returns all kinds.
 
   ## Examples
 
       Catalogue.list_catalogues()                     # active + archived
       Catalogue.list_catalogues(status: "deleted")    # only deleted
       Catalogue.list_catalogues(status: "active")     # only active
+      Catalogue.list_catalogues(kind: :smart)         # only smart catalogues
+      Catalogue.list_catalogues(kind: :standard)      # only standard catalogues
   """
   def list_catalogues(opts \\ []) do
     query = from(c in Catalogue, order_by: [asc: :name])
@@ -479,6 +167,69 @@ defmodule PhoenixKitCatalogue.Catalogue do
       case Keyword.get(opts, :status) do
         nil -> where(query, [c], c.status != "deleted")
         status -> where(query, [c], c.status == ^status)
+      end
+
+    query =
+      case Keyword.get(opts, :kind) do
+        nil -> query
+        kind -> where(query, [c], c.kind == ^to_string(kind))
+      end
+
+    repo().all(query)
+  end
+
+  @doc """
+  Lists catalogues whose name starts with `prefix`, case-insensitive.
+
+  Anchored at the start of the name — this is a *prefix* match
+  (`name ILIKE 'prefix%'`), not a contains match. LIKE metacharacters
+  (`%`, `_`) in the prefix are escaped.
+
+  Excludes deleted catalogues by default. Useful for narrowing a search
+  scope: pair with `search_items/2`'s `:catalogue_uuids` to search only
+  the matched catalogues.
+
+  ## Options
+
+    * `:status` — when provided, returns only catalogues with this exact status.
+      Defaults to non-deleted (active + archived).
+    * `:limit` — max results (no limit by default).
+
+  ## Examples
+
+      Catalogue.list_catalogues_by_name_prefix("Kit")
+      #=> [%Catalogue{name: "Kitchen Furniture"}, %Catalogue{name: "Kits"}]
+
+      Catalogue.list_catalogues_by_name_prefix("Kit", limit: 5)
+      Catalogue.list_catalogues_by_name_prefix("", limit: 10)  # returns first 10
+
+      # Compose with search
+      uuids =
+        "Kit"
+        |> Catalogue.list_catalogues_by_name_prefix()
+        |> Enum.map(& &1.uuid)
+
+      Catalogue.search_items("oak", catalogue_uuids: uuids)
+  """
+  def list_catalogues_by_name_prefix(prefix, opts \\ []) when is_binary(prefix) do
+    pattern = "#{Helpers.sanitize_like(prefix)}%"
+
+    query =
+      from(c in Catalogue,
+        where: ilike(c.name, ^pattern),
+        order_by: [asc: :name]
+      )
+
+    query =
+      case Keyword.get(opts, :status) do
+        nil -> where(query, [c], c.status != "deleted")
+        status -> where(query, [c], c.status == ^status)
+      end
+
+    query =
+      case Keyword.get(opts, :limit) do
+        nil -> query
+        lim -> limit(query, ^lim)
       end
 
     repo().all(query)
@@ -709,13 +460,41 @@ defmodule PhoenixKitCatalogue.Catalogue do
   2. Hard-deletes all categories
   3. Hard-deletes the catalogue
 
+  Refuses with `{:error, {:referenced_by_smart_items, count}}` when one or
+  more smart-catalogue items still have rules pointing at this catalogue.
+  V102's `ON DELETE CASCADE` would silently wipe those rule rows;
+  callers should resolve the references explicitly (or remove the rules)
+  before retrying. Use `:force` to bypass this guard at your own risk.
+
   This cannot be undone.
+
+  ## Options
+
+    * `:actor_uuid` — UUID to attribute on the activity log
+    * `:force` — when `true`, deletes even if smart-rule references exist
 
   ## Examples
 
       {:ok, _} = Catalogue.permanently_delete_catalogue(catalogue)
+      {:error, {:referenced_by_smart_items, 3}} =
+        Catalogue.permanently_delete_catalogue(catalogue_with_refs)
   """
+  @spec permanently_delete_catalogue(Catalogue.t(), keyword()) ::
+          {:ok, Catalogue.t()}
+          | {:error, {:referenced_by_smart_items, non_neg_integer()}}
+          | {:error, term()}
   def permanently_delete_catalogue(%Catalogue{} = catalogue, opts \\ []) do
+    force? = Keyword.get(opts, :force, false)
+    ref_count = catalogue_reference_count(catalogue.uuid)
+
+    if ref_count > 0 and not force? do
+      {:error, {:referenced_by_smart_items, ref_count}}
+    else
+      do_permanently_delete_catalogue(catalogue, ref_count, opts)
+    end
+  end
+
+  defp do_permanently_delete_catalogue(catalogue, ref_count, opts) do
     result =
       repo().transaction(fn ->
         from(i in Item, where: i.catalogue_uuid == ^catalogue.uuid)
@@ -734,7 +513,10 @@ defmodule PhoenixKitCatalogue.Catalogue do
         actor_uuid: opts[:actor_uuid],
         resource_type: "catalogue",
         resource_uuid: catalogue.uuid,
-        metadata: %{"name" => catalogue.name}
+        metadata: %{
+          "name" => catalogue.name,
+          "smart_rules_cascaded" => ref_count
+        }
       })
 
       result
@@ -1224,6 +1006,8 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
       {:ok, _} = Catalogue.swap_category_positions(cat_a, cat_b)
   """
+  @spec swap_category_positions(Category.t(), Category.t(), keyword()) ::
+          {:ok, term()} | {:error, term()}
   def swap_category_positions(%Category{} = cat_a, %Category{} = cat_b, opts \\ []) do
     result =
       repo().transaction(fn ->
@@ -1240,6 +1024,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
         mode: "manual",
         actor_uuid: opts[:actor_uuid],
         resource_type: "category",
+        resource_uuid: cat_a.uuid,
         metadata: %{
           "category_a_uuid" => cat_a.uuid,
           "category_a_name" => cat_a.name,
@@ -1483,8 +1268,8 @@ defmodule PhoenixKitCatalogue.Catalogue do
   # create/update: the incoming one from attrs if provided (nil if it's
   # an empty string), otherwise the item's current value (nil on create).
   defp effective_category_uuid(item, attrs) do
-    if has_attr?(attrs, :category_uuid) do
-      attrs |> fetch_attr(:category_uuid) |> blank_to_nil()
+    if Helpers.has_attr?(attrs, :category_uuid) do
+      attrs |> Helpers.fetch_attr(:category_uuid) |> blank_to_nil()
     else
       item && Map.get(item, :category_uuid)
     end
@@ -1494,8 +1279,9 @@ defmodule PhoenixKitCatalogue.Catalogue do
   # to `nil` so the changeset treats it as "clear category" instead of
   # tripping a malformed FK lookup.
   defp normalize_blank_category(attrs) do
-    if has_attr?(attrs, :category_uuid) and fetch_attr(attrs, :category_uuid) == "" do
-      put_attr(attrs, :category_uuid, nil)
+    if Helpers.has_attr?(attrs, :category_uuid) and
+         Helpers.fetch_attr(attrs, :category_uuid) == "" do
+      Helpers.put_attr(attrs, :category_uuid, nil)
     else
       attrs
     end
@@ -1518,7 +1304,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
     case repo().one(query) do
       %Category{catalogue_uuid: cat_uuid} ->
-        put_attr(attrs, :catalogue_uuid, cat_uuid)
+        Helpers.put_attr(attrs, :catalogue_uuid, cat_uuid)
 
       nil ->
         # Target category doesn't exist — leave attrs as-is so the
@@ -1529,43 +1315,6 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
   defp blank_to_nil(value) when value in [nil, ""], do: nil
   defp blank_to_nil(value), do: value
-
-  defp has_attr?(attrs, key) do
-    Map.has_key?(attrs, key) or Map.has_key?(attrs, to_string(key))
-  end
-
-  defp fetch_attr(attrs, key) do
-    case Map.fetch(attrs, key) do
-      {:ok, value} -> value
-      :error -> Map.get(attrs, to_string(key))
-    end
-  end
-
-  defp put_attr(attrs, key, value) do
-    cond do
-      Map.has_key?(attrs, key) ->
-        Map.put(attrs, key, value)
-
-      Map.has_key?(attrs, to_string(key)) ->
-        Map.put(attrs, to_string(key), value)
-
-      # Neither form exists — insert using the same key style as the rest
-      # of the map. Mixing atom and string keys yields an
-      # `Ecto.CastError` inside `Ecto.Changeset.cast/4`, which is what
-      # form-submitted (string-keyed) params will hit otherwise.
-      string_keyed?(attrs) ->
-        Map.put(attrs, to_string(key), value)
-
-      true ->
-        Map.put(attrs, key, value)
-    end
-  end
-
-  defp string_keyed?(attrs) when map_size(attrs) == 0, do: false
-
-  defp string_keyed?(attrs) do
-    attrs |> Map.keys() |> hd() |> is_binary()
-  end
 
   @doc "Updates an item with the given attributes."
   def update_item(%Item{} = item, attrs, opts \\ []) do
@@ -1804,85 +1553,179 @@ defmodule PhoenixKitCatalogue.Catalogue do
     end
   end
 
+  @doc """
+  Moves an item to a different catalogue, clearing its category.
+
+  Primarily used for **smart** items, where categories don't apply —
+  the "where does this item live?" question reduces to "which catalogue?".
+  Sets both `catalogue_uuid` and `category_uuid` in one update so the
+  item becomes uncategorized within its new catalogue.
+
+  Returns `{:error, :catalogue_not_found}` if the target catalogue UUID
+  doesn't resolve, `{:error, :same_catalogue}` if it's already there, or
+  `{:error, changeset}` on validation failure. Logs an `item.moved`
+  activity with from/to catalogue metadata.
+
+  ## Examples
+
+      {:ok, item} = Catalogue.move_item_to_catalogue(item, other_smart.uuid)
+  """
+  @spec move_item_to_catalogue(Item.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Item.t()}
+          | {:error, :catalogue_not_found | :same_catalogue | Ecto.Changeset.t(Item.t())}
+  def move_item_to_catalogue(%Item{} = item, catalogue_uuid, opts \\ [])
+      when is_binary(catalogue_uuid) do
+    from_catalogue_uuid = item.catalogue_uuid
+
+    cond do
+      catalogue_uuid == from_catalogue_uuid ->
+        {:error, :same_catalogue}
+
+      is_nil(repo().get(Catalogue, catalogue_uuid)) ->
+        {:error, :catalogue_not_found}
+
+      true ->
+        attrs = %{catalogue_uuid: catalogue_uuid, category_uuid: nil}
+
+        with {:ok, moved} <- item |> Item.changeset(attrs) |> repo().update() do
+          log_activity(%{
+            action: "item.moved",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "item",
+            resource_uuid: moved.uuid,
+            metadata: %{
+              "name" => moved.name,
+              "from_catalogue_uuid" => from_catalogue_uuid,
+              "to_catalogue_uuid" => catalogue_uuid,
+              "from_category_uuid" => item.category_uuid,
+              "to_category_uuid" => nil
+            }
+          })
+
+          {:ok, moved}
+        end
+    end
+  end
+
   @doc "Returns a changeset for tracking item changes."
   def change_item(%Item{} = item, attrs \\ %{}) do
     Item.changeset(item, attrs)
   end
 
   @doc """
-  Returns pricing info for an item within a catalogue.
+  Returns the full pricing breakdown for an item within its catalogue.
 
-  Looks up the catalogue's markup percentage directly on the item, then
-  computes the sale price. Never raises — if the catalogue can't be
-  loaded (e.g. DB hiccup, connection timeout), falls back to 0% markup
-  and logs a warning so the caller still gets a renderable result
-  instead of crashing a template.
+  Resolves both the catalogue's markup and discount (loading the
+  catalogue association once if needed), then computes the sale price
+  (after markup) and final price (after discount). The chain is
+  `base → markup → discount`:
 
-  Returns a map with:
+      sale_price  = base_price * (1 + effective_markup   / 100)
+      final_price = sale_price  * (1 -  effective_discount / 100)
+
+  Never raises — if the catalogue can't be loaded (e.g. DB hiccup), falls
+  back to 0% markup and 0% discount and logs a warning so the caller
+  still gets a renderable result instead of crashing a template.
+
+  Returns a map with every field a pricing UI needs in one hop:
 
     * `:base_price` — the item's stored base price (or `nil` if unset)
-    * `:catalogue_markup` — the parent catalogue's `markup_percentage`
-      (the inherited default for items without an override)
-    * `:item_markup` — the item's `markup_percentage` override, or
-      `nil` when the item inherits from the catalogue
-    * `:markup_percentage` — the markup actually applied to compute
-      `:price` — the item's override if set, otherwise the catalogue's
-    * `:price` — the computed sale price (or `nil` if no base price)
-
-  Returns `nil` for `:price` if the item has no base price.
+    * `:catalogue_markup` — the catalogue's `markup_percentage` (the
+      inherited default when the item has no override)
+    * `:item_markup` — the item's markup override, or `nil` when
+      inheriting from the catalogue
+    * `:markup_percentage` — the markup actually applied (item override
+      if set, otherwise catalogue's)
+    * `:sale_price` — the price after markup, before any discount
+      (or `nil` if no base price)
+    * `:catalogue_discount` — the catalogue's `discount_percentage`
+    * `:item_discount` — the item's discount override, or `nil` when
+      inheriting from the catalogue
+    * `:discount_percentage` — the discount actually applied (item
+      override if set, otherwise catalogue's)
+    * `:discount_amount` — the Decimal amount subtracted by the discount
+      (`sale_price - final_price`), or `nil` if no discount applies or
+      no base price
+    * `:final_price` — the price after both markup and discount (or
+      `nil` if no base price)
 
   ## Examples
 
-      # Item inherits the catalogue's markup
+      # Item inherits both markup (15%) and discount (10%)
       Catalogue.item_pricing(item)
       #=> %{
       #=>   base_price: Decimal.new("100.00"),
       #=>   catalogue_markup: Decimal.new("15.0"),
       #=>   item_markup: nil,
       #=>   markup_percentage: Decimal.new("15.0"),
-      #=>   price: Decimal.new("115.00")
+      #=>   sale_price: Decimal.new("115.00"),
+      #=>   catalogue_discount: Decimal.new("10.0"),
+      #=>   item_discount: nil,
+      #=>   discount_percentage: Decimal.new("10.0"),
+      #=>   discount_amount: Decimal.new("11.50"),
+      #=>   final_price: Decimal.new("103.50")
       #=> }
 
-      # Item overrides to 50%
-      Catalogue.item_pricing(item_with_override)
-      #=> %{
-      #=>   base_price: Decimal.new("100.00"),
-      #=>   catalogue_markup: Decimal.new("15.0"),
-      #=>   item_markup: Decimal.new("50.0"),
-      #=>   markup_percentage: Decimal.new("50.0"),
-      #=>   price: Decimal.new("150.00")
-      #=> }
+      # Item overrides discount to 0 — sale price is charged at full
+      Catalogue.item_pricing(item_with_zero_discount)
+      #=> %{..., final_price: Decimal.new("115.00"), discount_amount: Decimal.new("0.00"), ...}
   """
+  @spec item_pricing(Item.t()) :: %{
+          base_price: Decimal.t() | nil,
+          catalogue_markup: Decimal.t() | nil,
+          item_markup: Decimal.t() | nil,
+          markup_percentage: Decimal.t() | nil,
+          sale_price: Decimal.t() | nil,
+          catalogue_discount: Decimal.t() | nil,
+          item_discount: Decimal.t() | nil,
+          discount_percentage: Decimal.t() | nil,
+          discount_amount: Decimal.t() | nil,
+          final_price: Decimal.t() | nil
+        }
   def item_pricing(%Item{} = item) do
-    catalogue_markup = safe_markup_for_item(item)
-    effective = Item.effective_markup(item, catalogue_markup)
+    {catalogue_markup, catalogue_discount} = safe_pricing_for_item(item)
+    effective_markup = Item.effective_markup(item, catalogue_markup)
+    effective_discount = Item.effective_discount(item, catalogue_discount)
 
     %{
       base_price: item.base_price,
       catalogue_markup: catalogue_markup,
       item_markup: item.markup_percentage,
-      markup_percentage: effective,
-      price: Item.sale_price(item, catalogue_markup)
+      markup_percentage: effective_markup,
+      sale_price: Item.sale_price(item, catalogue_markup),
+      catalogue_discount: catalogue_discount,
+      item_discount: item.discount_percentage,
+      discount_percentage: effective_discount,
+      discount_amount: Item.discount_amount(item, catalogue_markup, catalogue_discount),
+      final_price: Item.final_price(item, catalogue_markup, catalogue_discount)
     }
   end
 
-  defp safe_markup_for_item(item) do
+  # Returns {markup, discount} from the item's catalogue. Preloads
+  # the catalogue association if needed; falls back to {0, 0} on any
+  # failure so pricing rendering never crashes a template. One preload
+  # handles both values.
+  defp safe_pricing_for_item(item) do
     case item.catalogue do
-      %Catalogue{markup_percentage: mp} when not is_nil(mp) ->
-        mp
+      %Catalogue{} = catalogue ->
+        {markup_from(catalogue), discount_from(catalogue)}
 
       %Ecto.Association.NotLoaded{} ->
-        load_catalogue_markup(item)
+        load_pricing(item)
 
       _ ->
-        Decimal.new("0")
+        {Decimal.new("0"), Decimal.new("0")}
     end
   end
 
-  defp load_catalogue_markup(item) do
+  defp load_pricing(item) do
     case repo().preload(item, [:catalogue]) do
-      %Item{catalogue: %Catalogue{markup_percentage: mp}} when not is_nil(mp) -> mp
-      _ -> Decimal.new("0")
+      %Item{catalogue: %Catalogue{} = catalogue} ->
+        {markup_from(catalogue), discount_from(catalogue)}
+
+      _ ->
+        {Decimal.new("0"), Decimal.new("0")}
     end
   rescue
     e ->
@@ -1891,361 +1734,59 @@ defmodule PhoenixKitCatalogue.Catalogue do
           Exception.message(e)
       )
 
-      Decimal.new("0")
+      {Decimal.new("0"), Decimal.new("0")}
   end
+
+  defp markup_from(%Catalogue{markup_percentage: nil}), do: Decimal.new("0")
+  defp markup_from(%Catalogue{markup_percentage: mp}), do: mp
+
+  defp discount_from(%Catalogue{discount_percentage: nil}), do: Decimal.new("0")
+  defp discount_from(%Catalogue{discount_percentage: d}), do: d
 
   # ═══════════════════════════════════════════════════════════════════
-  # Search
+  # Smart-catalogue rules — see PhoenixKitCatalogue.Catalogue.Rules
   # ═══════════════════════════════════════════════════════════════════
 
-  @doc """
-  Searches items across all non-deleted catalogues.
-
-  Matches against item name, description, and SKU using case-insensitive
-  partial matching. Only returns non-deleted items in non-deleted categories
-  of non-deleted catalogues.
-
-  Preloads category (with catalogue) and manufacturer.
-
-  Returns a list of items ordered by name.
-
-  ## Options
-
-    * `:limit` — max results to return (default 50)
-    * `:offset` — number of results to skip, for paging (default 0)
-
-  ## Examples
-
-      Catalogue.search_items("oak")
-      Catalogue.search_items("OAK-18", limit: 10)
-      Catalogue.search_items("oak", limit: 100, offset: 100)
-  """
-  def search_items(query, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 50)
-    offset = Keyword.get(opts, :offset, 0)
-    pattern = "%#{sanitize_like(query)}%"
-
-    from(i in Item,
-      join: cat in Catalogue,
-      on: i.catalogue_uuid == cat.uuid,
-      left_join: c in Category,
-      on: i.category_uuid == c.uuid,
-      where: i.status != "deleted" and cat.status != "deleted",
-      where: is_nil(c.uuid) or c.status != "deleted",
-      where:
-        ilike(i.name, ^pattern) or
-          ilike(i.description, ^pattern) or
-          ilike(i.sku, ^pattern) or
-          fragment("?::text ILIKE ?", i.data, ^pattern),
-      order_by: [asc: i.name, asc: i.uuid],
-      limit: ^limit,
-      offset: ^offset,
-      preload: [:catalogue, category: :catalogue, manufacturer: []]
-    )
-    |> repo().all()
-  end
-
-  @doc """
-  Returns the total number of items across all non-deleted catalogues
-  that match a search query, using the same matching rules as
-  `search_items/2`. Runs independently of `:limit`/`:offset`.
-
-  ## Examples
-
-      Catalogue.count_search_items("oak")
-      #=> 1204
-  """
-  def count_search_items(query) do
-    pattern = "%#{sanitize_like(query)}%"
-
-    from(i in Item,
-      join: cat in Catalogue,
-      on: i.catalogue_uuid == cat.uuid,
-      left_join: c in Category,
-      on: i.category_uuid == c.uuid,
-      where: i.status != "deleted" and cat.status != "deleted",
-      where: is_nil(c.uuid) or c.status != "deleted",
-      where:
-        ilike(i.name, ^pattern) or
-          ilike(i.description, ^pattern) or
-          ilike(i.sku, ^pattern) or
-          fragment("?::text ILIKE ?", i.data, ^pattern),
-      select: count(i.uuid)
-    )
-    |> repo().one()
-  end
-
-  @doc """
-  Searches items within a specific catalogue.
-
-  Matches against item name, description, and SKU using case-insensitive
-  partial matching. Only returns non-deleted items in non-deleted categories.
-
-  Preloads category and manufacturer.
-
-  Returns a list of items ordered by category position then item name.
-
-  ## Options
-
-    * `:limit` — max results to return (default 50)
-    * `:offset` — number of results to skip, for paging (default 0)
-
-  ## Examples
-
-      Catalogue.search_items_in_catalogue(catalogue_uuid, "panel")
-      Catalogue.search_items_in_catalogue(catalogue_uuid, "SKU", limit: 25)
-      Catalogue.search_items_in_catalogue(catalogue_uuid, "panel", limit: 100, offset: 100)
-  """
-  def search_items_in_catalogue(catalogue_uuid, query, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 50)
-    offset = Keyword.get(opts, :offset, 0)
-    pattern = "%#{sanitize_like(query)}%"
-
-    from(i in Item,
-      left_join: c in Category,
-      on: i.category_uuid == c.uuid,
-      where: i.catalogue_uuid == ^catalogue_uuid,
-      where: i.status != "deleted",
-      where: is_nil(c.uuid) or c.status != "deleted",
-      where:
-        ilike(i.name, ^pattern) or
-          ilike(i.description, ^pattern) or
-          ilike(i.sku, ^pattern) or
-          fragment("?::text ILIKE ?", i.data, ^pattern),
-      order_by: [asc_nulls_last: c.position, asc: i.name, asc: i.uuid],
-      limit: ^limit,
-      offset: ^offset,
-      preload: [:catalogue, category: :catalogue, manufacturer: []]
-    )
-    |> repo().all()
-  end
-
-  @doc """
-  Returns the total number of items in a catalogue that match a search
-  query, using the same matching rules as `search_items_in_catalogue/3`.
-
-  Useful for paginating or driving "N of M" summaries alongside paged
-  search results. Runs independently of `:limit`/`:offset` — this is the
-  unbounded total.
-
-  ## Examples
-
-      Catalogue.count_search_items_in_catalogue(catalogue_uuid, "panel")
-      #=> 237
-  """
-  def count_search_items_in_catalogue(catalogue_uuid, query) do
-    pattern = "%#{sanitize_like(query)}%"
-
-    from(i in Item,
-      left_join: c in Category,
-      on: i.category_uuid == c.uuid,
-      where: i.catalogue_uuid == ^catalogue_uuid,
-      where: i.status != "deleted",
-      where: is_nil(c.uuid) or c.status != "deleted",
-      where:
-        ilike(i.name, ^pattern) or
-          ilike(i.description, ^pattern) or
-          ilike(i.sku, ^pattern) or
-          fragment("?::text ILIKE ?", i.data, ^pattern),
-      select: count(i.uuid)
-    )
-    |> repo().one()
-  end
-
-  @doc """
-  Searches items within a specific category.
-
-  Matches against item name, description, and SKU using case-insensitive
-  partial matching. Only returns non-deleted items.
-
-  Preloads category (with catalogue) and manufacturer.
-
-  ## Options
-
-    * `:limit` — max results to return (default 50)
-    * `:offset` — number of results to skip, for paging (default 0)
-
-  ## Examples
-
-      Catalogue.search_items_in_category(category_uuid, "panel")
-      Catalogue.search_items_in_category(category_uuid, "panel", limit: 100, offset: 100)
-  """
-  def search_items_in_category(category_uuid, query, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 50)
-    offset = Keyword.get(opts, :offset, 0)
-    pattern = "%#{sanitize_like(query)}%"
-
-    from(i in Item,
-      where: i.category_uuid == ^category_uuid,
-      where: i.status != "deleted",
-      where:
-        ilike(i.name, ^pattern) or
-          ilike(i.description, ^pattern) or
-          ilike(i.sku, ^pattern) or
-          fragment("?::text ILIKE ?", i.data, ^pattern),
-      order_by: [asc: i.name, asc: i.uuid],
-      limit: ^limit,
-      offset: ^offset,
-      preload: [:catalogue, category: :catalogue, manufacturer: []]
-    )
-    |> repo().all()
-  end
-
-  @doc """
-  Returns the total number of non-deleted items in a category that
-  match a search query, using the same matching rules as
-  `search_items_in_category/3`. Runs independently of `:limit`/`:offset`.
-
-  ## Examples
-
-      Catalogue.count_search_items_in_category(category_uuid, "panel")
-      #=> 42
-  """
-  def count_search_items_in_category(category_uuid, query) do
-    pattern = "%#{sanitize_like(query)}%"
-
-    from(i in Item,
-      where: i.category_uuid == ^category_uuid,
-      where: i.status != "deleted",
-      where:
-        ilike(i.name, ^pattern) or
-          ilike(i.description, ^pattern) or
-          ilike(i.sku, ^pattern) or
-          fragment("?::text ILIKE ?", i.data, ^pattern),
-      select: count(i.uuid)
-    )
-    |> repo().one()
-  end
-
-  defp sanitize_like(query) do
-    query
-    |> String.replace("\\", "\\\\")
-    |> String.replace("%", "\\%")
-    |> String.replace("_", "\\_")
-  end
+  defdelegate list_catalogue_rules(item_or_uuid), to: Rules
+  defdelegate catalogue_rule_map(item_or_uuid), to: Rules
+  defdelegate get_catalogue_rule(item_uuid, referenced_catalogue_uuid), to: Rules
+  defdelegate put_catalogue_rules(item, rules, opts \\ []), to: Rules
+  defdelegate list_items_referencing_catalogue(catalogue_uuid), to: Rules
+  defdelegate catalogue_reference_count(catalogue_uuid), to: Rules
+  defdelegate change_catalogue_rule(rule, attrs \\ %{}), to: Rules
+  defdelegate create_catalogue_rule(attrs, opts \\ []), to: Rules
+  defdelegate update_catalogue_rule(rule, attrs, opts \\ []), to: Rules
+  defdelegate delete_catalogue_rule(rule, opts \\ []), to: Rules
 
   # ═══════════════════════════════════════════════════════════════════
-  # Counts
+  # Search — see PhoenixKitCatalogue.Catalogue.Search
   # ═══════════════════════════════════════════════════════════════════
 
-  @doc """
-  Counts non-deleted items in a catalogue, including items without a category.
-  """
-  def item_count_for_catalogue(catalogue_uuid) do
-    from(i in Item,
-      where: i.catalogue_uuid == ^catalogue_uuid and i.status != "deleted"
-    )
-    |> repo().aggregate(:count)
-  end
-
-  @doc """
-  Returns a map of `%{catalogue_uuid => non_deleted_item_count}` for all catalogues.
-
-  Single-query batch version of `item_count_for_catalogue/1` — avoids N+1 when
-  displaying item counts alongside a catalogue list. Includes items both in
-  categories and directly attached to a catalogue (uncategorized).
-  """
-  def item_counts_by_catalogue do
-    from(i in Item,
-      where: i.status != "deleted" and not is_nil(i.catalogue_uuid),
-      group_by: i.catalogue_uuid,
-      select: {i.catalogue_uuid, count(i.uuid)}
-    )
-    |> repo().all()
-    |> Map.new()
-  end
-
-  @doc "Counts non-deleted categories for a catalogue."
-  def category_count_for_catalogue(catalogue_uuid) do
-    from(c in Category,
-      where: c.catalogue_uuid == ^catalogue_uuid and c.status != "deleted"
-    )
-    |> repo().aggregate(:count)
-  end
-
-  @doc """
-  Returns a map of `catalogue_uuid => non_deleted_category_count`, in a
-  single query. Useful for displaying category counts alongside a
-  catalogue list (e.g. in the import wizard's catalogue picker) without
-  N+1 lookups.
-  """
-  def category_counts_by_catalogue do
-    from(c in Category,
-      where: c.status != "deleted",
-      group_by: c.catalogue_uuid,
-      select: {c.catalogue_uuid, count(c.uuid)}
-    )
-    |> repo().all()
-    |> Map.new()
-  end
-
-  @doc """
-  Counts deleted items in a catalogue, including items without a category.
-  """
-  def deleted_item_count_for_catalogue(catalogue_uuid) do
-    from(i in Item,
-      where: i.catalogue_uuid == ^catalogue_uuid and i.status == "deleted"
-    )
-    |> repo().aggregate(:count)
-  end
-
-  @doc "Counts deleted categories for a catalogue."
-  def deleted_category_count_for_catalogue(catalogue_uuid) do
-    from(c in Category,
-      where: c.catalogue_uuid == ^catalogue_uuid and c.status == "deleted"
-    )
-    |> repo().aggregate(:count)
-  end
-
-  @doc """
-  Total count of deleted entities (items + categories) for a catalogue.
-
-  Used to determine whether to show the "Deleted" tab.
-  """
-  def deleted_count_for_catalogue(catalogue_uuid) do
-    deleted_item_count_for_catalogue(catalogue_uuid) +
-      deleted_category_count_for_catalogue(catalogue_uuid)
-  end
+  defdelegate search_items(query, opts \\ []), to: Search
+  defdelegate count_search_items(query, opts \\ []), to: Search
+  defdelegate search_items_in_catalogue(catalogue_uuid, query, opts \\ []), to: Search
+  defdelegate count_search_items_in_catalogue(catalogue_uuid, query), to: Search
+  defdelegate search_items_in_category(category_uuid, query, opts \\ []), to: Search
+  defdelegate count_search_items_in_category(category_uuid, query), to: Search
 
   # ═══════════════════════════════════════════════════════════════════
-  # Multilang helpers
+  # Counts — see PhoenixKitCatalogue.Catalogue.Counts
   # ═══════════════════════════════════════════════════════════════════
 
-  @doc """
-  Gets translated field data for a record in a specific language.
+  defdelegate item_count_for_catalogue(catalogue_uuid), to: Counts
+  defdelegate item_counts_by_catalogue(), to: Counts
+  defdelegate category_count_for_catalogue(catalogue_uuid), to: Counts
+  defdelegate category_counts_by_catalogue(), to: Counts
+  defdelegate deleted_item_count_for_catalogue(catalogue_uuid), to: Counts
+  defdelegate deleted_category_count_for_catalogue(catalogue_uuid), to: Counts
+  defdelegate deleted_count_for_catalogue(catalogue_uuid), to: Counts
 
-  Returns merged data (primary language as base + overrides for the requested language).
+  # ═══════════════════════════════════════════════════════════════════
+  # Multilang helpers — see PhoenixKitCatalogue.Catalogue.Translations
+  # ═══════════════════════════════════════════════════════════════════
 
-  ## Examples
+  defdelegate get_translation(record, lang_code), to: Translations
 
-      data = Catalogue.get_translation(catalogue, "ja")
-      # => %{"_name" => "キッチン", "_description" => "..."}
-  """
-  def get_translation(record, lang_code) do
-    Multilang.get_language_data(record.data || %{}, lang_code)
-  end
-
-  @doc """
-  Updates the multilang `data` field for a record with language-specific field data.
-
-  For primary language: stores ALL fields.
-  For secondary languages: stores only overrides (differences from primary).
-
-  The `update_fn` should be the entity's update function. It receives `(record, attrs)` for
-  2-arity or `(record, attrs, opts)` for 3-arity when activity logging opts are provided.
-
-  ## Examples
-
-      Catalogue.set_translation(catalogue, "ja", %{"_name" => "キッチン"}, &Catalogue.update_catalogue/2)
-      Catalogue.set_translation(catalogue, "ja", %{"_name" => "キッチン"}, &Catalogue.update_catalogue/3, actor_uuid: user.uuid)
-  """
-  def set_translation(record, lang_code, field_data, update_fn, opts \\ []) do
-    new_data = Multilang.put_language_data(record.data || %{}, lang_code, field_data)
-
-    if opts == [] do
-      update_fn.(record, %{data: new_data})
-    else
-      update_fn.(record, %{data: new_data}, opts)
-    end
-  end
+  defdelegate set_translation(record, lang_code, field_data, update_fn, opts \\ []),
+    to: Translations
 end

--- a/lib/phoenix_kit_catalogue/catalogue/activity_log.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/activity_log.ex
@@ -1,0 +1,51 @@
+defmodule PhoenixKitCatalogue.Catalogue.ActivityLog do
+  @moduledoc false
+  # Shared activity-logging helper used by every Catalogue submodule.
+  # Wraps `PhoenixKit.Activity.log/1` with the catalogue module key
+  # injected. External plugins must guard with `Code.ensure_loaded?/1`,
+  # which we do here once so callers don't have to repeat it.
+
+  require Logger
+
+  @module_key "catalogue"
+
+  @spec log(map()) :: :ok
+  def log(attrs) when is_map(attrs) do
+    # Activity logging must never crash the primary operation. If the
+    # Activity context raises (e.g. DB hiccup, misconfigured module), we
+    # swallow it with a Logger warning so the caller's mutation succeeds.
+    if Code.ensure_loaded?(PhoenixKit.Activity) do
+      try do
+        PhoenixKit.Activity.log(Map.put(attrs, :module, @module_key))
+      rescue
+        error ->
+          Logger.warning(
+            "PhoenixKitCatalogue activity log failed: #{Exception.message(error)} — attrs=#{inspect(Map.take(attrs, [:action, :resource_type, :resource_uuid]))}"
+          )
+      end
+    end
+
+    :ok
+  end
+
+  @doc """
+  Runs `op_fun` and, on `{:ok, _}`, logs an activity entry with `attrs_fun(record)`.
+  Collapses the repeating `case Repo.insert(...) do {:ok, x} = ok -> log; ok; ... end`
+  pattern that appears across every CRUD function.
+
+  `op_fun` should return `{:ok, record} | {:error, anything}`. `attrs_fun` is
+  only called on success and receives the inserted/updated record.
+  """
+  @spec with_log((-> {:ok, term()} | {:error, term()}), (term() -> map())) ::
+          {:ok, term()} | {:error, term()}
+  def with_log(op_fun, attrs_fun) when is_function(op_fun, 0) and is_function(attrs_fun, 1) do
+    case op_fun.() do
+      {:ok, record} = ok ->
+        log(attrs_fun.(record))
+        ok
+
+      {:error, _} = err ->
+        err
+    end
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/counts.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/counts.ex
@@ -1,0 +1,97 @@
+defmodule PhoenixKitCatalogue.Catalogue.Counts do
+  @moduledoc """
+  Catalogue-level item and category counts. Includes both per-uuid
+  helpers and single-query batch versions to avoid N+1 lookups when
+  rendering catalogue lists with associated item / category counts.
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue`.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias PhoenixKitCatalogue.Schemas.{Category, Item}
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+
+  @doc "Counts non-deleted items in a catalogue, including items without a category."
+  @spec item_count_for_catalogue(Ecto.UUID.t()) :: non_neg_integer()
+  def item_count_for_catalogue(catalogue_uuid) do
+    from(i in Item,
+      where: i.catalogue_uuid == ^catalogue_uuid and i.status != "deleted"
+    )
+    |> repo().aggregate(:count)
+  end
+
+  @doc """
+  Returns a map of `%{catalogue_uuid => non_deleted_item_count}` for all catalogues.
+
+  Single-query batch version of `item_count_for_catalogue/1` — avoids N+1 when
+  displaying item counts alongside a catalogue list. Includes items both in
+  categories and directly attached to a catalogue (uncategorized).
+  """
+  @spec item_counts_by_catalogue() :: %{Ecto.UUID.t() => non_neg_integer()}
+  def item_counts_by_catalogue do
+    from(i in Item,
+      where: i.status != "deleted" and not is_nil(i.catalogue_uuid),
+      group_by: i.catalogue_uuid,
+      select: {i.catalogue_uuid, count(i.uuid)}
+    )
+    |> repo().all()
+    |> Map.new()
+  end
+
+  @doc "Counts non-deleted categories for a catalogue."
+  @spec category_count_for_catalogue(Ecto.UUID.t()) :: non_neg_integer()
+  def category_count_for_catalogue(catalogue_uuid) do
+    from(c in Category,
+      where: c.catalogue_uuid == ^catalogue_uuid and c.status != "deleted"
+    )
+    |> repo().aggregate(:count)
+  end
+
+  @doc """
+  Returns a map of `catalogue_uuid => non_deleted_category_count`, in a
+  single query. Useful for displaying category counts alongside a
+  catalogue list (e.g. in the import wizard's catalogue picker) without
+  N+1 lookups.
+  """
+  @spec category_counts_by_catalogue() :: %{Ecto.UUID.t() => non_neg_integer()}
+  def category_counts_by_catalogue do
+    from(c in Category,
+      where: c.status != "deleted",
+      group_by: c.catalogue_uuid,
+      select: {c.catalogue_uuid, count(c.uuid)}
+    )
+    |> repo().all()
+    |> Map.new()
+  end
+
+  @doc "Counts deleted items in a catalogue, including items without a category."
+  @spec deleted_item_count_for_catalogue(Ecto.UUID.t()) :: non_neg_integer()
+  def deleted_item_count_for_catalogue(catalogue_uuid) do
+    from(i in Item,
+      where: i.catalogue_uuid == ^catalogue_uuid and i.status == "deleted"
+    )
+    |> repo().aggregate(:count)
+  end
+
+  @doc "Counts deleted categories for a catalogue."
+  @spec deleted_category_count_for_catalogue(Ecto.UUID.t()) :: non_neg_integer()
+  def deleted_category_count_for_catalogue(catalogue_uuid) do
+    from(c in Category,
+      where: c.catalogue_uuid == ^catalogue_uuid and c.status == "deleted"
+    )
+    |> repo().aggregate(:count)
+  end
+
+  @doc """
+  Total count of deleted entities (items + categories) for a catalogue.
+
+  Used to determine whether to show the "Deleted" tab.
+  """
+  @spec deleted_count_for_catalogue(Ecto.UUID.t()) :: non_neg_integer()
+  def deleted_count_for_catalogue(catalogue_uuid) do
+    deleted_item_count_for_catalogue(catalogue_uuid) +
+      deleted_category_count_for_catalogue(catalogue_uuid)
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/helpers.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/helpers.ex
@@ -1,0 +1,65 @@
+defmodule PhoenixKitCatalogue.Catalogue.Helpers do
+  @moduledoc false
+  # Cross-section helpers used by multiple Catalogue submodules.
+  # Right now: polymorphic atom/string-keyed map accessors so the same
+  # helpers work on Phoenix form params (string-keyed) and IEx /
+  # internal-call attrs (atom-keyed).
+
+  @doc "True when `attrs` has the key as either an atom or its string form."
+  @spec has_attr?(map(), atom()) :: boolean()
+  def has_attr?(attrs, key) when is_map(attrs) and is_atom(key) do
+    Map.has_key?(attrs, key) or Map.has_key?(attrs, to_string(key))
+  end
+
+  @doc """
+  Reads `attrs[key]` falling back to `attrs[to_string(key)]`. Returns `nil`
+  when neither is present.
+  """
+  @spec fetch_attr(map(), atom()) :: term() | nil
+  def fetch_attr(attrs, key) when is_map(attrs) and is_atom(key) do
+    case Map.fetch(attrs, key) do
+      {:ok, value} -> value
+      :error -> Map.get(attrs, to_string(key))
+    end
+  end
+
+  @doc """
+  Writes a value into `attrs` under whichever key form is already present.
+  Falls back to matching the rest of the map's key style on a fresh insert
+  so that mixed-key maps (which would later trip `Ecto.Changeset.cast/4`)
+  don't get introduced here.
+  """
+  @spec put_attr(map(), atom(), term()) :: map()
+  def put_attr(attrs, key, value) when is_map(attrs) and is_atom(key) do
+    cond do
+      Map.has_key?(attrs, key) ->
+        Map.put(attrs, key, value)
+
+      Map.has_key?(attrs, to_string(key)) ->
+        Map.put(attrs, to_string(key), value)
+
+      string_keyed?(attrs) ->
+        Map.put(attrs, to_string(key), value)
+
+      true ->
+        Map.put(attrs, key, value)
+    end
+  end
+
+  @doc "True when the first key in `attrs` is a binary string."
+  @spec string_keyed?(map()) :: boolean()
+  def string_keyed?(attrs) when map_size(attrs) == 0, do: false
+  def string_keyed?(attrs) when is_map(attrs), do: attrs |> Map.keys() |> hd() |> is_binary()
+
+  @doc """
+  Escapes Postgres `LIKE`/`ILIKE` metacharacters so user-supplied search
+  text is matched literally. Handles `\\`, `%`, and `_`.
+  """
+  @spec sanitize_like(String.t()) :: String.t()
+  def sanitize_like(query) when is_binary(query) do
+    query
+    |> String.replace("\\", "\\\\")
+    |> String.replace("%", "\\%")
+    |> String.replace("_", "\\_")
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/links.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/links.ex
@@ -1,0 +1,189 @@
+defmodule PhoenixKitCatalogue.Catalogue.Links do
+  @moduledoc """
+  Manufacturer ↔ Supplier many-to-many links.
+
+  Add and remove individual links via `link_*`/`unlink_*`; sync the
+  full set for one side via `sync_*`. Bulk syncs run inside a single
+  transaction and emit one summary activity entry (added + removed
+  counts).
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue`.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias PhoenixKitCatalogue.Catalogue.{ActivityLog, PubSub}
+  alias PhoenixKitCatalogue.Schemas.{Manufacturer, ManufacturerSupplier, Supplier}
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+
+  @doc """
+  Creates a many-to-many link between a manufacturer and a supplier.
+
+  Returns `{:error, changeset}` if the link already exists (unique constraint).
+  """
+  @spec link_manufacturer_supplier(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, ManufacturerSupplier.t()}
+          | {:error, Ecto.Changeset.t(ManufacturerSupplier.t())}
+  def link_manufacturer_supplier(manufacturer_uuid, supplier_uuid) do
+    %ManufacturerSupplier{}
+    |> ManufacturerSupplier.changeset(%{
+      manufacturer_uuid: manufacturer_uuid,
+      supplier_uuid: supplier_uuid
+    })
+    |> repo().insert()
+  end
+
+  @doc """
+  Removes the link between a manufacturer and a supplier.
+
+  Returns `{:error, :not_found}` if the link doesn't exist.
+  """
+  @spec unlink_manufacturer_supplier(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, ManufacturerSupplier.t()}
+          | {:error, :not_found | Ecto.Changeset.t(ManufacturerSupplier.t())}
+  def unlink_manufacturer_supplier(manufacturer_uuid, supplier_uuid) do
+    query =
+      from(ms in ManufacturerSupplier,
+        where: ms.manufacturer_uuid == ^manufacturer_uuid and ms.supplier_uuid == ^supplier_uuid
+      )
+
+    case repo().one(query) do
+      nil -> {:error, :not_found}
+      record -> repo().delete(record)
+    end
+  end
+
+  @doc "Lists all suppliers linked to a manufacturer, ordered by name."
+  @spec list_suppliers_for_manufacturer(Ecto.UUID.t()) :: [Supplier.t()]
+  def list_suppliers_for_manufacturer(manufacturer_uuid) do
+    from(s in Supplier,
+      join: ms in ManufacturerSupplier,
+      on: ms.supplier_uuid == s.uuid,
+      where: ms.manufacturer_uuid == ^manufacturer_uuid,
+      order_by: [asc: s.name]
+    )
+    |> repo().all()
+  end
+
+  @doc "Lists all manufacturers linked to a supplier, ordered by name."
+  @spec list_manufacturers_for_supplier(Ecto.UUID.t()) :: [Manufacturer.t()]
+  def list_manufacturers_for_supplier(supplier_uuid) do
+    from(m in Manufacturer,
+      join: ms in ManufacturerSupplier,
+      on: ms.manufacturer_uuid == m.uuid,
+      where: ms.supplier_uuid == ^supplier_uuid,
+      order_by: [asc: m.name]
+    )
+    |> repo().all()
+  end
+
+  @doc "Returns a list of supplier UUIDs linked to a manufacturer."
+  @spec linked_supplier_uuids(Ecto.UUID.t()) :: [Ecto.UUID.t()]
+  def linked_supplier_uuids(manufacturer_uuid) do
+    from(ms in ManufacturerSupplier,
+      where: ms.manufacturer_uuid == ^manufacturer_uuid,
+      select: ms.supplier_uuid
+    )
+    |> repo().all()
+  end
+
+  @doc "Returns a list of manufacturer UUIDs linked to a supplier."
+  @spec linked_manufacturer_uuids(Ecto.UUID.t()) :: [Ecto.UUID.t()]
+  def linked_manufacturer_uuids(supplier_uuid) do
+    from(ms in ManufacturerSupplier,
+      where: ms.supplier_uuid == ^supplier_uuid,
+      select: ms.manufacturer_uuid
+    )
+    |> repo().all()
+  end
+
+  @doc """
+  Syncs the supplier links for a manufacturer to match the given list of supplier UUIDs.
+
+  Adds missing links and removes extra ones via set difference.
+  Returns `{:ok, :synced}` on success or `{:error, reason}` on the first failure.
+  """
+  @spec sync_manufacturer_suppliers(Ecto.UUID.t(), [Ecto.UUID.t()], keyword()) ::
+          {:ok, :synced} | {:error, term()}
+  def sync_manufacturer_suppliers(manufacturer_uuid, supplier_uuids, opts \\ [])
+      when is_list(supplier_uuids) do
+    current = linked_supplier_uuids(manufacturer_uuid) |> MapSet.new()
+    desired = MapSet.new(supplier_uuids)
+    added = MapSet.difference(desired, current)
+    removed = MapSet.difference(current, desired)
+
+    result =
+      repo().transaction(fn ->
+        Enum.each(added, &ok_or_rollback(link_manufacturer_supplier(manufacturer_uuid, &1)))
+        Enum.each(removed, &ok_or_rollback(unlink_manufacturer_supplier(manufacturer_uuid, &1)))
+        :synced
+      end)
+
+    with {:ok, :synced} <- result do
+      if MapSet.size(added) > 0 or MapSet.size(removed) > 0 do
+        ActivityLog.log(%{
+          action: "manufacturer.suppliers_synced",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "manufacturer",
+          resource_uuid: manufacturer_uuid,
+          metadata: %{
+            "added_count" => MapSet.size(added),
+            "removed_count" => MapSet.size(removed)
+          }
+        })
+
+        PubSub.broadcast(:links, manufacturer_uuid)
+      end
+
+      result
+    end
+  end
+
+  @doc """
+  Syncs the manufacturer links for a supplier to match the given list of manufacturer UUIDs.
+
+  Adds missing links and removes extra ones via set difference.
+  Returns `{:ok, :synced}` on success or `{:error, reason}` on the first failure.
+  """
+  @spec sync_supplier_manufacturers(Ecto.UUID.t(), [Ecto.UUID.t()], keyword()) ::
+          {:ok, :synced} | {:error, term()}
+  def sync_supplier_manufacturers(supplier_uuid, manufacturer_uuids, opts \\ [])
+      when is_list(manufacturer_uuids) do
+    current = linked_manufacturer_uuids(supplier_uuid) |> MapSet.new()
+    desired = MapSet.new(manufacturer_uuids)
+    added = MapSet.difference(desired, current)
+    removed = MapSet.difference(current, desired)
+
+    result =
+      repo().transaction(fn ->
+        Enum.each(added, &ok_or_rollback(link_manufacturer_supplier(&1, supplier_uuid)))
+        Enum.each(removed, &ok_or_rollback(unlink_manufacturer_supplier(&1, supplier_uuid)))
+        :synced
+      end)
+
+    with {:ok, :synced} <- result do
+      if MapSet.size(added) > 0 or MapSet.size(removed) > 0 do
+        ActivityLog.log(%{
+          action: "supplier.manufacturers_synced",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "supplier",
+          resource_uuid: supplier_uuid,
+          metadata: %{
+            "added_count" => MapSet.size(added),
+            "removed_count" => MapSet.size(removed)
+          }
+        })
+
+        PubSub.broadcast(:links, supplier_uuid)
+      end
+
+      result
+    end
+  end
+
+  defp ok_or_rollback({:ok, _}), do: :ok
+  defp ok_or_rollback({:error, reason}), do: repo().rollback(reason)
+end

--- a/lib/phoenix_kit_catalogue/catalogue/manufacturers.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/manufacturers.ex
@@ -1,0 +1,141 @@
+defmodule PhoenixKitCatalogue.Catalogue.Manufacturers do
+  @moduledoc """
+  Manufacturers — company directory used as the source of items.
+
+  Hard-deletes only (manufacturers are reference data, not user content).
+  Status field is `"active"` / `"inactive"`; inactive manufacturers
+  remain in the DB but are filtered from item dropdowns.
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue` via
+  `defdelegate`, so callers can keep using the canonical context module.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias PhoenixKitCatalogue.Catalogue.{ActivityLog, PubSub}
+  alias PhoenixKitCatalogue.Schemas.Manufacturer
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+
+  @doc """
+  Lists all manufacturers, ordered by name.
+
+  ## Options
+
+    * `:status` — filter by status (e.g. `"active"`, `"inactive"`).
+      When nil (default), returns all manufacturers.
+  """
+  @spec list_manufacturers(keyword()) :: [Manufacturer.t()]
+  def list_manufacturers(opts \\ []) do
+    query = from(m in Manufacturer, order_by: [asc: :name])
+
+    query =
+      case Keyword.get(opts, :status) do
+        nil -> query
+        status -> where(query, [m], m.status == ^status)
+      end
+
+    repo().all(query)
+  end
+
+  @doc "Fetches a manufacturer by UUID. Returns `nil` if not found."
+  @spec get_manufacturer(Ecto.UUID.t()) :: Manufacturer.t() | nil
+  def get_manufacturer(uuid), do: repo().get(Manufacturer, uuid)
+
+  @doc "Fetches a manufacturer by UUID. Raises `Ecto.NoResultsError` if not found."
+  @spec get_manufacturer!(Ecto.UUID.t()) :: Manufacturer.t()
+  def get_manufacturer!(uuid), do: repo().get!(Manufacturer, uuid)
+
+  @doc """
+  Creates a manufacturer.
+
+  ## Required attributes
+
+    * `:name` — manufacturer name (1-255 chars)
+
+  ## Optional attributes
+
+    * `:description`, `:website`, `:contact_info`, `:logo_url`, `:notes`
+    * `:status` — `"active"` (default) or `"inactive"`
+    * `:data` — flexible JSON map
+  """
+  @spec create_manufacturer(map(), keyword()) ::
+          {:ok, Manufacturer.t()} | {:error, Ecto.Changeset.t(Manufacturer.t())}
+  def create_manufacturer(attrs, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> %Manufacturer{} |> Manufacturer.changeset(attrs) |> repo().insert() end,
+        fn manufacturer ->
+          %{
+            action: "manufacturer.created",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "manufacturer",
+            resource_uuid: manufacturer.uuid,
+            metadata: %{"name" => manufacturer.name}
+          }
+        end
+      )
+
+    with {:ok, manufacturer} <- result do
+      PubSub.broadcast(:manufacturer, manufacturer.uuid)
+      {:ok, manufacturer}
+    end
+  end
+
+  @doc "Updates a manufacturer with the given attributes."
+  @spec update_manufacturer(Manufacturer.t(), map(), keyword()) ::
+          {:ok, Manufacturer.t()} | {:error, Ecto.Changeset.t(Manufacturer.t())}
+  def update_manufacturer(%Manufacturer{} = manufacturer, attrs, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> manufacturer |> Manufacturer.changeset(attrs) |> repo().update() end,
+        fn updated ->
+          %{
+            action: "manufacturer.updated",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "manufacturer",
+            resource_uuid: updated.uuid,
+            metadata: %{"name" => updated.name}
+          }
+        end
+      )
+
+    with {:ok, updated} <- result do
+      PubSub.broadcast(:manufacturer, updated.uuid)
+      {:ok, updated}
+    end
+  end
+
+  @doc "Hard-deletes a manufacturer from the database."
+  @spec delete_manufacturer(Manufacturer.t(), keyword()) ::
+          {:ok, Manufacturer.t()} | {:error, Ecto.Changeset.t(Manufacturer.t())}
+  def delete_manufacturer(%Manufacturer{} = manufacturer, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> repo().delete(manufacturer) end,
+        fn _ ->
+          %{
+            action: "manufacturer.deleted",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "manufacturer",
+            resource_uuid: manufacturer.uuid,
+            metadata: %{"name" => manufacturer.name}
+          }
+        end
+      )
+
+    with {:ok, deleted} <- result do
+      PubSub.broadcast(:manufacturer, manufacturer.uuid)
+      {:ok, deleted}
+    end
+  end
+
+  @doc "Returns a changeset for tracking manufacturer changes."
+  @spec change_manufacturer(Manufacturer.t(), map()) :: Ecto.Changeset.t(Manufacturer.t())
+  def change_manufacturer(%Manufacturer{} = manufacturer, attrs \\ %{}) do
+    Manufacturer.changeset(manufacturer, attrs)
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/pub_sub.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/pub_sub.ex
@@ -1,0 +1,70 @@
+defmodule PhoenixKitCatalogue.Catalogue.PubSub do
+  @moduledoc """
+  Real-time fan-out for catalogue mutations.
+
+  Every successful write in the Catalogue context broadcasts a small
+  `{:catalogue_data_changed, kind, uuid}` event to a single shared
+  topic. List/detail LiveViews `subscribe/0` once in `mount/3` (after
+  `connected?(socket)`) and re-fetch the affected slice on any event,
+  so two admins editing the same data converge without manual refresh.
+
+  Payloads are intentionally minimal — UUID + kind, no record data —
+  to (a) avoid leaking field-level changes through PubSub, and (b)
+  keep the consumer in charge of how much to re-load (single row vs
+  full list).
+
+  Subscriptions are cleaned up automatically when the LV process
+  terminates; callers don't need to unsubscribe.
+  """
+
+  @topic "phoenix_kit_catalogue"
+
+  @typedoc "Resource kind that mutated."
+  @type kind ::
+          :catalogue
+          | :category
+          | :item
+          | :manufacturer
+          | :supplier
+          | :smart_rule
+          | :links
+
+  @typedoc "Event message format for `handle_info/2`."
+  @type event :: {:catalogue_data_changed, kind(), Ecto.UUID.t() | nil}
+
+  @doc "Returns the canonical topic name. Useful for tests."
+  @spec topic() :: String.t()
+  def topic, do: @topic
+
+  @doc """
+  Subscribes the current process to the catalogue PubSub topic.
+
+  Call from `mount/3` guarded by `connected?(socket)` so the
+  disconnected (initial render) pass doesn't subscribe and never
+  unsubscribes. Do this **after** any subscription requirements but
+  **before** the initial DB load to avoid a race where a write between
+  the load and the subscribe leaves the UI stale.
+  """
+  @spec subscribe() :: :ok | {:error, term()}
+  def subscribe do
+    if Code.ensure_loaded?(PhoenixKit.PubSubHelper) do
+      PhoenixKit.PubSubHelper.subscribe(@topic)
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Broadcasts a `{:catalogue_data_changed, kind, uuid}` event after a
+  successful write. Pass `nil` for `uuid` when the change isn't tied
+  to a specific record (e.g. a bulk link sync).
+  """
+  @spec broadcast(kind(), Ecto.UUID.t() | nil) :: :ok
+  def broadcast(kind, uuid) when is_atom(kind) do
+    if Code.ensure_loaded?(PhoenixKit.PubSubHelper) do
+      PhoenixKit.PubSubHelper.broadcast(@topic, {:catalogue_data_changed, kind, uuid})
+    end
+
+    :ok
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/rules.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/rules.ex
@@ -1,0 +1,342 @@
+defmodule PhoenixKitCatalogue.Catalogue.Rules do
+  @moduledoc """
+  Smart-catalogue rules — one row per `(item, referenced_catalogue)` pair.
+
+  Items in a smart catalogue (`kind: "smart"`) reference other catalogues
+  with a value + unit. The rule row stores the user's intent; consumers
+  evaluate the math, and `CatalogueRule.effective/2` resolves null
+  `value` / `unit` to the parent item's `default_value` / `default_unit`.
+
+  Provides both the bulk replace-all flow (`put_catalogue_rules/3`,
+  preferred when editing the full set in a form) and surgical single-rule
+  CRUD (`create_*` / `update_*` / `delete_*`) for CLI / external use.
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue`.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias PhoenixKitCatalogue.Catalogue.{ActivityLog, Helpers, PubSub}
+  alias PhoenixKitCatalogue.Schemas.{Catalogue, CatalogueRule, Item}
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+
+  @doc """
+  Lists the rules attached to an item, ordered by `position` then by the
+  referenced catalogue's name. The `:referenced_catalogue` association
+  is preloaded so UIs can render the catalogue name + status without a
+  second query.
+
+  Smart items are the only ones that should have rules; a standard item
+  simply returns `[]` unless someone put rules on it manually.
+  """
+  @spec list_catalogue_rules(Item.t() | Ecto.UUID.t()) :: [CatalogueRule.t()]
+  def list_catalogue_rules(%Item{uuid: uuid}), do: list_catalogue_rules(uuid)
+
+  def list_catalogue_rules(item_uuid) when is_binary(item_uuid) do
+    from(r in CatalogueRule,
+      join: c in Catalogue,
+      on: r.referenced_catalogue_uuid == c.uuid,
+      where: r.item_uuid == ^item_uuid,
+      order_by: [asc: r.position, asc: c.name],
+      preload: [referenced_catalogue: c]
+    )
+    |> repo().all()
+  end
+
+  @doc """
+  Returns the rules for an item as `%{referenced_catalogue_uuid => rule}`.
+
+  Convenient for picker UIs that render every available catalogue row
+  and need O(1) lookup for "is this one checked?". Preloads the
+  referenced catalogue on each rule.
+  """
+  @spec catalogue_rule_map(Item.t() | Ecto.UUID.t()) :: %{Ecto.UUID.t() => CatalogueRule.t()}
+  def catalogue_rule_map(item_or_uuid) do
+    item_or_uuid
+    |> list_catalogue_rules()
+    |> Map.new(fn %CatalogueRule{referenced_catalogue_uuid: uuid} = rule -> {uuid, rule} end)
+  end
+
+  @doc """
+  Fetches a single rule by `{item_uuid, referenced_catalogue_uuid}`.
+  Returns `nil` if not found. Does not preload the referenced catalogue.
+  """
+  @spec get_catalogue_rule(Ecto.UUID.t(), Ecto.UUID.t()) :: CatalogueRule.t() | nil
+  def get_catalogue_rule(item_uuid, referenced_catalogue_uuid) do
+    repo().get_by(CatalogueRule,
+      item_uuid: item_uuid,
+      referenced_catalogue_uuid: referenced_catalogue_uuid
+    )
+  end
+
+  @doc """
+  Atomic replace-all for an item's rules. See moduledoc for context.
+  """
+  @spec put_catalogue_rules(Item.t(), [map()], keyword()) ::
+          {:ok, [CatalogueRule.t()]}
+          | {:error, {:duplicate_referenced_catalogue, Ecto.UUID.t() | nil}}
+          | {:error, Ecto.Changeset.t(CatalogueRule.t())}
+  def put_catalogue_rules(%Item{} = item, rules, opts \\ []) when is_list(rules) do
+    case detect_duplicate_references(rules) do
+      {:duplicate, uuid} ->
+        {:error, {:duplicate_referenced_catalogue, uuid}}
+
+      :ok ->
+        do_put_catalogue_rules(item, rules, opts)
+    end
+  end
+
+  defp do_put_catalogue_rules(item, rules, opts) do
+    existing = list_catalogue_rules(item) |> Map.new(&{&1.referenced_catalogue_uuid, &1})
+
+    incoming_by_uuid =
+      Map.new(rules, &{Helpers.fetch_attr(&1, :referenced_catalogue_uuid), &1})
+
+    {to_delete, to_keep} =
+      Map.split(existing, Map.keys(existing) -- Map.keys(incoming_by_uuid))
+
+    Ecto.Multi.new()
+    |> delete_removed_rules(to_delete)
+    |> upsert_rules(item, rules, to_keep)
+    |> repo().transaction()
+    |> case do
+      {:ok, results} ->
+        {added, updated} = count_rule_ops(results)
+        removed = map_size(to_delete)
+
+        ActivityLog.log(%{
+          action: "smart_rules.synced",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "item",
+          resource_uuid: item.uuid,
+          metadata: %{
+            "added" => added,
+            "updated" => updated,
+            "removed" => removed,
+            "total" => length(rules)
+          }
+        })
+
+        PubSub.broadcast(:smart_rule, item.uuid)
+
+        {:ok, list_catalogue_rules(item)}
+
+      {:error, _step, changeset, _changes} ->
+        {:error, changeset}
+    end
+  end
+
+  defp detect_duplicate_references(rules) do
+    rules
+    |> Enum.map(&Helpers.fetch_attr(&1, :referenced_catalogue_uuid))
+    |> Enum.reduce_while(MapSet.new(), fn uuid, seen ->
+      cond do
+        is_nil(uuid) -> {:halt, {:duplicate, nil}}
+        MapSet.member?(seen, uuid) -> {:halt, {:duplicate, uuid}}
+        true -> {:cont, MapSet.put(seen, uuid)}
+      end
+    end)
+    |> case do
+      {:duplicate, _} = err -> err
+      _ -> :ok
+    end
+  end
+
+  defp delete_removed_rules(multi, to_delete) do
+    Enum.reduce(to_delete, multi, fn {uuid, rule}, multi ->
+      Ecto.Multi.delete(multi, {:delete, uuid}, rule)
+    end)
+  end
+
+  defp upsert_rules(multi, item, rules, to_keep) do
+    rules
+    |> Enum.with_index()
+    |> Enum.reduce(multi, fn {rule_attrs, idx}, multi ->
+      referenced_uuid = Helpers.fetch_attr(rule_attrs, :referenced_catalogue_uuid)
+      attrs = rule_attrs_with_item_and_position(rule_attrs, item, idx)
+
+      case Map.get(to_keep, referenced_uuid) do
+        nil ->
+          changeset = CatalogueRule.changeset(%CatalogueRule{}, attrs)
+          Ecto.Multi.insert(multi, {:insert, referenced_uuid}, changeset)
+
+        %CatalogueRule{} = existing ->
+          changeset = CatalogueRule.changeset(existing, attrs)
+          Ecto.Multi.update(multi, {:update, referenced_uuid}, changeset)
+      end
+    end)
+  end
+
+  # Merges :item_uuid (from the item) and defaults a missing :position
+  # to the rule's index in the incoming list.
+  defp rule_attrs_with_item_and_position(rule_attrs, item, idx) do
+    rule_attrs
+    |> normalize_rule_attrs()
+    |> Map.put(:item_uuid, item.uuid)
+    |> Map.put_new(:position, idx)
+  end
+
+  # Closed-set string-key normalizer. Unknown string keys are dropped
+  # (rather than raising via `String.to_existing_atom/1`) so a future
+  # caller that adds an unrecognized field gets a clean changeset
+  # validation error instead of a confusing ArgumentError.
+  @rule_known_keys ~w(item_uuid referenced_catalogue_uuid value unit position)
+  defp normalize_rule_attrs(attrs) when is_map(attrs) do
+    Enum.reduce(attrs, %{}, fn
+      {k, v}, acc when is_atom(k) ->
+        Map.put(acc, k, v)
+
+      {k, v}, acc when is_binary(k) and k in @rule_known_keys ->
+        Map.put(acc, String.to_atom(k), v)
+
+      {_k, _v}, acc ->
+        acc
+    end)
+  end
+
+  defp count_rule_ops(results) when is_map(results) do
+    Enum.reduce(results, {0, 0}, fn
+      {{:insert, _}, _}, {ins, upd} -> {ins + 1, upd}
+      {{:update, _}, _}, {ins, upd} -> {ins, upd + 1}
+      _, acc -> acc
+    end)
+  end
+
+  @doc """
+  Lists non-deleted smart items that reference a given catalogue.
+
+  Useful for warning-before-delete flows: "This catalogue is referenced
+  by 3 smart items — deleting it cascades to those rules."
+
+  Preloads the parent catalogue so the UI can render "Services / Delivery".
+  """
+  @spec list_items_referencing_catalogue(Ecto.UUID.t()) :: [Item.t()]
+  def list_items_referencing_catalogue(catalogue_uuid) do
+    from(r in CatalogueRule,
+      join: i in Item,
+      on: r.item_uuid == i.uuid,
+      where: r.referenced_catalogue_uuid == ^catalogue_uuid,
+      where: i.status != "deleted",
+      order_by: [asc: i.name, asc: i.uuid],
+      select: i,
+      distinct: true,
+      preload: [:catalogue]
+    )
+    |> repo().all()
+  end
+
+  @doc """
+  Returns the count of rules referencing a given catalogue (non-deleted
+  items only). Cheaper than `list_items_referencing_catalogue/1` when
+  you just need a badge number.
+  """
+  @spec catalogue_reference_count(Ecto.UUID.t()) :: non_neg_integer()
+  def catalogue_reference_count(catalogue_uuid) do
+    from(r in CatalogueRule,
+      join: i in Item,
+      on: r.item_uuid == i.uuid,
+      where: r.referenced_catalogue_uuid == ^catalogue_uuid,
+      where: i.status != "deleted"
+    )
+    |> repo().aggregate(:count)
+  end
+
+  @doc "Returns a changeset for tracking a single rule's changes."
+  @spec change_catalogue_rule(CatalogueRule.t(), map()) :: Ecto.Changeset.t(CatalogueRule.t())
+  def change_catalogue_rule(%CatalogueRule{} = rule, attrs \\ %{}) do
+    CatalogueRule.changeset(rule, attrs)
+  end
+
+  @doc """
+  Inserts a single rule. Prefer `put_catalogue_rules/3` for managing an
+  item's full set of rules; this function exists for surgical edits.
+  """
+  @spec create_catalogue_rule(map(), keyword()) ::
+          {:ok, CatalogueRule.t()} | {:error, Ecto.Changeset.t(CatalogueRule.t())}
+  def create_catalogue_rule(attrs, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn ->
+          %CatalogueRule{}
+          |> CatalogueRule.changeset(normalize_rule_attrs(attrs))
+          |> repo().insert()
+        end,
+        fn rule ->
+          %{
+            action: "smart_rule.created",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "smart_rule",
+            resource_uuid: rule.uuid,
+            metadata: %{
+              "item_uuid" => rule.item_uuid,
+              "referenced_catalogue_uuid" => rule.referenced_catalogue_uuid
+            }
+          }
+        end
+      )
+
+    with {:ok, rule} <- result do
+      PubSub.broadcast(:smart_rule, rule.item_uuid)
+      {:ok, rule}
+    end
+  end
+
+  @doc "Updates a single rule's `value`/`unit`/`position`."
+  @spec update_catalogue_rule(CatalogueRule.t(), map(), keyword()) ::
+          {:ok, CatalogueRule.t()} | {:error, Ecto.Changeset.t(CatalogueRule.t())}
+  def update_catalogue_rule(%CatalogueRule{} = rule, attrs, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> rule |> CatalogueRule.changeset(normalize_rule_attrs(attrs)) |> repo().update() end,
+        fn updated ->
+          %{
+            action: "smart_rule.updated",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "smart_rule",
+            resource_uuid: updated.uuid,
+            metadata: %{
+              "item_uuid" => updated.item_uuid,
+              "referenced_catalogue_uuid" => updated.referenced_catalogue_uuid
+            }
+          }
+        end
+      )
+
+    with {:ok, updated} <- result do
+      PubSub.broadcast(:smart_rule, updated.item_uuid)
+      {:ok, updated}
+    end
+  end
+
+  @doc "Deletes a single rule."
+  @spec delete_catalogue_rule(CatalogueRule.t(), keyword()) ::
+          {:ok, CatalogueRule.t()} | {:error, Ecto.Changeset.t(CatalogueRule.t())}
+  def delete_catalogue_rule(%CatalogueRule{} = rule, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> repo().delete(rule) end,
+        fn deleted ->
+          %{
+            action: "smart_rule.deleted",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "smart_rule",
+            resource_uuid: deleted.uuid,
+            metadata: %{
+              "item_uuid" => deleted.item_uuid,
+              "referenced_catalogue_uuid" => deleted.referenced_catalogue_uuid
+            }
+          }
+        end
+      )
+
+    with {:ok, deleted} <- result do
+      PubSub.broadcast(:smart_rule, deleted.item_uuid)
+      {:ok, deleted}
+    end
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/search.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/search.ex
@@ -1,0 +1,134 @@
+defmodule PhoenixKitCatalogue.Catalogue.Search do
+  @moduledoc """
+  Item search — global, per-catalogue, and per-category, with optional
+  scope composition (`catalogue_uuids` AND `category_uuids`).
+
+  Matches case-insensitively against `name`, `description`, `sku`, and
+  the multilang `data` JSONB. Excludes items in deleted catalogues or
+  deleted categories. Uncategorized items are included unless a
+  `:category_uuids` filter narrows the search.
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue`.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias PhoenixKitCatalogue.Catalogue.Helpers
+  alias PhoenixKitCatalogue.Schemas.{Catalogue, Category, Item}
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+
+  @doc """
+  Searches items with flexible scope.
+
+  ## Options
+
+    * `:catalogue_uuids` — list of catalogue UUIDs to scope to. `nil` or `[]` = all.
+    * `:category_uuids` — list of category UUIDs to scope to. `nil` or `[]` = all + uncategorized.
+    * `:limit` — max results (default 50).
+    * `:offset` — paging offset (default 0).
+  """
+  @spec search_items(String.t(), keyword()) :: [Item.t()]
+  def search_items(query, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
+
+    query
+    |> search_items_base(opts)
+    |> order_by([i, _cat, _c], asc: i.name, asc: i.uuid)
+    |> limit(^limit)
+    |> offset(^offset)
+    |> preload([:catalogue, category: :catalogue, manufacturer: []])
+    |> repo().all()
+  end
+
+  @doc """
+  Returns the total number of items matching `search_items/2`'s filters.
+  Ignores `:limit`/`:offset`. Same scope opts as `search_items/2`.
+  """
+  @spec count_search_items(String.t(), keyword()) :: non_neg_integer()
+  def count_search_items(query, opts \\ []) do
+    query
+    |> search_items_base(opts)
+    |> select([i], count(i.uuid))
+    |> repo().one()
+  end
+
+  @doc """
+  Searches items within a specific catalogue. Convenience wrapper
+  around `search_items/2` with `catalogue_uuids: [catalogue_uuid]`,
+  but orders by category position first (then item name) for a stable
+  walk through a catalogue's categories.
+  """
+  @spec search_items_in_catalogue(Ecto.UUID.t(), String.t(), keyword()) :: [Item.t()]
+  def search_items_in_catalogue(catalogue_uuid, query, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
+    opts = Keyword.put(opts, :catalogue_uuids, [catalogue_uuid])
+
+    query
+    |> search_items_base(opts)
+    |> order_by([i, _cat, c], asc_nulls_last: c.position, asc: i.name, asc: i.uuid)
+    |> limit(^limit)
+    |> offset(^offset)
+    |> preload([:catalogue, category: :catalogue, manufacturer: []])
+    |> repo().all()
+  end
+
+  @doc "Total match count for `search_items_in_catalogue/3`."
+  @spec count_search_items_in_catalogue(Ecto.UUID.t(), String.t()) :: non_neg_integer()
+  def count_search_items_in_catalogue(catalogue_uuid, query) do
+    count_search_items(query, catalogue_uuids: [catalogue_uuid])
+  end
+
+  @doc """
+  Searches items within a specific category. Convenience wrapper around
+  `search_items/2` with `category_uuids: [category_uuid]`.
+  """
+  @spec search_items_in_category(Ecto.UUID.t(), String.t(), keyword()) :: [Item.t()]
+  def search_items_in_category(category_uuid, query, opts \\ []) do
+    opts = Keyword.put(opts, :category_uuids, [category_uuid])
+    search_items(query, opts)
+  end
+
+  @doc "Total match count for `search_items_in_category/3`."
+  @spec count_search_items_in_category(Ecto.UUID.t(), String.t()) :: non_neg_integer()
+  def count_search_items_in_category(category_uuid, query) do
+    count_search_items(query, category_uuids: [category_uuid])
+  end
+
+  # Builds the shared base query (joins + status + text-match + scope filters).
+  defp search_items_base(query_str, opts) do
+    pattern = "%#{Helpers.sanitize_like(query_str)}%"
+    catalogue_uuids = opts[:catalogue_uuids]
+    category_uuids = opts[:category_uuids]
+
+    from(i in Item,
+      join: cat in Catalogue,
+      on: i.catalogue_uuid == cat.uuid,
+      left_join: c in Category,
+      on: i.category_uuid == c.uuid,
+      where: i.status != "deleted" and cat.status != "deleted",
+      where: is_nil(c.uuid) or c.status != "deleted",
+      where:
+        ilike(i.name, ^pattern) or
+          ilike(i.description, ^pattern) or
+          ilike(i.sku, ^pattern) or
+          fragment("?::text ILIKE ?", i.data, ^pattern)
+    )
+    |> maybe_scope_catalogues(catalogue_uuids)
+    |> maybe_scope_categories(category_uuids)
+  end
+
+  defp maybe_scope_catalogues(query, uuids) when uuids in [nil, []], do: query
+
+  defp maybe_scope_catalogues(query, uuids) when is_list(uuids) do
+    from([i, _cat, _c] in query, where: i.catalogue_uuid in ^uuids)
+  end
+
+  defp maybe_scope_categories(query, uuids) when uuids in [nil, []], do: query
+
+  defp maybe_scope_categories(query, uuids) when is_list(uuids) do
+    from([i, _cat, _c] in query, where: i.category_uuid in ^uuids)
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/suppliers.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/suppliers.ex
@@ -1,0 +1,139 @@
+defmodule PhoenixKitCatalogue.Catalogue.Suppliers do
+  @moduledoc """
+  Suppliers — delivery companies linked to manufacturers via the
+  many-to-many `phoenix_kit_cat_manufacturer_suppliers` table.
+
+  Same lifecycle as manufacturers: hard-delete only, `"active"` /
+  `"inactive"` status.
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue`.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias PhoenixKitCatalogue.Catalogue.{ActivityLog, PubSub}
+  alias PhoenixKitCatalogue.Schemas.Supplier
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+
+  @doc """
+  Lists all suppliers, ordered by name.
+
+  ## Options
+
+    * `:status` — filter by status (e.g. `"active"`, `"inactive"`).
+  """
+  @spec list_suppliers(keyword()) :: [Supplier.t()]
+  def list_suppliers(opts \\ []) do
+    query = from(s in Supplier, order_by: [asc: :name])
+
+    query =
+      case Keyword.get(opts, :status) do
+        nil -> query
+        status -> where(query, [s], s.status == ^status)
+      end
+
+    repo().all(query)
+  end
+
+  @doc "Fetches a supplier by UUID. Returns `nil` if not found."
+  @spec get_supplier(Ecto.UUID.t()) :: Supplier.t() | nil
+  def get_supplier(uuid), do: repo().get(Supplier, uuid)
+
+  @doc "Fetches a supplier by UUID. Raises `Ecto.NoResultsError` if not found."
+  @spec get_supplier!(Ecto.UUID.t()) :: Supplier.t()
+  def get_supplier!(uuid), do: repo().get!(Supplier, uuid)
+
+  @doc """
+  Creates a supplier.
+
+  ## Required attributes
+
+    * `:name` — supplier name (1-255 chars)
+
+  ## Optional attributes
+
+    * `:description`, `:website`, `:contact_info`, `:notes`
+    * `:status` — `"active"` (default) or `"inactive"`
+    * `:data` — flexible JSON map
+  """
+  @spec create_supplier(map(), keyword()) ::
+          {:ok, Supplier.t()} | {:error, Ecto.Changeset.t(Supplier.t())}
+  def create_supplier(attrs, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> %Supplier{} |> Supplier.changeset(attrs) |> repo().insert() end,
+        fn supplier ->
+          %{
+            action: "supplier.created",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "supplier",
+            resource_uuid: supplier.uuid,
+            metadata: %{"name" => supplier.name}
+          }
+        end
+      )
+
+    with {:ok, supplier} <- result do
+      PubSub.broadcast(:supplier, supplier.uuid)
+      {:ok, supplier}
+    end
+  end
+
+  @doc "Updates a supplier with the given attributes."
+  @spec update_supplier(Supplier.t(), map(), keyword()) ::
+          {:ok, Supplier.t()} | {:error, Ecto.Changeset.t(Supplier.t())}
+  def update_supplier(%Supplier{} = supplier, attrs, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> supplier |> Supplier.changeset(attrs) |> repo().update() end,
+        fn updated ->
+          %{
+            action: "supplier.updated",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "supplier",
+            resource_uuid: updated.uuid,
+            metadata: %{"name" => updated.name}
+          }
+        end
+      )
+
+    with {:ok, updated} <- result do
+      PubSub.broadcast(:supplier, updated.uuid)
+      {:ok, updated}
+    end
+  end
+
+  @doc "Hard-deletes a supplier from the database."
+  @spec delete_supplier(Supplier.t(), keyword()) ::
+          {:ok, Supplier.t()} | {:error, Ecto.Changeset.t(Supplier.t())}
+  def delete_supplier(%Supplier{} = supplier, opts \\ []) do
+    result =
+      ActivityLog.with_log(
+        fn -> repo().delete(supplier) end,
+        fn _ ->
+          %{
+            action: "supplier.deleted",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "supplier",
+            resource_uuid: supplier.uuid,
+            metadata: %{"name" => supplier.name}
+          }
+        end
+      )
+
+    with {:ok, deleted} <- result do
+      PubSub.broadcast(:supplier, supplier.uuid)
+      {:ok, deleted}
+    end
+  end
+
+  @doc "Returns a changeset for tracking supplier changes."
+  @spec change_supplier(Supplier.t(), map()) :: Ecto.Changeset.t(Supplier.t())
+  def change_supplier(%Supplier{} = supplier, attrs \\ %{}) do
+    Supplier.changeset(supplier, attrs)
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue/translations.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/translations.ex
@@ -1,0 +1,42 @@
+defmodule PhoenixKitCatalogue.Catalogue.Translations do
+  @moduledoc """
+  Multilang `data` JSONB helpers — read merged language data from a
+  record and write language-specific overrides through the entity's own
+  update function.
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue`.
+  """
+
+  alias PhoenixKit.Utils.Multilang
+
+  @doc """
+  Gets translated field data for a record in a specific language.
+  Returns merged data (primary language as base + overrides for the
+  requested language).
+  """
+  @spec get_translation(map(), String.t()) :: map()
+  def get_translation(record, lang_code) do
+    Multilang.get_language_data(record.data || %{}, lang_code)
+  end
+
+  @doc """
+  Updates the multilang `data` field for a record with language-specific
+  field data. For primary language: stores ALL fields. For secondary
+  languages: stores only overrides (differences from primary).
+
+  `update_fn` is the entity's update function. It receives `(record, attrs)`
+  for 2-arity or `(record, attrs, opts)` for 3-arity when activity-logging
+  opts are provided.
+  """
+  @spec set_translation(map(), String.t(), map(), function(), keyword()) ::
+          {:ok, term()} | {:error, term()}
+  def set_translation(record, lang_code, field_data, update_fn, opts \\ []) do
+    new_data = Multilang.put_language_data(record.data || %{}, lang_code, field_data)
+
+    if opts == [] do
+      update_fn.(record, %{data: new_data})
+    else
+      update_fn.(record, %{data: new_data}, opts)
+    end
+  end
+end

--- a/lib/phoenix_kit_catalogue/schemas/cat_catalogue.ex
+++ b/lib/phoenix_kit_catalogue/schemas/cat_catalogue.ex
@@ -10,11 +10,16 @@ defmodule PhoenixKitCatalogue.Schemas.Catalogue do
   @foreign_key_type UUIDv7
 
   @statuses ~w(active archived deleted)
+  @kinds ~w(standard smart)
+
+  def allowed_kinds, do: @kinds
 
   schema "phoenix_kit_cat_catalogues" do
     field(:name, :string)
     field(:description, :string)
+    field(:kind, :string, default: "standard")
     field(:markup_percentage, :decimal, default: Decimal.new("0"))
+    field(:discount_percentage, :decimal, default: Decimal.new("0"))
     field(:status, :string, default: "active")
     field(:data, :map, default: %{})
 
@@ -27,7 +32,14 @@ defmodule PhoenixKitCatalogue.Schemas.Catalogue do
   end
 
   @required_fields [:name]
-  @optional_fields [:description, :markup_percentage, :status, :data]
+  @optional_fields [
+    :description,
+    :kind,
+    :markup_percentage,
+    :discount_percentage,
+    :status,
+    :data
+  ]
 
   def changeset(catalogue, attrs) do
     catalogue
@@ -35,9 +47,14 @@ defmodule PhoenixKitCatalogue.Schemas.Catalogue do
     |> validate_required(@required_fields)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_inclusion(:status, @statuses)
+    |> validate_inclusion(:kind, @kinds)
     |> validate_number(:markup_percentage,
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: 1000
+    )
+    |> validate_number(:discount_percentage,
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: 100
     )
   end
 end

--- a/lib/phoenix_kit_catalogue/schemas/catalogue_rule.ex
+++ b/lib/phoenix_kit_catalogue/schemas/catalogue_rule.ex
@@ -1,0 +1,104 @@
+defmodule PhoenixKitCatalogue.Schemas.CatalogueRule do
+  @moduledoc """
+  Smart-catalogue rule: one row per `(item, referenced_catalogue)` pair.
+
+  Lets an item in a smart catalogue declare "I apply `value` `unit`
+  to this other catalogue" (e.g. 5% of Kitchen, flat $20 of Hardware).
+
+  Both `value` and `unit` are nullable — when `NULL`, the rule inherits
+  the parent item's `default_value` / `default_unit`. That lets a user
+  set "5% across everything" once and only override specific catalogues.
+
+  The `unit` vocabulary is open-ended VARCHAR so consumers can add new
+  units without a migration. V1 recognizes `"percent"` and `"flat"`;
+  anything else is stored verbatim and left to the consumer to validate.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          uuid: Ecto.UUID.t() | nil,
+          item_uuid: Ecto.UUID.t() | nil,
+          referenced_catalogue_uuid: Ecto.UUID.t() | nil,
+          value: Decimal.t() | nil,
+          unit: String.t() | nil,
+          position: integer(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  @primary_key {:uuid, UUIDv7, autogenerate: true}
+  @foreign_key_type UUIDv7
+
+  @units ~w(percent flat)
+
+  @spec allowed_units() :: [String.t()]
+  def allowed_units, do: @units
+
+  schema "phoenix_kit_cat_item_catalogue_rules" do
+    field(:value, :decimal)
+    field(:unit, :string)
+    field(:position, :integer, default: 0)
+
+    belongs_to(:item, PhoenixKitCatalogue.Schemas.Item,
+      foreign_key: :item_uuid,
+      references: :uuid,
+      type: UUIDv7
+    )
+
+    belongs_to(:referenced_catalogue, PhoenixKitCatalogue.Schemas.Catalogue,
+      foreign_key: :referenced_catalogue_uuid,
+      references: :uuid,
+      type: UUIDv7
+    )
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @required_fields [:item_uuid, :referenced_catalogue_uuid]
+  @optional_fields [:value, :unit, :position]
+
+  @spec changeset(t() | Ecto.Changeset.t(t()), map()) :: Ecto.Changeset.t(t())
+  def changeset(rule, attrs) do
+    rule
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:value, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:unit, @units ++ [nil])
+    |> foreign_key_constraint(:item_uuid)
+    |> foreign_key_constraint(:referenced_catalogue_uuid)
+    |> unique_constraint([:item_uuid, :referenced_catalogue_uuid],
+      name: :phoenix_kit_cat_item_catalogue_rules_pair_index
+    )
+  end
+
+  @doc """
+  Returns the effective `{value, unit}` for a rule, falling back to the
+  item's `default_value` / `default_unit` when the rule row has NULL.
+
+  Each leg is independent: a rule can have its own `value` while
+  inheriting `unit` from the item default (or vice versa).
+
+  Returns `{nil, nil}` when nothing is set anywhere — which means
+  "applies but amount unspecified"; the consumer decides what to do.
+
+  ## Examples
+
+      # Rule with both legs nil → inherits both from item
+      rule = %CatalogueRule{value: nil, unit: nil}
+      item = %Item{default_value: Decimal.new("5"), default_unit: "percent"}
+      effective(rule, item)
+      #=> {Decimal.new("5"), "percent"}
+
+      # Rule overrides value, inherits unit
+      rule = %CatalogueRule{value: Decimal.new("10"), unit: nil}
+      effective(rule, item)
+      #=> {Decimal.new("10"), "percent"}
+  """
+  @spec effective(t(), PhoenixKitCatalogue.Schemas.Item.t() | map() | nil) ::
+          {Decimal.t() | nil, String.t() | nil}
+  def effective(%__MODULE__{value: rv, unit: ru}, item) do
+    {rv || Map.get(item || %{}, :default_value), ru || Map.get(item || %{}, :default_unit)}
+  end
+end

--- a/lib/phoenix_kit_catalogue/schemas/item.ex
+++ b/lib/phoenix_kit_catalogue/schemas/item.ex
@@ -1,5 +1,14 @@
 defmodule PhoenixKitCatalogue.Schemas.Item do
-  @moduledoc "Schema for catalogue items — individual products/materials with SKU and pricing."
+  @moduledoc """
+  Schema for catalogue items — individual products/materials with SKU and pricing.
+
+  V102 added discount + smart-catalogue fields: `discount_percentage` (per-item
+  override of the catalogue discount, NULL = inherit), and `default_value` /
+  `default_unit` (smart-only fallbacks consumed by `CatalogueRule.effective/2`
+  when a rule row leaves either leg NULL). The optional `:catalogue_rules`
+  association mirrors the V102 rules table — only populated for items in a
+  smart catalogue.
+  """
 
   use Ecto.Schema
   import Ecto.Changeset
@@ -11,8 +20,13 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
 
   @statuses ~w(active inactive discontinued deleted)
   @units ~w(piece set pair sheet m2 running_meter)
+  @default_units ~w(percent flat)
 
+  @spec allowed_units() :: [String.t()]
   def allowed_units, do: @units
+
+  @spec allowed_default_units() :: [String.t()]
+  def allowed_default_units, do: @default_units
 
   schema "phoenix_kit_cat_items" do
     field(:name, :string)
@@ -23,6 +37,16 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
     # catalogue's markup_percentage" (the pre-V97 default behavior); any
     # Decimal (including 0) overrides the catalogue's value for this item.
     field(:markup_percentage, :decimal)
+    # Per-item discount override. Same inherit-or-override semantics as
+    # markup_percentage: `nil` = inherit the catalogue's discount, any
+    # Decimal (including 0) overrides. Added in V102.
+    field(:discount_percentage, :decimal)
+    # Smart-catalogue defaults (V102): the fallback value + unit applied
+    # when a CatalogueRule row has nil `value`/`unit`. Lets a user set
+    # "5% across everything" once and only override specific catalogues.
+    # Only meaningful when the parent catalogue is kind: "smart".
+    field(:default_value, :decimal)
+    field(:default_unit, :string)
     field(:unit, :string, default: "piece")
     field(:status, :string, default: "active")
     field(:data, :map, default: %{})
@@ -45,6 +69,11 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
       type: UUIDv7
     )
 
+    has_many(:catalogue_rules, PhoenixKitCatalogue.Schemas.CatalogueRule,
+      foreign_key: :item_uuid,
+      references: :uuid
+    )
+
     timestamps(type: :utc_datetime)
   end
 
@@ -54,6 +83,9 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
     :sku,
     :base_price,
     :markup_percentage,
+    :discount_percentage,
+    :default_value,
+    :default_unit,
     :unit,
     :status,
     :category_uuid,
@@ -61,6 +93,7 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
     :data
   ]
 
+  @spec changeset(t() | Ecto.Changeset.t(t()), map()) :: Ecto.Changeset.t(t())
   def changeset(item, attrs) do
     item
     |> cast(attrs, @required_fields ++ @optional_fields)
@@ -71,6 +104,12 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
     |> validate_inclusion(:unit, @units)
     |> validate_number(:base_price, greater_than_or_equal_to: 0)
     |> validate_number(:markup_percentage, greater_than_or_equal_to: 0)
+    |> validate_number(:discount_percentage,
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: 100
+    )
+    |> validate_number(:default_value, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:default_unit, @default_units ++ [nil])
     |> foreign_key_constraint(:catalogue_uuid)
     |> foreign_key_constraint(:category_uuid)
   end
@@ -101,6 +140,7 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
       Item.sale_price(%Item{base_price: Decimal.new("100"), markup_percentage: Decimal.new("0")}, Decimal.new("20"))
       #=> Decimal.new("100.00")
   """
+  @spec sale_price(t(), Decimal.t() | nil) :: Decimal.t() | nil
   def sale_price(%__MODULE__{base_price: nil}, _catalogue_markup), do: nil
 
   def sale_price(%__MODULE__{base_price: base_price} = item, catalogue_markup) do
@@ -122,9 +162,105 @@ defmodule PhoenixKitCatalogue.Schemas.Item do
   sold at its base price. Callers that only need to *display* which
   markup is active (without computing a price) can use this directly.
   """
+  @spec effective_markup(t(), Decimal.t() | nil) :: Decimal.t() | nil
   def effective_markup(%__MODULE__{markup_percentage: nil}, catalogue_markup),
     do: catalogue_markup
 
   def effective_markup(%__MODULE__{markup_percentage: override}, _catalogue_markup),
     do: override
+
+  @doc """
+  Returns the discount percentage that actually applies to an item — the
+  item's own `discount_percentage` if set, otherwise `catalogue_discount`.
+
+  Mirrors `effective_markup/2`: `nil` on the item means "inherit the
+  catalogue's discount", any Decimal (including `0`) overrides. `nil` on
+  both sides means "no discount at all".
+
+  Use this when you need to display which discount is active without
+  computing the final price.
+  """
+  @spec effective_discount(t(), Decimal.t() | nil) :: Decimal.t() | nil
+  def effective_discount(%__MODULE__{discount_percentage: nil}, catalogue_discount),
+    do: catalogue_discount
+
+  def effective_discount(%__MODULE__{discount_percentage: override}, _catalogue_discount),
+    do: override
+
+  @doc """
+  Returns the final price for an item — `base_price` with the effective
+  markup applied, then the effective discount subtracted.
+
+  The chain is `base → markup → discount`:
+
+      sale_price  = base_price * (1 + effective_markup   / 100)
+      final_price = sale_price  * (1 -  effective_discount / 100)
+
+  `catalogue_markup` and `catalogue_discount` are the fallbacks used when
+  the item has no matching override of its own. `nil` on either side
+  means "no markup / no discount on that leg"; the other leg still applies.
+
+  Returns `nil` when `base_price` is `nil`. Result is rounded to 2
+  decimal places. Percentage values should be `Decimal`s (e.g.
+  `Decimal.new("15.0")`).
+
+  ## Examples
+
+      # 100 * 1.20 * 0.90 = 108.00
+      Item.final_price(
+        %Item{base_price: Decimal.new("100"), markup_percentage: nil, discount_percentage: nil},
+        Decimal.new("20"),
+        Decimal.new("10")
+      )
+      #=> Decimal.new("108.00")
+
+      # Per-item discount 0 overrides a catalogue discount of 10 →
+      # final equals sale_price
+      Item.final_price(
+        %Item{base_price: Decimal.new("100"), discount_percentage: Decimal.new("0")},
+        Decimal.new("20"),
+        Decimal.new("10")
+      )
+      #=> Decimal.new("120.00")
+  """
+  @spec final_price(t(), Decimal.t() | nil, Decimal.t() | nil) :: Decimal.t() | nil
+  def final_price(%__MODULE__{base_price: nil}, _catalogue_markup, _catalogue_discount), do: nil
+
+  def final_price(%__MODULE__{} = item, catalogue_markup, catalogue_discount) do
+    with %Decimal{} = sale <- sale_price(item, catalogue_markup) do
+      case effective_discount(item, catalogue_discount) do
+        nil -> sale
+        discount -> apply_discount(sale, discount)
+      end
+    end
+  end
+
+  @doc """
+  Returns the Decimal amount subtracted by the discount for an item —
+  i.e. `sale_price - final_price`. Useful for "You save $X" UI.
+
+  Returns `nil` when `base_price` is `nil` or when no discount applies
+  (both catalogue and item discount are `nil`).
+  """
+  @spec discount_amount(t(), Decimal.t() | nil, Decimal.t() | nil) :: Decimal.t() | nil
+  def discount_amount(%__MODULE__{base_price: nil}, _catalogue_markup, _catalogue_discount),
+    do: nil
+
+  def discount_amount(%__MODULE__{} = item, catalogue_markup, catalogue_discount) do
+    case effective_discount(item, catalogue_discount) do
+      nil ->
+        nil
+
+      _discount ->
+        with %Decimal{} = sale <- sale_price(item, catalogue_markup),
+             %Decimal{} = final <- final_price(item, catalogue_markup, catalogue_discount) do
+          Decimal.sub(sale, final) |> Decimal.round(2)
+        end
+    end
+  end
+
+  defp apply_discount(sale_price, discount) do
+    multiplier = Decimal.sub(Decimal.new("1"), Decimal.div(discount, Decimal.new("100")))
+    sale_price |> Decimal.mult(multiplier) |> Decimal.round(2)
+  end
 end

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -22,6 +22,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   import PhoenixKitCatalogue.Web.Components
 
   alias PhoenixKitCatalogue.Catalogue
+  alias PhoenixKitCatalogue.Catalogue.PubSub
   alias PhoenixKitCatalogue.Paths
 
   @per_page 100
@@ -53,6 +54,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       )
 
     if connected?(socket) do
+      # Subscribe BEFORE the initial load so a write that lands between
+      # the load and a connect doesn't leave the UI stale forever — the
+      # broadcast triggers a re-load via handle_info/2.
+      PubSub.subscribe()
+
       try do
         {:ok, reset_and_load(socket)}
       rescue
@@ -68,6 +74,28 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       {:ok, socket}
     end
   end
+
+  # PubSub: another LV touched a category/item/catalogue/smart-rule
+  # we might be displaying. Re-load the visible slice. The catch-all
+  # absorbs unrelated events without letting the LV crash on an
+  # unexpected message.
+  @impl true
+  def handle_info({:catalogue_data_changed, kind, _uuid}, socket)
+      when kind in [:catalogue, :category, :item, :smart_rule] do
+    {:noreply, reset_and_load(socket)}
+  rescue
+    Ecto.NoResultsError ->
+      # The catalogue we're viewing was deleted in another session.
+      {:noreply,
+       socket
+       |> put_flash(
+         :info,
+         Gettext.gettext(PhoenixKitWeb.Gettext, "This catalogue was just deleted.")
+       )
+       |> push_navigate(to: Paths.index())}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
 
   # ── Event handlers ──────────────────────────────────────────────
 
@@ -127,7 +155,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          )}
 
       {:error, reason} ->
-        Logger.error("Failed to trash item #{uuid}: #{inspect(reason)}")
+        log_operation_error(socket, "trash_item", %{
+          entity_type: "item",
+          entity_uuid: uuid,
+          reason: reason
+        })
 
         {:noreply,
          put_flash(
@@ -156,7 +188,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          )}
 
       {:error, reason} ->
-        Logger.error("Failed to restore item #{uuid}: #{inspect(reason)}")
+        log_operation_error(socket, "restore_item", %{
+          entity_type: "item",
+          entity_uuid: uuid,
+          reason: reason
+        })
 
         {:noreply,
          put_flash(
@@ -172,30 +208,44 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   end
 
   def handle_event("permanently_delete_item", _params, socket) do
-    {"item", uuid} = confirm_delete!(socket)
+    case socket.assigns.confirm_delete do
+      {"item", uuid} ->
+        with %{} = item <- Catalogue.get_item(uuid),
+             {:ok, _} <- Catalogue.permanently_delete_item(item, actor_opts(socket)) do
+          {:noreply,
+           socket
+           |> assign(:confirm_delete, nil)
+           |> put_flash(
+             :info,
+             Gettext.gettext(PhoenixKitWeb.Gettext, "Item permanently deleted.")
+           )
+           |> remove_item_locally(uuid)
+           |> refresh_counts()}
+        else
+          nil ->
+            {:noreply,
+             socket
+             |> assign(:confirm_delete, nil)
+             |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found."))}
 
-    with %{} = item <- Catalogue.get_item(uuid),
-         {:ok, _} <- Catalogue.permanently_delete_item(item, actor_opts(socket)) do
-      {:noreply,
-       socket
-       |> assign(:confirm_delete, nil)
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item permanently deleted."))
-       |> remove_item_locally(uuid)
-       |> refresh_counts()}
-    else
-      nil ->
-        {:noreply,
-         socket
-         |> assign(:confirm_delete, nil)
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found."))}
+          {:error, reason} ->
+            log_operation_error(socket, "permanently_delete_item", %{
+              entity_type: "item",
+              entity_uuid: uuid,
+              reason: reason
+            })
 
-      {:error, reason} ->
-        Logger.error("Failed to permanently delete item #{uuid}: #{inspect(reason)}")
+            {:noreply,
+             socket
+             |> assign(:confirm_delete, nil)
+             |> put_flash(
+               :error,
+               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete item.")
+             )}
+        end
 
-        {:noreply,
-         socket
-         |> assign(:confirm_delete, nil)
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete item."))}
+      _ ->
+        unexpected_confirm_event(socket, "permanently_delete_item")
     end
   end
 
@@ -216,7 +266,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          )}
 
       {:error, reason} ->
-        Logger.error("Failed to trash category #{uuid}: #{inspect(reason)}")
+        log_operation_error(socket, "trash_category", %{
+          entity_type: "category",
+          entity_uuid: uuid,
+          reason: reason
+        })
 
         {:noreply,
          put_flash(
@@ -244,7 +298,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          )}
 
       {:error, reason} ->
-        Logger.error("Failed to restore category #{uuid}: #{inspect(reason)}")
+        log_operation_error(socket, "restore_category", %{
+          entity_type: "category",
+          entity_uuid: uuid,
+          reason: reason
+        })
 
         {:noreply,
          put_flash(
@@ -256,35 +314,46 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   end
 
   def handle_event("permanently_delete_category", _params, socket) do
-    {"category", uuid} = confirm_delete!(socket)
+    case socket.assigns.confirm_delete do
+      {"category", uuid} ->
+        with %{} = category <- Catalogue.get_category(uuid),
+             {:ok, _} <- Catalogue.permanently_delete_category(category, actor_opts(socket)) do
+          {:noreply,
+           socket
+           |> assign(:confirm_delete, nil)
+           |> put_flash(
+             :info,
+             Gettext.gettext(PhoenixKitWeb.Gettext, "Category permanently deleted.")
+           )
+           |> reset_and_load()}
+        else
+          nil ->
+            {:noreply,
+             socket
+             |> assign(:confirm_delete, nil)
+             |> put_flash(
+               :error,
+               Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found.")
+             )}
 
-    with %{} = category <- Catalogue.get_category(uuid),
-         {:ok, _} <- Catalogue.permanently_delete_category(category, actor_opts(socket)) do
-      {:noreply,
-       socket
-       |> assign(:confirm_delete, nil)
-       |> put_flash(
-         :info,
-         Gettext.gettext(PhoenixKitWeb.Gettext, "Category permanently deleted.")
-       )
-       |> reset_and_load()}
-    else
-      nil ->
-        {:noreply,
-         socket
-         |> assign(:confirm_delete, nil)
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found."))}
+          {:error, reason} ->
+            log_operation_error(socket, "permanently_delete_category", %{
+              entity_type: "category",
+              entity_uuid: uuid,
+              reason: reason
+            })
 
-      {:error, reason} ->
-        Logger.error("Failed to permanently delete category #{uuid}: #{inspect(reason)}")
+            {:noreply,
+             socket
+             |> assign(:confirm_delete, nil)
+             |> put_flash(
+               :error,
+               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete category.")
+             )}
+        end
 
-        {:noreply,
-         socket
-         |> assign(:confirm_delete, nil)
-         |> put_flash(
-           :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete category.")
-         )}
+      _ ->
+        unexpected_confirm_event(socket, "permanently_delete_category")
     end
   end
 
@@ -302,17 +371,76 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   # ── Helpers ─────────────────────────────────────────────────────
 
-  defp confirm_delete!(socket) do
-    case socket.assigns.confirm_delete do
-      {_type, _uuid} = value -> value
-      _ -> raise "confirm_delete not set"
+  # Graceful handler for an unreachable UI state: a delete event fires
+  # while `confirm_delete` is nil (e.g. someone pushed the event without
+  # first opening the modal). Clears the state, flashes a warning, and
+  # logs a warning so we can see it in production without crashing the
+  # LV and dropping the user's unrelated in-flight state.
+  defp unexpected_confirm_event(socket, event_name) do
+    Logger.warning(
+      "Catalogue detail LV: #{event_name} fired without confirm_delete — assigns=#{inspect(socket.assigns.confirm_delete)} actor_uuid=#{inspect(actor_uuid(socket))}"
+    )
+
+    {:noreply,
+     socket
+     |> assign(:confirm_delete, nil)
+     |> put_flash(
+       :error,
+       Gettext.gettext(PhoenixKitWeb.Gettext, "Unexpected request. Please try again.")
+     )}
+  end
+
+  # Structured error log for failed mutations — includes actor, entity,
+  # and changeset errors where available so a production incident can be
+  # diagnosed from the log alone.
+  defp log_operation_error(socket, operation, context) do
+    ctx = Map.put_new(context, :actor_uuid, actor_uuid(socket))
+
+    Logger.error(fn ->
+      [
+        "Catalogue detail LV ",
+        operation,
+        " failed: ",
+        format_error_context(ctx)
+      ]
+    end)
+  end
+
+  defp format_error_context(%{reason: reason} = ctx) do
+    rest = Map.delete(ctx, :reason)
+
+    [
+      inspect(rest, limit: :infinity),
+      " reason=",
+      format_reason(reason)
+    ]
+  end
+
+  defp format_reason(%Ecto.Changeset{} = cs) do
+    errors =
+      cs
+      |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+        Enum.reduce(opts, msg, fn {k, v}, acc ->
+          String.replace(acc, "%{#{k}}", to_string(v))
+        end)
+      end)
+
+    "changeset_errors=#{inspect(errors)}"
+  end
+
+  defp format_reason(other), do: inspect(other)
+
+  defp actor_uuid(socket) do
+    case socket.assigns[:phoenix_kit_current_user] do
+      %{uuid: uuid} -> uuid
+      _ -> nil
     end
   end
 
   defp actor_opts(socket) do
-    case socket.assigns[:phoenix_kit_current_user] do
-      %{uuid: uuid} -> [actor_uuid: uuid]
-      _ -> []
+    case actor_uuid(socket) do
+      nil -> []
+      uuid -> [actor_uuid: uuid]
     end
   end
 
@@ -484,7 +612,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         {:noreply, socket}
 
       other ->
-        Logger.warning("search task exited unexpectedly: #{inspect(other)}")
+        Logger.warning(
+          "Catalogue detail LV search task exited unexpectedly: reason=#{inspect(other)} query=#{inspect(socket.assigns.search_query)} catalogue_uuid=#{inspect(socket.assigns.catalogue_uuid)} actor_uuid=#{inspect(actor_uuid(socket))}"
+        )
 
         {:noreply,
          socket
@@ -529,7 +659,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         {:noreply, socket}
 
       other ->
-        Logger.warning("search page task exited unexpectedly: #{inspect(other)}")
+        Logger.warning(
+          "Catalogue detail LV search_page task exited unexpectedly: reason=#{inspect(other)} query=#{inspect(socket.assigns.search_query)} offset=#{socket.assigns.search_offset} catalogue_uuid=#{inspect(socket.assigns.catalogue_uuid)} actor_uuid=#{inspect(actor_uuid(socket))}"
+        )
 
         {:noreply,
          socket
@@ -742,7 +874,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <.search_input :if={@view_mode == "active"} query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items by name, description, or SKU...")} />
 
         <%!-- View toggle --%>
-        <.view_mode_toggle storage_key="catalogue-detail-items" />
+        <.view_mode_toggle :if={@category_list != []} storage_key="catalogue-detail-items" />
 
         <%!-- Search results (visible when the user has typed a query) --%>
         <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
@@ -980,7 +1112,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <.link navigate={Paths.category_edit(@card.category.uuid)} class="btn btn-ghost btn-xs">
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
             </.link>
-            <button phx-click="trash_category" phx-value-uuid={@card.category.uuid} class="btn btn-ghost btn-xs text-error">
+            <button
+              phx-click="trash_category"
+              phx-value-uuid={@card.category.uuid}
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
+              class="btn btn-ghost btn-xs text-error"
+            >
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
             </button>
           </div>
@@ -990,6 +1127,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <button
               phx-click="restore_category"
               phx-value-uuid={@card.category.uuid}
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")}
               class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
             >
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
@@ -1053,12 +1191,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     ~H"""
     <div class="card bg-base-100 shadow">
       <div class="card-body">
-        <div class="flex items-center gap-2">
+        <div :if={@category_total > 0} class="flex items-center gap-2">
           <h3 class="card-title text-lg text-base-content/70">{Gettext.gettext(PhoenixKitWeb.Gettext, "Uncategorized")}</h3>
           <span class="badge badge-ghost badge-sm">{@uncategorized_total} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
         </div>
 
-        <div class="mt-2">
+        <div class={if @category_total > 0, do: "mt-2", else: ""}>
           <.item_table
             items={@card.items}
             columns={[:name, :sku, :base_price, :unit, :status]}

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -8,13 +8,20 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
   import PhoenixKitWeb.Components.MultilangForm
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
+  import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
 
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Catalogue, as: CatalogueSchema
 
   @translatable_fields ["name", "description"]
-  @preserve_fields %{"status" => :status, "markup_percentage" => :markup_percentage}
+  @preserve_fields %{
+    "status" => :status,
+    "kind" => :kind,
+    "markup_percentage" => :markup_percentage,
+    "discount_percentage" => :discount_percentage
+  }
 
   @impl true
   def mount(params, _session, socket) do
@@ -53,11 +60,21 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
            ),
          action: action,
          catalogue: catalogue,
-         changeset: changeset,
          confirm_delete: false
        )
+       |> assign_changeset(changeset)
        |> mount_multilang()}
     end
+  end
+
+  # Single source of truth for form state: we keep both `:changeset` (for
+  # `<.translatable_field>`, which still reads the raw changeset) and
+  # `:form` (for `<.input>` / `<.select>` field bindings). Assigning both
+  # here means validate/save-error paths can't accidentally desync them.
+  defp assign_changeset(socket, changeset) do
+    socket
+    |> assign(:changeset, changeset)
+    |> assign(:form, to_form(changeset))
   end
 
   @impl true
@@ -77,7 +94,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       |> Catalogue.change_catalogue(params)
       |> Map.put(:action, socket.assigns.changeset.action)
 
-    {:noreply, assign(socket, :changeset, changeset)}
+    {:noreply, assign_changeset(socket, changeset)}
   end
 
   def handle_event("save", %{"catalogue" => params}, socket) do
@@ -139,7 +156,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
          |> push_navigate(to: Paths.catalogue_detail(catalogue.uuid))}
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -152,7 +169,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
          |> push_navigate(to: Paths.catalogue_detail(catalogue.uuid))}
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -170,7 +187,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       <%!-- Header --%>
       <.admin_page_header back={Paths.index()} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update catalogue details and settings.")} />
 
-      <.form for={to_form(@changeset)} action="#" phx-change="validate" phx-submit="save">
+      <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <%!-- Main content card --%>
         <div class="card bg-base-100 shadow-lg">
           <.multilang_tabs
@@ -238,31 +255,63 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
             <div class="divider my-0"></div>
 
             <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Percentage")}</span>
-              <input type="number" name="catalogue[markup_percentage]" value={Ecto.Changeset.get_field(@changeset, :markup_percentage)} class="input input-bordered w-full transition-colors focus:input-primary" step="0.01" min="0" placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 15.0")} />
+              <.select
+                field={@form[:kind]}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Kind")}
+                class="transition-colors focus-within:select-primary"
+                options={[
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Standard — items priced directly"), "standard"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Smart — items reference other catalogues"), "smart"}
+                ]}
+              />
+              <span class="label-text-alt text-base-content/50 mt-1">
+                <%= if Ecto.Changeset.get_field(@changeset, :kind) == "smart" do %>
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Smart catalogues hold items like \"Delivery\" whose cost is a per-catalogue %/flat rule picked from other catalogues. Items here reference other catalogues instead of carrying a base price of their own.")}
+                <% else %>
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Standard catalogues hold items priced directly — each item has its own base price, markup, and discount. This is the normal flow for materials, products, or anything with a fixed price tag.")}
+                <% end %>
+              </span>
+            </div>
+
+            <div class="form-control">
+              <.input
+                field={@form[:markup_percentage]}
+                type="number"
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Percentage")}
+                step="0.01"
+                min="0"
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 15.0")}
+              />
               <span class="label-text-alt text-base-content/50 mt-1">
                 {Gettext.gettext(PhoenixKitWeb.Gettext, "Applied to all item base prices to calculate sale prices. Leave blank for no markup.")}
               </span>
             </div>
 
             <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-              <label class="select w-full transition-colors focus-within:select-primary">
-                <select name="catalogue[status]">
-                  <option
-                    value="active"
-                    selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
-                  >
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
-                  </option>
-                  <option
-                    value="archived"
-                    selected={Ecto.Changeset.get_field(@changeset, :status) == "archived"}
-                  >
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived")}
-                  </option>
-                </select>
-              </label>
+              <.input
+                field={@form[:discount_percentage]}
+                type="number"
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Discount Percentage")}
+                step="0.01"
+                min="0"
+                max="100"
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 10.0")}
+              />
+              <span class="label-text-alt text-base-content/50 mt-1">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Applied on top of the sale price to compute the final price. 0..100. Individual items can override this.")}
+              </span>
+            </div>
+
+            <div class="form-control">
+              <.select
+                field={@form[:status]}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                class="transition-colors focus-within:select-primary"
+                options={[
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived"), "archived"}
+                ]}
+              />
               <span class="label-text-alt text-base-content/50 mt-1">
                 {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived catalogues are hidden from active views.")}
               </span>
@@ -273,7 +322,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
 
             <div class="flex justify-end gap-3">
               <.link navigate={Paths.index()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
-              <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">
+              <button
+                type="submit"
+                class="btn btn-primary phx-submit-loading:opacity-75"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+              >
                 {if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Catalogue"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}
               </button>
             </div>

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -19,12 +19,15 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   import PhoenixKitCatalogue.Web.Components
 
   alias PhoenixKitCatalogue.Catalogue
+  alias PhoenixKitCatalogue.Catalogue.PubSub
   alias PhoenixKitCatalogue.Paths
 
   @per_page 100
 
   @impl true
   def mount(_params, _session, socket) do
+    if connected?(socket), do: PubSub.subscribe()
+
     {:ok,
      assign(socket,
        page_title: Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue"),
@@ -44,6 +47,29 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
      )}
   end
 
+  # PubSub: re-load whichever tab is active when relevant data changes
+  # in another LV process. Catch-all is required since the topic is
+  # shared across all catalogue resources — we ignore events we don't
+  # care about for the current tab.
+  @impl true
+  def handle_info({:catalogue_data_changed, kind, _uuid}, socket) do
+    cond do
+      socket.assigns.active_tab == :index and kind in [:catalogue, :item, :category] ->
+        {:noreply, load_data(socket, :index)}
+
+      socket.assigns.active_tab == :manufacturers and kind in [:manufacturer, :links] ->
+        {:noreply, load_data(socket, :manufacturers)}
+
+      socket.assigns.active_tab == :suppliers and kind in [:supplier, :links] ->
+        {:noreply, load_data(socket, :suppliers)}
+
+      true ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
   @impl true
   def handle_params(_params, _uri, socket) do
     action = socket.assigns.live_action || :index
@@ -62,17 +88,75 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   defp tab_title(:manufacturers), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturers")
   defp tab_title(:suppliers), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Suppliers")
 
-  defp confirm_delete!(socket) do
-    case socket.assigns.confirm_delete do
-      {_type, _uuid} = value -> value
-      _ -> raise "confirm_delete not set"
+  # Graceful handler for a delete event that fires while `confirm_delete`
+  # is nil (e.g. someone pushed the event without first opening the
+  # modal). Clears the state, flashes a warning, and logs a warning
+  # instead of crashing the LV.
+  defp unexpected_confirm_event(socket, event_name) do
+    Logger.warning(
+      "CataloguesLive: #{event_name} fired without confirm_delete — assigns=#{inspect(socket.assigns.confirm_delete)} actor_uuid=#{inspect(actor_uuid(socket))}"
+    )
+
+    {:noreply,
+     socket
+     |> assign(:confirm_delete, nil)
+     |> put_flash(
+       :error,
+       Gettext.gettext(PhoenixKitWeb.Gettext, "Unexpected request. Please try again.")
+     )}
+  end
+
+  # Structured error log for failed mutations — includes actor, entity,
+  # and changeset errors where available so a production incident can be
+  # diagnosed from the log alone.
+  defp log_operation_error(socket, operation, context) do
+    ctx = Map.put_new(context, :actor_uuid, actor_uuid(socket))
+
+    Logger.error(fn ->
+      [
+        "CataloguesLive ",
+        operation,
+        " failed: ",
+        format_error_context(ctx)
+      ]
+    end)
+  end
+
+  defp format_error_context(%{reason: reason} = ctx) do
+    rest = Map.delete(ctx, :reason)
+
+    [
+      inspect(rest, limit: :infinity),
+      " reason=",
+      format_reason(reason)
+    ]
+  end
+
+  defp format_reason(%Ecto.Changeset{} = cs) do
+    errors =
+      cs
+      |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+        Enum.reduce(opts, msg, fn {k, v}, acc ->
+          String.replace(acc, "%{#{k}}", to_string(v))
+        end)
+      end)
+
+    "changeset_errors=#{inspect(errors)}"
+  end
+
+  defp format_reason(other), do: inspect(other)
+
+  defp actor_uuid(socket) do
+    case socket.assigns[:phoenix_kit_current_user] do
+      %{uuid: uuid} -> uuid
+      _ -> nil
     end
   end
 
   defp actor_opts(socket) do
-    case socket.assigns[:phoenix_kit_current_user] do
-      %{uuid: uuid} -> [actor_uuid: uuid]
-      _ -> []
+    case actor_uuid(socket) do
+      nil -> []
+      uuid -> [actor_uuid: uuid]
     end
   end
 
@@ -146,7 +230,11 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          |> load_data(:index)}
 
       {:error, reason} ->
-        Logger.error("Failed to trash catalogue #{uuid}: #{inspect(reason)}")
+        log_operation_error(socket, "trash_catalogue", %{
+          entity_type: "catalogue",
+          entity_uuid: uuid,
+          reason: reason
+        })
 
         {:noreply,
          socket
@@ -174,7 +262,11 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          |> load_data(:index)}
 
       {:error, reason} ->
-        Logger.error("Failed to restore catalogue #{uuid}: #{inspect(reason)}")
+        log_operation_error(socket, "restore_catalogue", %{
+          entity_type: "catalogue",
+          entity_uuid: uuid,
+          reason: reason
+        })
 
         {:noreply,
          socket
@@ -191,84 +283,112 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   end
 
   def handle_event("permanently_delete_catalogue", _params, socket) do
-    {"catalogue", uuid} = confirm_delete!(socket)
+    case socket.assigns.confirm_delete do
+      {"catalogue", uuid} ->
+        with %{} = catalogue <- Catalogue.get_catalogue(uuid),
+             {:ok, _} <-
+               Catalogue.permanently_delete_catalogue(catalogue, actor_opts(socket)) do
+          {:noreply,
+           socket
+           |> put_flash(
+             :info,
+             Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue permanently deleted.")
+           )
+           |> assign(:confirm_delete, nil)
+           |> load_data(:index)}
+        else
+          nil ->
+            {:noreply,
+             socket
+             |> assign(:confirm_delete, nil)
+             |> put_flash(
+               :error,
+               Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found.")
+             )
+             |> load_data(:index)}
 
-    with %{} = catalogue <- Catalogue.get_catalogue(uuid),
-         {:ok, _} <- Catalogue.permanently_delete_catalogue(catalogue, actor_opts(socket)) do
-      {:noreply,
-       socket
-       |> put_flash(
-         :info,
-         Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue permanently deleted.")
-       )
-       |> assign(:confirm_delete, nil)
-       |> load_data(:index)}
-    else
-      nil ->
-        {:noreply,
-         socket
-         |> assign(:confirm_delete, nil)
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found."))
-         |> load_data(:index)}
+          {:error, reason} ->
+            log_operation_error(socket, "permanently_delete_catalogue", %{
+              entity_type: "catalogue",
+              entity_uuid: uuid,
+              reason: reason
+            })
 
-      {:error, reason} ->
-        Logger.error("Failed to permanently delete catalogue #{uuid}: #{inspect(reason)}")
+            {:noreply,
+             socket
+             |> assign(:confirm_delete, nil)
+             |> put_flash(
+               :error,
+               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete catalogue.")
+             )
+             |> load_data(:index)}
+        end
 
-        {:noreply,
-         socket
-         |> assign(:confirm_delete, nil)
-         |> put_flash(
-           :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete catalogue.")
-         )
-         |> load_data(:index)}
+      _ ->
+        unexpected_confirm_event(socket, "permanently_delete_catalogue")
     end
   end
 
   def handle_event("delete_manufacturer", _params, socket) do
-    {"manufacturer", uuid} = confirm_delete!(socket)
+    case socket.assigns.confirm_delete do
+      {"manufacturer", uuid} ->
+        with %{} = manufacturer <- Catalogue.get_manufacturer(uuid),
+             {:ok, _} <- Catalogue.delete_manufacturer(manufacturer, actor_opts(socket)) do
+          {:noreply,
+           assign(socket, manufacturers: Catalogue.list_manufacturers(), confirm_delete: nil)}
+        else
+          nil ->
+            {:noreply, assign(socket, :confirm_delete, nil)}
 
-    with %{} = manufacturer <- Catalogue.get_manufacturer(uuid),
-         {:ok, _} <- Catalogue.delete_manufacturer(manufacturer, actor_opts(socket)) do
-      {:noreply,
-       assign(socket, manufacturers: Catalogue.list_manufacturers(), confirm_delete: nil)}
-    else
-      nil ->
-        {:noreply, assign(socket, :confirm_delete, nil)}
+          {:error, reason} ->
+            log_operation_error(socket, "delete_manufacturer", %{
+              entity_type: "manufacturer",
+              entity_uuid: uuid,
+              reason: reason
+            })
 
-      {:error, reason} ->
-        Logger.error("Failed to delete manufacturer #{uuid}: #{inspect(reason)}")
+            {:noreply,
+             socket
+             |> put_flash(
+               :error,
+               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete manufacturer.")
+             )
+             |> assign(:confirm_delete, nil)}
+        end
 
-        {:noreply,
-         socket
-         |> put_flash(
-           :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete manufacturer.")
-         )
-         |> assign(:confirm_delete, nil)}
+      _ ->
+        unexpected_confirm_event(socket, "delete_manufacturer")
     end
   end
 
   def handle_event("delete_supplier", _params, socket) do
-    {"supplier", uuid} = confirm_delete!(socket)
+    case socket.assigns.confirm_delete do
+      {"supplier", uuid} ->
+        with %{} = supplier <- Catalogue.get_supplier(uuid),
+             {:ok, _} <- Catalogue.delete_supplier(supplier, actor_opts(socket)) do
+          {:noreply, assign(socket, suppliers: Catalogue.list_suppliers(), confirm_delete: nil)}
+        else
+          nil ->
+            {:noreply, assign(socket, :confirm_delete, nil)}
 
-    with %{} = supplier <- Catalogue.get_supplier(uuid),
-         {:ok, _} <- Catalogue.delete_supplier(supplier, actor_opts(socket)) do
-      {:noreply, assign(socket, suppliers: Catalogue.list_suppliers(), confirm_delete: nil)}
-    else
-      nil ->
-        {:noreply, assign(socket, :confirm_delete, nil)}
+          {:error, reason} ->
+            log_operation_error(socket, "delete_supplier", %{
+              entity_type: "supplier",
+              entity_uuid: uuid,
+              reason: reason
+            })
 
-      {:error, reason} ->
-        Logger.error("Failed to delete supplier #{uuid}: #{inspect(reason)}")
+            {:noreply,
+             socket
+             |> put_flash(
+               :error,
+               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete supplier.")
+             )
+             |> assign(:confirm_delete, nil)}
+        end
 
-        {:noreply,
-         socket
-         |> put_flash(
-           :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete supplier.")
-         )
-         |> assign(:confirm_delete, nil)}
+      _ ->
+        unexpected_confirm_event(socket, "delete_supplier")
     end
   end
 
@@ -349,7 +469,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         {:noreply, socket}
 
       other ->
-        Logger.warning("search task exited unexpectedly: #{inspect(other)}")
+        Logger.warning(
+          "CataloguesLive search task exited unexpectedly: reason=#{inspect(other)} query=#{inspect(socket.assigns.search_query)} actor_uuid=#{inspect(actor_uuid(socket))}"
+        )
 
         {:noreply,
          socket
@@ -387,7 +509,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         {:noreply, socket}
 
       other ->
-        Logger.warning("search page task exited unexpectedly: #{inspect(other)}")
+        Logger.warning(
+          "CataloguesLive search_page task exited unexpectedly: reason=#{inspect(other)} query=#{inspect(socket.assigns.search_query)} offset=#{socket.assigns.search_offset} actor_uuid=#{inspect(actor_uuid(socket))}"
+        )
 
         {:noreply,
          socket
@@ -706,13 +830,13 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
                 <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label={Gettext.gettext(PhoenixKitWeb.Gettext, "View")} />
                 <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} variant="secondary" />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
+                <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
             <%!-- Deleted mode actions --%>
             <.table_default_cell :if={@view_mode == "deleted"} class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"cat-del-menu-#{catalogue.uuid}"}>
-                <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")} variant="success" />
+                <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")} variant="success" />
                 <.table_row_menu_divider />
                 <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")} variant="error" />
               </.table_row_menu>
@@ -726,10 +850,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         <:card_actions :let={catalogue} :if={@view_mode == "active"}>
           <.link navigate={Paths.catalogue_detail(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitWeb.Gettext, "View")}</.link>
           <.link navigate={Paths.catalogue_edit(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}</.link>
-          <button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}</button>
+          <button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")} class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}</button>
         </:card_actions>
         <:card_actions :let={catalogue} :if={@view_mode == "deleted"}>
-          <button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} class="btn btn-ghost btn-xs text-success">{Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}</button>
+          <button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")} class="btn btn-ghost btn-xs text-success">{Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}</button>
           <button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}</button>
         </:card_actions>
       </.table_default>

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -8,6 +8,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   import PhoenixKitWeb.Components.MultilangForm
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
+  import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
 
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
@@ -68,12 +70,18 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
        action: action,
        category: category,
        catalogue_uuid: catalogue_uuid,
-       changeset: changeset,
        confirm_delete_all: false,
        other_catalogues: other_catalogues,
        move_target: nil
      )
+     |> assign_changeset(changeset)
      |> mount_multilang()}
+  end
+
+  defp assign_changeset(socket, changeset) do
+    socket
+    |> assign(:changeset, changeset)
+    |> assign(:form, to_form(changeset))
   end
 
   @impl true
@@ -94,7 +102,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       |> Catalogue.change_category(params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign(socket, :changeset, changeset)}
+    {:noreply, assign_changeset(socket, changeset)}
   end
 
   def handle_event("save", %{"category" => params}, socket) do
@@ -193,7 +201,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
          |> push_navigate(to: Paths.catalogue_detail(socket.assigns.catalogue_uuid))}
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -206,7 +214,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
          |> push_navigate(to: Paths.catalogue_detail(socket.assigns.catalogue_uuid))}
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -224,11 +232,14 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       <%!-- Header --%>
       <.admin_page_header back={Paths.catalogue_detail(@catalogue_uuid)} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Add a new category to organize items within this catalogue."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update category details and ordering.")} />
 
-      <.form for={to_form(@changeset)} action="#" phx-change="validate" phx-submit="save">
+      <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
           <.multilang_tabs multilang_enabled={@multilang_enabled} language_tabs={@language_tabs} current_lang={@current_lang} />
 
-          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5">
+          <%!-- Only translatable fields live inside the wrapper so a
+               language switch only re-mounts name + description, not
+               the whole form. Everything else renders as a sibling. --%>
+          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5 pb-0">
             <:skeleton>
               <%!-- Name --%>
               <div class="space-y-2">
@@ -240,20 +251,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
                 <div class="skeleton h-4 w-28"></div>
                 <div class="skeleton h-24 w-full"></div>
               </div>
-              <div class="divider my-0"></div>
-              <%!-- Position --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-20"></div>
-                <div class="skeleton h-12 w-28"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Buttons --%>
-              <div class="flex justify-end gap-3">
-                <div class="skeleton h-12 w-20"></div>
-                <div class="skeleton h-12 w-36"></div>
-              </div>
             </:skeleton>
-            <div class="card-body flex flex-col gap-5">
+            <div class="card-body flex flex-col gap-5 pb-0">
               <.translatable_field
                 field_name="name" form_prefix="category" changeset={@changeset}
                 schema_field={:name} multilang_enabled={@multilang_enabled}
@@ -270,24 +269,35 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
                 placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "What kinds of items belong in this category...")}
                 class="w-full"
               />
-
-              <div class="divider my-0"></div>
-
-              <div class="form-control">
-                <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Position")}</span>
-                <input type="number" name="category[position]" value={Ecto.Changeset.get_field(@changeset, :position)} class="input input-bordered w-28 transition-colors focus:input-primary" min="0" />
-                <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Lower numbers appear first. You can also reorder from the catalogue detail page.")}</span>
-              </div>
-
-              <%!-- Actions --%>
-              <div class="divider my-0"></div>
-
-              <div class="flex justify-end gap-3">
-                <.link navigate={Paths.catalogue_detail(@catalogue_uuid)} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
-                <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">{if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Category"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}</button>
-              </div>
             </div>
           </.multilang_fields_wrapper>
+
+          <div class="card-body flex flex-col gap-5 pt-0">
+            <div class="divider my-0"></div>
+
+            <div class="form-control">
+              <.input
+                field={@form[:position]}
+                type="number"
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Position")}
+                class="w-28"
+                min="0"
+              />
+              <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Lower numbers appear first. You can also reorder from the catalogue detail page.")}</span>
+            </div>
+
+            <%!-- Actions --%>
+            <div class="divider my-0"></div>
+
+            <div class="flex justify-end gap-3">
+              <.link navigate={Paths.catalogue_detail(@catalogue_uuid)} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
+              <button
+                type="submit"
+                class="btn btn-primary phx-submit-loading:opacity-75"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+              >{if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Category"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}</button>
+            </div>
+          </div>
         </div>
       </.form>
 
@@ -298,12 +308,15 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
           <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this category and all its items to a different catalogue.")}</p>
           <div class="flex items-end gap-3">
             <div class="form-control flex-1">
-              <label class="select w-full select-sm transition-colors focus-within:select-primary">
-                <select phx-change="select_move_target" name="catalogue_uuid">
-                  <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}</option>
-                  <option :for={cat <- @other_catalogues} value={cat.uuid}>{cat.name}</option>
-                </select>
-              </label>
+              <.select
+                name="catalogue_uuid"
+                id="category-move-target"
+                value={@move_target}
+                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
+                options={Enum.map(@other_catalogues, &{&1.name, &1.uuid})}
+                class="select-sm transition-colors focus-within:select-primary"
+                phx-change="select_move_target"
+              />
             </div>
             <button
               type="button"

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -10,8 +10,21 @@ defmodule PhoenixKitCatalogue.Web.Components do
   ## Components
 
     * `search_input/1` — search bar with debounce and clear button
+    * `search_results_summary/1` — "N results for …" / "X of Y" summary line
+    * `scope_selector/1` — disclosure with catalogue/category checkbox lists
+      for narrowing a search (pairs with `Catalogue.search_items/2` filters)
+    * `catalogue_rules_picker/1` — smart-catalogue rule editor (checkbox +
+      value + unit per catalogue; pairs with `Catalogue.put_catalogue_rules/3`)
+    * `view_mode_toggle/1` — table/card view toggle synced via localStorage
     * `item_table/1` — configurable item table with selectable columns
     * `empty_state/1` — centered empty state card with message and optional action
+
+  Several of these (`search_input`, `search_results_summary`,
+  `view_mode_toggle`, `empty_state`) are deliberately generic — no
+  catalogue-specific schema knowledge — and are candidates for
+  promotion to `phoenix_kit` core once a coordinated release lands.
+  Keeping them here for now avoids coupling catalogue's hex dep to
+  unpublished core features.
 
   ## Examples
 
@@ -36,6 +49,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
   require Logger
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
   import PhoenixKitWeb.Components.Core.TableDefault
   import PhoenixKitWeb.Components.Core.TableRowMenu
 
@@ -50,7 +64,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
   def status_badge(assigns) do
     ~H"""
     <div class={["badge", status_class(@status), size_class(@size)]}>
-      {String.capitalize(@status)}
+      {status_label(@status)}
     </div>
     """
   end
@@ -60,6 +74,17 @@ defmodule PhoenixKitCatalogue.Web.Components do
   defp status_class("deleted"), do: "badge-error"
   defp status_class("inactive"), do: "badge-warning"
   defp status_class(_), do: "badge-neutral"
+
+  # Status labels are translated via gettext so admin UIs render in the
+  # active locale instead of the raw English DB value. Unknown statuses
+  # fall through to a capitalized version of the raw string.
+  defp status_label("active"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Active")
+  defp status_label("inactive"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")
+  defp status_label("archived"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Archived")
+  defp status_label("deleted"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")
+  defp status_label("discontinued"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued")
+  defp status_label(other) when is_binary(other), do: String.capitalize(other)
+  defp status_label(_), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unknown")
 
   defp size_class(:xs), do: "badge-xs"
   defp size_class(:sm), do: "badge-sm"
@@ -228,10 +253,446 @@ defmodule PhoenixKitCatalogue.Web.Components do
   end
 
   # ═══════════════════════════════════════════════════════════════════
+  # Scope selector
+  # ═══════════════════════════════════════════════════════════════════
+
+  @doc """
+  Renders a compact scope selector for narrowing a search to a subset of
+  catalogues and/or categories.
+
+  Designed to pair with `Catalogue.search_items/2`'s `:catalogue_uuids`
+  and `:category_uuids` options. The component is thin — the parent
+  LiveView owns the selection state and decides which catalogues and
+  categories are pickable. Typical flow:
+
+      # LV loads the pickable set (e.g. via list_catalogues_by_name_prefix/2)
+      socket
+      |> assign(:scope_catalogues, Catalogue.list_catalogues_by_name_prefix("Kit"))
+      |> assign(:scope_categories, [])
+      |> assign(:selected_catalogue_uuids, [])
+      |> assign(:selected_category_uuids, [])
+
+  Renders as a disclosure with a summary ("2 catalogues · all categories")
+  and two checkbox lists inside. Each section is only rendered when its
+  list is non-empty, so callers can use it for catalogue-only or
+  category-only scoping.
+
+  ## Events
+
+  Emits four events (all names customizable via attrs):
+
+    * `on_toggle_catalogue` — `%{"uuid" => uuid}` when a catalogue is clicked
+    * `on_toggle_category` — `%{"uuid" => uuid}` when a category is clicked
+    * `on_clear_catalogues` — no params; clear all catalogue selections
+    * `on_clear_categories` — no params; clear all category selections
+
+  The LV toggles membership in its own selection lists, then re-runs
+  the search with the updated scope.
+
+  ## Attributes
+
+    * `catalogues` — list of `%Catalogue{}` the user can pick from (default `[]`)
+    * `categories` — list of `%Category{}` the user can pick from (default `[]`)
+    * `selected_catalogue_uuids` — currently selected catalogue UUIDs (default `[]`)
+    * `selected_category_uuids` — currently selected category UUIDs (default `[]`)
+    * `on_toggle_catalogue` — event name (default `"toggle_catalogue_scope"`)
+    * `on_toggle_category` — event name (default `"toggle_category_scope"`)
+    * `on_clear_catalogues` — event name (default `"clear_catalogue_scope"`)
+    * `on_clear_categories` — event name (default `"clear_category_scope"`)
+    * `id` — DOM id (default `"scope-selector"`)
+    * `open` — force the disclosure open (default `false` — collapsed until clicked)
+    * `class` — extra CSS classes on the wrapper
+
+  ## Example
+
+      <.scope_selector
+        catalogues={@scope_catalogues}
+        categories={@scope_categories}
+        selected_catalogue_uuids={@selected_catalogue_uuids}
+        selected_category_uuids={@selected_category_uuids}
+      />
+  """
+  attr(:catalogues, :list, default: [])
+  attr(:categories, :list, default: [])
+  attr(:selected_catalogue_uuids, :list, default: [])
+  attr(:selected_category_uuids, :list, default: [])
+  attr(:on_toggle_catalogue, :string, default: "toggle_catalogue_scope")
+  attr(:on_toggle_category, :string, default: "toggle_category_scope")
+  attr(:on_clear_catalogues, :string, default: "clear_catalogue_scope")
+  attr(:on_clear_categories, :string, default: "clear_category_scope")
+  attr(:id, :string, default: "scope-selector")
+  attr(:open, :boolean, default: false)
+  attr(:class, :string, default: "")
+
+  def scope_selector(assigns) do
+    assigns =
+      assigns
+      |> assign(:has_catalogues, assigns.catalogues != [])
+      |> assign(:has_categories, assigns.categories != [])
+      |> assign(:cat_count, length(assigns.selected_catalogue_uuids))
+      |> assign(:cat_categories_count, length(assigns.selected_category_uuids))
+
+    ~H"""
+    <details
+      :if={@has_catalogues or @has_categories}
+      id={@id}
+      open={@open}
+      class={["collapse collapse-arrow bg-base-200 border border-base-300", @class]}
+    >
+      <summary class="collapse-title min-h-0 py-3 pr-10 text-sm font-medium cursor-pointer">
+        <span class="inline-flex items-center gap-2">
+          <.icon name="hero-funnel" class="w-4 h-4" />
+          <span>{Gettext.gettext(PhoenixKitWeb.Gettext, "Scope")}</span>
+          <span class="text-base-content/60 font-normal">
+            {scope_summary_text(@has_catalogues, @has_categories, @cat_count, @cat_categories_count)}
+          </span>
+        </span>
+      </summary>
+      <div class="collapse-content">
+        <div class="grid gap-4 md:grid-cols-2">
+          <section :if={@has_catalogues}>
+            <div class="flex items-center justify-between mb-2">
+              <span class="label-text font-medium">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogues")}
+              </span>
+              <button
+                :if={@cat_count > 0}
+                type="button"
+                phx-click={@on_clear_catalogues}
+                class="btn btn-ghost btn-xs"
+              >
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+              </button>
+            </div>
+            <ul class="max-h-60 overflow-y-auto pr-1 space-y-1">
+              <li :for={cat <- @catalogues}>
+                <label class="label cursor-pointer justify-start gap-2 py-1">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm"
+                    checked={cat.uuid in @selected_catalogue_uuids}
+                    phx-click={@on_toggle_catalogue}
+                    phx-value-uuid={cat.uuid}
+                  />
+                  <span class="label-text truncate" title={cat.name}>{cat.name}</span>
+                </label>
+              </li>
+            </ul>
+          </section>
+          <section :if={@has_categories}>
+            <div class="flex items-center justify-between mb-2">
+              <span class="label-text font-medium">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Categories")}
+              </span>
+              <button
+                :if={@cat_categories_count > 0}
+                type="button"
+                phx-click={@on_clear_categories}
+                class="btn btn-ghost btn-xs"
+              >
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+              </button>
+            </div>
+            <ul class="max-h-60 overflow-y-auto pr-1 space-y-1">
+              <li :for={cat <- @categories}>
+                <label class="label cursor-pointer justify-start gap-2 py-1">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm"
+                    checked={cat.uuid in @selected_category_uuids}
+                    phx-click={@on_toggle_category}
+                    phx-value-uuid={cat.uuid}
+                  />
+                  <span class="label-text truncate" title={cat.name}>{cat.name}</span>
+                </label>
+              </li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </details>
+    """
+  end
+
+  defp scope_summary_text(has_catalogues, has_categories, cat_count, cat_categories_count) do
+    parts =
+      [
+        has_catalogues && catalogue_summary(cat_count),
+        has_categories && category_summary(cat_categories_count)
+      ]
+      |> Enum.filter(& &1)
+
+    case parts do
+      [] -> ""
+      list -> "· " <> Enum.join(list, " · ")
+    end
+  end
+
+  defp catalogue_summary(0), do: Gettext.gettext(PhoenixKitWeb.Gettext, "all catalogues")
+
+  defp catalogue_summary(n) do
+    Gettext.ngettext(
+      PhoenixKitWeb.Gettext,
+      "%{count} catalogue",
+      "%{count} catalogues",
+      n,
+      count: n
+    )
+  end
+
+  defp category_summary(0), do: Gettext.gettext(PhoenixKitWeb.Gettext, "all categories")
+
+  defp category_summary(n) do
+    Gettext.ngettext(
+      PhoenixKitWeb.Gettext,
+      "%{count} category",
+      "%{count} categories",
+      n,
+      count: n
+    )
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Catalogue rules picker (smart catalogue)
+  # ═══════════════════════════════════════════════════════════════════
+
+  @doc """
+  Renders the smart-catalogue rule editor: one row per candidate
+  catalogue with a checkbox, a numeric value input, and a unit dropdown.
+
+  Pairs with `PhoenixKitCatalogue.Catalogue.put_catalogue_rules/3`. The
+  component is thin — the caller (usually `ItemFormLive`) owns the
+  working-rules state in a map `%{referenced_catalogue_uuid => %{value, unit}}`
+  and calls `put_catalogue_rules/3` on save.
+
+  **Event flow:**
+
+    * `on_toggle` — `%{"uuid" => uuid}` when the checkbox is clicked.
+      Caller toggles membership in its rules map.
+    * `on_set_value` — `%{"uuid" => uuid, "value" => string}` when the
+      user edits the amount input.
+    * `on_set_unit` — `%{"uuid" => uuid, "unit" => string}` when the
+      user picks a different unit.
+    * `on_clear` — no params; clear every checked row. Shown only when
+      at least one rule is active.
+
+  Rows for an unchecked catalogue render disabled inputs but stay
+  visible so the user always sees the full picker. When `value` is blank
+  and `item_default_value` is given, the input's placeholder previews
+  the inherited default (e.g. `"Inherit: 5"`). The unit dropdown is
+  self-contained per row — it does not inherit from any item-level
+  default, so changing the item's `default_unit` never flips a rule
+  row's visible unit.
+
+  ## Attributes
+
+    * `catalogues` — list of `%Catalogue{}` the user can pick (required).
+      Typically `Catalogue.list_catalogues()` filtered to active/archived
+      and excluding the parent smart catalogue itself.
+    * `rules` — map `%{referenced_catalogue_uuid => %{value, unit}}`
+      (or `%CatalogueRule{}` values; only `:value` / `:unit` are read).
+      Unchecked catalogues simply don't appear in the map (default `%{}`).
+    * `item_default_value` — item's `default_value`, used as the value
+      input's placeholder (default `nil`)
+    * `units` — list of unit options for the dropdown
+      (default `["percent", "flat"]`). The first entry is the fallback
+      shown when a rule has no unit set yet.
+    * `on_toggle` — event name (default `"toggle_catalogue_rule"`)
+    * `on_set_value` — event name (default `"set_catalogue_rule_value"`)
+    * `on_set_unit` — event name (default `"set_catalogue_rule_unit"`)
+    * `on_clear` — event name (default `"clear_catalogue_rules"`)
+    * `id` — DOM id (default `"catalogue-rules-picker"`)
+    * `class` — extra wrapper classes
+
+  ## Example
+
+      <.catalogue_rules_picker
+        catalogues={@candidate_catalogues}
+        rules={@working_rules}
+        item_default_value={@item_default_value}
+      />
+  """
+  attr(:catalogues, :list, required: true)
+  attr(:rules, :map, default: %{})
+  attr(:item_default_value, :any, default: nil)
+  attr(:units, :list, default: ["percent", "flat"])
+  attr(:on_toggle, :string, default: "toggle_catalogue_rule")
+  attr(:on_set_value, :string, default: "set_catalogue_rule_value")
+  attr(:on_set_unit, :string, default: "set_catalogue_rule_unit")
+  attr(:on_clear, :string, default: "clear_catalogue_rules")
+  attr(:id, :string, default: "catalogue-rules-picker")
+  attr(:class, :string, default: "")
+
+  def catalogue_rules_picker(assigns) do
+    assigns =
+      assigns
+      |> assign(:active_count, map_size(assigns.rules))
+      |> assign(:default_placeholder, default_placeholder(assigns))
+
+    ~H"""
+    <div id={@id} class={["space-y-3", @class]}>
+      <div :if={@catalogues == []} class="text-sm text-base-content/60 italic">
+        {Gettext.gettext(PhoenixKitWeb.Gettext, "No other catalogues available to reference yet.")}
+      </div>
+      <div :if={@catalogues != []}>
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-sm text-base-content/70">
+            {rules_summary_text(@active_count, length(@catalogues))}
+          </span>
+          <button
+            :if={@active_count > 0}
+            type="button"
+            phx-click={@on_clear}
+            class="btn btn-ghost btn-xs"
+          >
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear all")}
+          </button>
+        </div>
+        <div class="rounded-box border border-base-300 bg-base-100 divide-y divide-base-300">
+          <.catalogue_rule_row
+            :for={cat <- @catalogues}
+            catalogue={cat}
+            rule={Map.get(@rules, cat.uuid)}
+            default_placeholder={@default_placeholder}
+            units={@units}
+            on_toggle={@on_toggle}
+            on_set_value={@on_set_value}
+            on_set_unit={@on_set_unit}
+          />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr(:catalogue, :any, required: true)
+  attr(:rule, :any, default: nil)
+  attr(:default_placeholder, :string, default: "")
+  attr(:units, :list, required: true)
+  attr(:on_toggle, :string, required: true)
+  attr(:on_set_value, :string, required: true)
+  attr(:on_set_unit, :string, required: true)
+
+  defp catalogue_rule_row(assigns) do
+    fallback_unit = List.first(assigns.units) || "percent"
+
+    assigns =
+      assigns
+      |> assign(:checked?, not is_nil(assigns.rule))
+      |> assign(:rule_value, rule_value(assigns.rule))
+      |> assign(:rule_unit, rule_unit(assigns.rule, fallback_unit))
+      |> assign(:kind_label, kind_label(assigns.catalogue))
+
+    ~H"""
+    <div class="flex items-center gap-3 px-3 py-2">
+      <label class="flex items-center gap-2 flex-1 min-w-0 cursor-pointer">
+        <input
+          type="checkbox"
+          class="checkbox checkbox-sm"
+          checked={@checked?}
+          phx-click={@on_toggle}
+          phx-value-uuid={@catalogue.uuid}
+        />
+        <span class="truncate" title={@catalogue.name}>{@catalogue.name}</span>
+        <span :if={@kind_label} class="badge badge-outline badge-xs">{@kind_label}</span>
+      </label>
+      <div class="flex items-center gap-2 shrink-0">
+        <input
+          type="number"
+          class="input input-bordered input-sm w-24"
+          value={@rule_value}
+          step="0.0001"
+          min="0"
+          disabled={not @checked?}
+          placeholder={@default_placeholder}
+          phx-blur={@on_set_value}
+          phx-value-uuid={@catalogue.uuid}
+          name="value"
+        />
+        <.select
+          name="unit"
+          id={"rule-unit-#{@catalogue.uuid}"}
+          value={@rule_unit}
+          options={Enum.map(@units, &{unit_label(&1), &1})}
+          class="select-sm w-28"
+          disabled={not @checked?}
+          phx-change={@on_set_unit}
+          phx-value-uuid={@catalogue.uuid}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  defp rules_summary_text(0, total),
+    do:
+      Gettext.gettext(
+        PhoenixKitWeb.Gettext,
+        "%{total} catalogues available — none selected",
+        total: total
+      )
+
+  defp rules_summary_text(active, total) do
+    Gettext.ngettext(
+      PhoenixKitWeb.Gettext,
+      "%{active} of %{total} catalogue selected",
+      "%{active} of %{total} catalogues selected",
+      total,
+      active: active,
+      total: total
+    )
+  end
+
+  defp default_placeholder(%{item_default_value: nil}), do: ""
+
+  defp default_placeholder(%{item_default_value: value}) do
+    Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{value}",
+      value: format_decimal_display(value)
+    )
+  rescue
+    _ -> ""
+  end
+
+  # Strip insignificant trailing zeros so DB values like `5.0000` render
+  # as `5` while `5.1000` still renders as `5.1`. Non-Decimal values
+  # (strings mid-edit, numbers) pass through unchanged.
+  defp format_decimal_display(%Decimal{} = d),
+    do: d |> Decimal.normalize() |> Decimal.to_string(:normal)
+
+  defp format_decimal_display(v) when is_number(v), do: to_string(v)
+  defp format_decimal_display(v) when is_binary(v), do: v
+  defp format_decimal_display(_), do: ""
+
+  defp rule_value(nil), do: ""
+  defp rule_value(%{value: nil}), do: ""
+  defp rule_value(%{value: %Decimal{} = d}), do: format_decimal_display(d)
+  defp rule_value(%{value: v}) when is_number(v) or is_binary(v), do: v
+  defp rule_value(_), do: ""
+
+  # Second arg is the component-level fallback (first entry of `units`,
+  # typically `"percent"`) used only when the rule has no unit of its
+  # own — it does NOT reach for the item's `default_unit`. A rule's unit
+  # is self-contained per row.
+  defp rule_unit(nil, fallback), do: fallback
+  defp rule_unit(%{unit: nil}, fallback), do: fallback
+  defp rule_unit(%{unit: u}, _fallback) when is_binary(u), do: u
+  defp rule_unit(_, fallback), do: fallback
+
+  # "%" is a literal symbol — sending it through gettext just creates
+  # a no-op translation entry that every locale would translate to "%".
+  # "Flat" is a real word and stays translatable.
+  defp unit_label("percent"), do: "%"
+  defp unit_label("flat"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Flat")
+  defp unit_label(u), do: to_string(u)
+
+  defp kind_label(%{kind: "smart"}), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Smart")
+  defp kind_label(_), do: nil
+
+  # ═══════════════════════════════════════════════════════════════════
   # Item table
   # ═══════════════════════════════════════════════════════════════════
 
-  @all_columns ~w(name sku base_price price unit status category catalogue manufacturer)a
+  @all_columns ~w(name sku base_price price discount final_price unit status category catalogue manufacturer)a
 
   @doc """
   Renders a configurable item table with optional card view toggle.
@@ -250,7 +711,11 @@ defmodule PhoenixKitCatalogue.Web.Components do
       and action buttons in the card footer.
     * `id` — unique ID for the component (required when `cards` is true, used by
       the JS hook to persist view preference)
-    * `markup_percentage` — catalogue markup for `:price` column (required if `:price` in columns)
+    * `markup_percentage` — catalogue markup for `:price` and `:final_price` columns
+      (required when either is listed; ignored otherwise)
+    * `discount_percentage` — catalogue discount for `:discount` and `:final_price`
+      columns (required when either is listed; ignored otherwise). The `:discount`
+      column honors per-item overrides via `Item.effective_discount/2`.
     * `edit_path` — 1-arity function `(uuid -> path)` to enable edit links
     * `on_delete` — event name for soft-delete button (e.g. `"delete_item"`)
     * `on_restore` — event name for restore button (e.g. `"restore_item"`)
@@ -284,6 +749,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
   attr(:id, :string, default: nil)
   attr(:storage_key, :string, default: nil)
   attr(:markup_percentage, :any, default: nil)
+  attr(:discount_percentage, :any, default: nil)
   attr(:edit_path, :any, default: nil)
   attr(:on_delete, :string, default: nil)
   attr(:on_restore, :string, default: nil)
@@ -308,7 +774,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
       id={@id}
       storage_key={@storage_key}
       items={@items}
-      card_fields={&card_fields(&1, @card_columns, @markup_percentage, @catalogue_path)}
+      card_fields={&card_fields(&1, @card_columns, @markup_percentage, @discount_percentage, @catalogue_path)}
     >
       <:card_header :let={item}>
         <.link :if={@edit_path && item.uuid} navigate={safe_call(@edit_path, item.uuid)} class="font-medium text-sm link link-hover">{item.name || "—"}</.link>
@@ -322,7 +788,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
       </.table_default_header>
       <.table_default_body>
         <.table_default_row :for={item <- @items}>
-          <.item_cell :for={col <- @columns} column={col} item={item} markup_percentage={@markup_percentage} catalogue_path={@catalogue_path} edit_path={@edit_path} />
+          <.item_cell :for={col <- @columns} column={col} item={item} markup_percentage={@markup_percentage} discount_percentage={@discount_percentage} catalogue_path={@catalogue_path} edit_path={@edit_path} />
           <.item_actions
             :if={@has_actions}
             item={item}
@@ -350,29 +816,41 @@ defmodule PhoenixKitCatalogue.Web.Components do
 
   # ── Card view helpers ───────────────────────────────────────────
 
-  defp card_fields(item, columns, markup_percentage, catalogue_path) do
+  defp card_fields(item, columns, markup_percentage, discount_percentage, catalogue_path) do
     Enum.flat_map(columns, fn col ->
-      case card_field_value(item, col, markup_percentage, catalogue_path) do
+      case card_field_value(item, col, markup_percentage, discount_percentage, catalogue_path) do
         nil -> []
         value -> [%{label: column_label(col), value: value}]
       end
     end)
   end
 
-  defp card_field_value(item, :sku, _, _), do: item.sku || "—"
-  defp card_field_value(item, :base_price, _, _), do: format_price(item.base_price)
-  defp card_field_value(item, :price, markup, _), do: format_price(safe_sale_price(item, markup))
-  defp card_field_value(item, :unit, _, _), do: format_unit(item.unit)
-  defp card_field_value(item, :status, _, _), do: String.capitalize(item.status || "unknown")
-  defp card_field_value(item, :category, _, _), do: safe_assoc_field(item, :category, :name)
+  defp card_field_value(item, :sku, _, _, _), do: item.sku || "—"
+  defp card_field_value(item, :base_price, _, _, _), do: format_price(item.base_price)
 
-  defp card_field_value(item, :catalogue, _, _),
+  defp card_field_value(item, :price, markup, _, _),
+    do: format_price(safe_sale_price(item, markup))
+
+  defp card_field_value(item, :discount, _, discount, _),
+    do: format_percentage(safe_effective_discount(item, discount))
+
+  defp card_field_value(item, :final_price, markup, discount, _),
+    do: format_price(safe_final_price(item, markup, discount))
+
+  defp card_field_value(item, :unit, _, _, _), do: format_unit(item.unit)
+
+  defp card_field_value(item, :status, _, _, _),
+    do: String.capitalize(item.status || "unknown")
+
+  defp card_field_value(item, :category, _, _, _), do: safe_assoc_field(item, :category, :name)
+
+  defp card_field_value(item, :catalogue, _, _, _),
     do: safe_assoc_field(item, :catalogue, :name)
 
-  defp card_field_value(item, :manufacturer, _, _),
+  defp card_field_value(item, :manufacturer, _, _, _),
     do: safe_assoc_field(item, :manufacturer, :name)
 
-  defp card_field_value(_, col, _, _) do
+  defp card_field_value(_, col, _, _, _) do
     Logger.warning("item_table card: unknown column #{inspect(col)}, skipping")
     nil
   end
@@ -389,10 +867,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
     <.link :if={@edit_path && @item.uuid} navigate={safe_call(@edit_path, @item.uuid)} class="btn btn-ghost btn-xs">
       <.icon name="hero-pencil" class="w-3.5 h-3.5" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
     </.link>
-    <button :if={@on_delete} phx-click={@on_delete} phx-value-uuid={@item.uuid} class="btn btn-ghost btn-xs text-error">
+    <button :if={@on_delete} phx-click={@on_delete} phx-value-uuid={@item.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")} class="btn btn-ghost btn-xs text-error">
       <.icon name="hero-trash" class="w-3.5 h-3.5" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
     </button>
-    <button :if={@on_restore} phx-click={@on_restore} phx-value-uuid={@item.uuid} class="btn btn-ghost btn-xs text-success">
+    <button :if={@on_restore} phx-click={@on_restore} phx-value-uuid={@item.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")} class="btn btn-ghost btn-xs text-success">
       <.icon name="hero-arrow-path" class="w-3.5 h-3.5" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
     </button>
     <button :if={@on_permanent_delete} phx-click={@on_permanent_delete} phx-value-uuid={@item.uuid} phx-value-type={@permanent_delete_type} class="btn btn-ghost btn-xs text-error">
@@ -406,6 +884,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
   attr(:column, :atom, required: true)
   attr(:item, :any, required: true)
   attr(:markup_percentage, :any, default: nil)
+  attr(:discount_percentage, :any, default: nil)
   attr(:catalogue_path, :any, default: nil)
   attr(:edit_path, :any, default: nil)
 
@@ -439,6 +918,18 @@ defmodule PhoenixKitCatalogue.Web.Components do
   defp item_cell(%{column: :price} = assigns) do
     ~H"""
     <.table_default_cell class="text-sm font-semibold">{format_price(safe_sale_price(@item, @markup_percentage))}</.table_default_cell>
+    """
+  end
+
+  defp item_cell(%{column: :discount} = assigns) do
+    ~H"""
+    <.table_default_cell class="text-sm">{format_percentage(safe_effective_discount(@item, @discount_percentage))}</.table_default_cell>
+    """
+  end
+
+  defp item_cell(%{column: :final_price} = assigns) do
+    ~H"""
+    <.table_default_cell class="text-sm font-semibold">{format_price(safe_final_price(@item, @markup_percentage, @discount_percentage))}</.table_default_cell>
     """
   end
 
@@ -518,8 +1009,8 @@ defmodule PhoenixKitCatalogue.Web.Components do
       <.table_row_menu mode="auto" id={"item-action-#{@item.uuid}"}>
         <.table_row_menu_link :if={@edit_path} navigate={safe_call(@edit_path, @item.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} />
         <.table_row_menu_divider :if={@edit_path && (@on_delete || @on_restore)} />
-        <.table_row_menu_button :if={@on_delete} phx-click={@on_delete} phx-value-uuid={@item.uuid} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
-        <.table_row_menu_button :if={@on_restore} phx-click={@on_restore} phx-value-uuid={@item.uuid} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")} variant="success" />
+        <.table_row_menu_button :if={@on_delete} phx-click={@on_delete} phx-value-uuid={@item.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
+        <.table_row_menu_button :if={@on_restore} phx-click={@on_restore} phx-value-uuid={@item.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")} variant="success" />
         <.table_row_menu_divider :if={@on_restore && @on_permanent_delete} />
         <.table_row_menu_button :if={@on_permanent_delete} phx-click={@on_permanent_delete} phx-value-uuid={@item.uuid} phx-value-type={@permanent_delete_type} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")} variant="error" />
       </.table_row_menu>
@@ -538,6 +1029,8 @@ defmodule PhoenixKitCatalogue.Web.Components do
   defp column_label(:sku), do: Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")
   defp column_label(:base_price), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")
   defp column_label(:price), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Price")
+  defp column_label(:discount), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Discount")
+  defp column_label(:final_price), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Final Price")
   defp column_label(:unit), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")
   defp column_label(:status), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Status")
   defp column_label(:category), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Category")
@@ -562,13 +1055,19 @@ defmodule PhoenixKitCatalogue.Web.Components do
   defp format_unit("running_meter"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "rm")
   defp format_unit(other), do: to_string(other)
 
-  # Safe sale price calculation — handles non-Decimal markup gracefully
+  # Sale-price wrapper: coerces non-Decimal markup at the boundary so
+  # callers can pass Decimal | number | string | nil without thinking.
+  # `Item.sale_price/2` itself is total over `(item, Decimal | nil)`.
   defp safe_sale_price(item, markup) do
     Item.sale_price(item, ensure_decimal(markup))
-  rescue
-    e ->
-      Logger.warning("item_table: sale_price error: #{Exception.message(e)}")
-      nil
+  end
+
+  defp safe_final_price(item, markup, discount) do
+    Item.final_price(item, ensure_decimal(markup), ensure_decimal(discount))
+  end
+
+  defp safe_effective_discount(item, discount) do
+    Item.effective_discount(item, ensure_decimal(discount))
   end
 
   defp ensure_decimal(nil), do: nil
@@ -577,7 +1076,18 @@ defmodule PhoenixKitCatalogue.Web.Components do
   defp ensure_decimal(s) when is_binary(s), do: Decimal.new(s)
   defp ensure_decimal(_), do: nil
 
-  # Safe association access — returns "—" if association is nil or not loaded
+  defp format_percentage(nil), do: "—"
+
+  defp format_percentage(%Decimal{} = pct) do
+    case Decimal.compare(pct, Decimal.new("0")) do
+      :eq -> "—"
+      _ -> Decimal.to_string(pct, :normal) <> "%"
+    end
+  end
+
+  # Returns "—" if the association is nil or not loaded; otherwise the
+  # named field. Used at template render time, where a bare `nil` would
+  # be ugly. This is presentation, not error handling.
   defp safe_assoc_field(record, assoc, field) do
     case Map.get(record, assoc) do
       %{__struct__: Ecto.Association.NotLoaded} -> "—"
@@ -586,14 +1096,13 @@ defmodule PhoenixKitCatalogue.Web.Components do
     end
   end
 
-  # Safe function call — catches errors from path functions
-  defp safe_call(func, arg) do
-    func.(arg)
-  rescue
-    e ->
-      Logger.warning("item_table: path function error: #{Exception.message(e)}")
-      "#"
-  end
+  # Calls a caller-supplied path function. Both `nil` paths and `nil`
+  # UUIDs collapse to `"#"` so unguarded `navigate={...}` attrs always
+  # produce a defined href. Path functions themselves are trusted to
+  # be total over a binary UUID.
+  defp safe_call(nil, _arg), do: "#"
+  defp safe_call(_func, nil), do: "#"
+  defp safe_call(func, arg) when is_function(func, 1), do: func.(arg)
 
   # Safe nested association access — follows a path of keys, returns nil on any miss
 end

--- a/lib/phoenix_kit_catalogue/web/events_live.ex
+++ b/lib/phoenix_kit_catalogue/web/events_live.ex
@@ -9,6 +9,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   use Phoenix.LiveView
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
 
   alias PhoenixKit.Utils.Routes
   alias PhoenixKitCatalogue.Paths
@@ -149,6 +150,28 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   defp blank_to_nil(""), do: nil
   defp blank_to_nil(val), do: val
 
+  # Translates the raw resource_type string for the filter dropdown.
+  # `resource_types` is built from DB content and may surface unknown
+  # types in the future — fall through to capitalize so they still
+  # render readably.
+  defp humanize_resource_type("item"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Item")
+  defp humanize_resource_type("category"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Category")
+
+  defp humanize_resource_type("catalogue"),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue")
+
+  defp humanize_resource_type("manufacturer"),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")
+
+  defp humanize_resource_type("supplier"),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Supplier")
+
+  defp humanize_resource_type("smart_rule"),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Smart rule")
+
+  defp humanize_resource_type(other) when is_binary(other), do: String.capitalize(other)
+  defp humanize_resource_type(_), do: ""
+
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, _key, ""), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
@@ -229,35 +252,27 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
       <div class="bg-base-200 rounded-lg p-3">
         <.form for={%{}} phx-change="filter" class="flex flex-wrap gap-3 items-end">
           <div class="form-control">
-            <label class="label"><span class="label-text text-xs">Action</span></label>
-            <label class="select select-bordered select-sm">
-              <select name="filter[action]">
-                <option value="">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "All Actions")}
-                </option>
-                <%= for action <- @action_types do %>
-                  <option value={action} selected={@filter_action == action}>
-                    {action}
-                  </option>
-                <% end %>
-              </select>
-            </label>
+            <.select
+              name="filter[action]"
+              id="events-filter-action"
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Action")}
+              value={@filter_action}
+              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "All Actions")}
+              options={Enum.map(@action_types, &{&1, &1})}
+              class="select-sm"
+            />
           </div>
 
           <div class="form-control">
-            <label class="label"><span class="label-text text-xs">Resource</span></label>
-            <label class="select select-bordered select-sm">
-              <select name="filter[resource_type]">
-                <option value="">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "All Types")}
-                </option>
-                <%= for rt <- @resource_types do %>
-                  <option value={rt} selected={@filter_resource_type == rt}>
-                    {String.capitalize(rt)}
-                  </option>
-                <% end %>
-              </select>
-            </label>
+            <.select
+              name="filter[resource_type]"
+              id="events-filter-resource"
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Resource")}
+              value={@filter_resource_type}
+              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "All Types")}
+              options={Enum.map(@resource_types, &{humanize_resource_type(&1), &1})}
+              class="select-sm"
+            />
           </div>
 
           <button type="button" phx-click="clear_filters" class="btn btn-ghost btn-sm">

--- a/lib/phoenix_kit_catalogue/web/import_live.ex
+++ b/lib/phoenix_kit_catalogue/web/import_live.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   require Logger
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
 
   import PhoenixKitWeb.Components.MultilangForm,
     only: [
@@ -1206,20 +1207,23 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     <div class="form-control w-full max-w-md">
       <span class="block mb-2 text-sm font-medium">{@label}</span>
       <form id={@form_id} phx-change={@on_change} class="space-y-3">
-        <label class="select w-full">
-          <select name={@mode_field}>
-            <option value="none" selected={@mode == :none}>{@none_label}</option>
-            <option value="column" selected={@mode == :column}>{@column_label}</option>
-            <option value="create" selected={@mode == :create}>{@create_label}</option>
-            <option
-              :for={opt <- @options}
-              value={"existing:#{opt.uuid}"}
-              selected={@mode == :existing and @uuid == opt.uuid}
-            >
-              {opt.name}
-            </option>
-          </select>
-        </label>
+        <.select
+          name={@mode_field}
+          id={"#{@form_id}-mode"}
+          value={
+            case @mode do
+              :existing -> "existing:#{@uuid}"
+              mode -> to_string(mode)
+            end
+          }
+          options={
+            [
+              {@none_label, "none"},
+              {@column_label, "column"},
+              {@create_label, "create"}
+            ] ++ Enum.map(@options, &{&1.name, "existing:#{&1.uuid}"})
+          }
+        />
 
         <div :if={@mode == :column} class="pl-4 border-l-2 border-secondary/20">
           <% available = available_picker_columns(@column_mappings, @target) %>
@@ -1232,26 +1236,24 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
               )}
             </p>
           <% else %>
-            <label class="select select-sm w-full">
-              <select name={@column_field}>
-                <option value="" disabled selected={not has_mapping?(@column_mappings, @target)}>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
-                </option>
-                <%!-- Only offer columns that are unmapped (`:skip`),
-                     already this picker's target, or used as a custom
-                     `{:data, _}` field. Hiding columns already mapped
-                     to another unique target (`:name`, `:sku`, etc.)
-                     prevents the picker from silently clobbering an
-                     auto-detected mapping the user still relies on. --%>
-                <option
-                  :for={mapping <- available}
-                  value={mapping.column_index}
-                  selected={mapping.target == @target}
-                >
-                  {mapping.header}
-                </option>
-              </select>
-            </label>
+            <% selected_col =
+              Enum.find_value(available, fn m ->
+                if m.target == @target, do: m.column_index
+              end) %>
+            <%!-- Only offer columns that are unmapped (`:skip`),
+                 already this picker's target, or used as a custom
+                 `{:data, _}` field. Hiding columns already mapped
+                 to another unique target (`:name`, `:sku`, etc.)
+                 prevents the picker from silently clobbering an
+                 auto-detected mapping the user still relies on. --%>
+            <.select
+              name={@column_field}
+              id={"#{@form_id}-column"}
+              value={selected_col}
+              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
+              options={Enum.map(available, &{&1.header, &1.column_index})}
+              class="select-sm"
+            />
           <% end %>
           <div :if={has_mapping?(@column_mappings, @target)} class="mt-2">
             <span class="text-xs text-base-content/60">{@preview_label}</span>
@@ -1371,6 +1373,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       phx-submit="continue_to_confirm"
       class="mt-4 pl-4 border-l-2 border-secondary/20"
     >
+      <%!-- Only translatable fields live inside the wrapper. Position
+           stays outside so a language switch doesn't remount it. --%>
       <.multilang_fields_wrapper
         multilang_enabled={@multilang_enabled}
         current_lang={@current_lang}
@@ -1422,26 +1426,26 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           type="textarea"
           class="w-full"
         />
-
-        <div class="form-control">
-          <span class="label-text font-semibold mb-2">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Position")}
-          </span>
-          <input
-            type="number"
-            name="category[position]"
-            value={Ecto.Changeset.get_field(@changeset, :position)}
-            class="input input-bordered w-28 transition-colors focus:input-primary"
-            min="0"
-          />
-          <span class="label-text-alt text-base-content/50 mt-1">
-            {Gettext.gettext(
-              PhoenixKitWeb.Gettext,
-              "Lower numbers appear first."
-            )}
-          </span>
-        </div>
       </.multilang_fields_wrapper>
+
+      <div class="form-control mt-6">
+        <span class="label-text font-semibold mb-2">
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Position")}
+        </span>
+        <input
+          type="number"
+          name="category[position]"
+          value={Ecto.Changeset.get_field(@changeset, :position)}
+          class="input input-bordered w-28 transition-colors focus:input-primary"
+          min="0"
+        />
+        <span class="label-text-alt text-base-content/50 mt-1">
+          {Gettext.gettext(
+            PhoenixKitWeb.Gettext,
+            "Lower numbers appear first."
+          )}
+        </span>
+      </div>
     </form>
     """
   end
@@ -1491,20 +1495,18 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             <span class="block mb-2 text-sm font-medium">
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Target Catalogue")}
             </span>
-            <label class="select w-full">
-              <select name="catalogue">
-                <option value="" disabled selected={@selected_catalogue == nil}>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Select a catalogue...")}
-                </option>
-                <option
-                  :for={cat <- @catalogues}
-                  value={cat.uuid}
-                  selected={@selected_catalogue && @selected_catalogue.uuid == cat.uuid}
-                >
-                  {catalogue_picker_label(cat, @catalogue_item_counts, @catalogue_category_counts)}
-                </option>
-              </select>
-            </label>
+            <.select
+              name="catalogue"
+              id="upload-catalogue"
+              value={@selected_catalogue && @selected_catalogue.uuid}
+              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Select a catalogue...")}
+              options={
+                Enum.map(
+                  @catalogues,
+                  &{catalogue_picker_label(&1, @catalogue_item_counts, @catalogue_category_counts), &1.uuid}
+                )
+              }
+            />
             <p :if={@catalogues == []} class="text-sm text-base-content/50 mt-1">
               {Gettext.gettext(PhoenixKitWeb.Gettext, "No catalogues yet.")}
               <.link navigate={Paths.catalogue_new()} class="link link-primary">
@@ -1647,11 +1649,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <%!-- Sheet selector --%>
         <form :if={length(@sheets) > 1} id="sheet-form" phx-change="select_sheet" class="flex items-center gap-2">
           <span class="text-sm font-medium">{Gettext.gettext(PhoenixKitWeb.Gettext, "Sheet:")}</span>
-          <label class="select select-sm">
-            <select name="sheet">
-              <option :for={sheet <- @sheets} value={sheet} selected={sheet == @selected_sheet}>{sheet}</option>
-            </select>
-          </label>
+          <.select
+            name="sheet"
+            id="import-sheet"
+            value={@selected_sheet}
+            options={Enum.map(@sheets, &{&1, &1})}
+            class="select-sm"
+          />
         </form>
 
         <%!-- Language selector --%>
@@ -1667,22 +1671,24 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <div class="form-control w-full max-w-md">
           <span class="block mb-2 text-sm font-medium">{Gettext.gettext(PhoenixKitWeb.Gettext, "Import Into Category")}</span>
           <form id="category-form" phx-change="select_import_category" class="space-y-3">
-            <label class="select w-full">
-              <select name="category_mode">
-                <option value="none" selected={@import_category_mode == :none}>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No category — import items without a category")}
-                </option>
-                <option value="column" selected={@import_category_mode == :column}>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — create categories from column values")}
-                </option>
-                <option value="create" selected={@import_category_mode == :create}>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new category — fill in the details below")}
-                </option>
-                <option :for={cat <- @catalogue_categories} value={"existing:#{cat.uuid}"} selected={@import_category_mode == :existing and @import_category_uuid == cat.uuid}>
-                  {cat.name}
-                </option>
-              </select>
-            </label>
+            <.select
+              name="category_mode"
+              id="import-category-mode"
+              value={
+                case @import_category_mode do
+                  :existing -> "existing:#{@import_category_uuid}"
+                  mode -> to_string(mode)
+                end
+              }
+              options={
+                [
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No category — import items without a category"), "none"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — create categories from column values"), "column"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new category — fill in the details below"), "create"}
+                ] ++
+                  Enum.map(@catalogue_categories, &{&1.name, "existing:#{&1.uuid}"})
+              }
+            />
 
             <%!-- Column picker for category --%>
             <div :if={@import_category_mode == :column} class="pl-4 border-l-2 border-secondary/20">
@@ -1724,20 +1730,18 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                   )}
                 </p>
               <% else %>
-                <label class="select select-sm w-full">
-                  <select name="category_column">
-                    <option value="" disabled selected={not has_mapping?(@column_mappings, :category)}>
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
-                    </option>
-                    <option
-                      :for={mapping <- available_category_cols}
-                      value={mapping.column_index}
-                      selected={mapping.target == :category}
-                    >
-                      {mapping.header}
-                    </option>
-                  </select>
-                </label>
+                <% selected_category_col =
+                  Enum.find_value(available_category_cols, fn m ->
+                    if m.target == :category, do: m.column_index
+                  end) %>
+                <.select
+                  name="category_column"
+                  id="import-category-column"
+                  value={selected_category_col}
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
+                  options={Enum.map(available_category_cols, &{&1.header, &1.column_index})}
+                  class="select-sm"
+                />
               <% end %>
               <%!-- Show preview of categories that will be created --%>
               <div :if={has_mapping?(@column_mappings, :category)} class="mt-2">
@@ -1837,17 +1841,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                   {mapping.header}
                 </div>
                 <.icon name="hero-arrow-right" class="w-4 h-4 text-base-content/30 hidden sm:block" />
-                <label class="select select-sm flex-1">
-                  <select name={"mapping[#{mapping.column_index}]"}>
-                    <option
-                      :for={{target, label} <- @all_targets}
-                      value={target_to_string(target)}
-                      selected={mapping.target == target}
-                    >
-                      {label}
-                    </option>
-                  </select>
-                </label>
+                <.select
+                  name={"mapping[#{mapping.column_index}]"}
+                  id={"mapping-#{mapping.column_index}"}
+                  value={target_to_string(mapping.target)}
+                  options={Enum.map(@all_targets, fn {target, label} -> {label, target_to_string(target)} end)}
+                  class="select-sm flex-1"
+                />
               </div>
 
               <%!-- Inline unit value mapping (shows when this column is mapped to Unit) --%>
@@ -1859,11 +1859,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                   <div :for={value <- @unit_values} class="flex items-center gap-2">
                     <span class="badge badge-outline badge-sm min-w-[60px] justify-center">{value}</span>
                     <.icon name="hero-arrow-right" class="w-3 h-3 text-base-content/30" />
-                    <label class="select select-xs">
-                      <select name={"unit_map[#{value}]"}>
-                        <option :for={unit <- @allowed_units} value={unit} selected={Map.get(@unit_map, value, "piece") == unit}>{unit}</option>
-                      </select>
-                    </label>
+                    <.select
+                      name={"unit_map[#{value}]"}
+                      id={"unit-map-#{value}"}
+                      value={Map.get(@unit_map, value, "piece")}
+                      options={Enum.map(@allowed_units, &{&1, &1})}
+                      class="select-xs"
+                    />
                   </div>
                 </div>
               </div>

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -8,6 +8,9 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   import PhoenixKitWeb.Components.MultilangForm
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
+  import PhoenixKitCatalogue.Web.Components, only: [catalogue_rules_picker: 1]
 
   alias PhoenixKit.Utils.Multilang
   alias PhoenixKitCatalogue.Catalogue
@@ -19,6 +22,9 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     "sku" => :sku,
     "base_price" => :base_price,
     "markup_percentage" => :markup_percentage,
+    "discount_percentage" => :discount_percentage,
+    "default_value" => :default_value,
+    "default_unit" => :default_unit,
     "unit" => :unit,
     "status" => :status,
     "category_uuid" => :category_uuid,
@@ -54,10 +60,26 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         {nil, nil, nil}
 
       item ->
-        item = PhoenixKit.RepoHelper.repo().preload(item, [:category, :manufacturer])
+        item =
+          item
+          |> PhoenixKit.RepoHelper.repo().preload([:category, :manufacturer])
+          |> normalize_display_decimals()
+
         {item, Catalogue.change_item(item), item.catalogue_uuid}
     end
   end
+
+  # DB-stored decimals keep the column's scale (e.g. DECIMAL(12, 4) gives
+  # back `#Decimal<5.0000>` for what the user typed as `5`). Strip the
+  # insignificant trailing zeros once at load time so the initial form
+  # render shows `5`; user-typed values during validate are left alone.
+  defp normalize_display_decimals(%Item{} = item) do
+    %{item | default_value: normalize_decimal(item.default_value)}
+  end
+
+  defp normalize_decimal(nil), do: nil
+  defp normalize_decimal(%Decimal{} = d), do: Decimal.normalize(d)
+  defp normalize_decimal(other), do: other
 
   defp mount_form(socket, action, item, changeset, catalogue_uuid) do
     categories =
@@ -66,6 +88,17 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         else: Catalogue.list_all_categories()
 
     all_categories = if action == :edit, do: Catalogue.list_all_categories(), else: []
+    parent_catalogue = load_parent_catalogue(catalogue_uuid)
+    kind = catalogue_kind(parent_catalogue)
+
+    # Smart items move between smart catalogues (no category concept);
+    # standard items use the existing "pick a category anywhere" flow.
+    smart_move_targets =
+      if action == :edit and kind == "smart" do
+        Catalogue.list_catalogues(kind: :smart) |> Enum.reject(&(&1.uuid == catalogue_uuid))
+      else
+        []
+      end
 
     socket
     |> assign(
@@ -77,16 +110,58 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       action: action,
       item: item,
       catalogue_uuid: catalogue_uuid,
-      catalogue_markup: catalogue_markup_for(catalogue_uuid),
-      changeset: changeset,
+      catalogue_kind: kind,
+      catalogue_markup: markup_from_catalogue(parent_catalogue),
+      catalogue_discount: discount_from_catalogue(parent_catalogue),
       categories: categories,
       manufacturers: Catalogue.list_manufacturers(status: "active"),
       all_categories: all_categories,
+      smart_move_targets: smart_move_targets,
       move_target: nil
     )
+    |> assign_changeset(changeset)
+    |> assign_rule_state(item, kind, catalogue_uuid)
     |> mount_multilang()
     |> adjust_multilang_for_item(item)
   end
+
+  # Keeps both :changeset (for <.translatable_field>) and :form (for
+  # <.input>/<.select> bindings) in sync — validate and save-error paths
+  # go through this helper so they can't drift apart.
+  defp assign_changeset(socket, changeset) do
+    socket
+    |> assign(:changeset, changeset)
+    |> assign(:form, to_form(changeset))
+  end
+
+  # Smart-catalogue picker state: only populated when the parent
+  # catalogue is kind: "smart". For standard catalogues we still assign
+  # empty defaults so the render path can reference the keys unconditionally.
+  defp assign_rule_state(socket, _item, "smart" = _kind, catalogue_uuid) do
+    candidates = Catalogue.list_catalogues() |> Enum.reject(&(&1.uuid == catalogue_uuid))
+
+    existing =
+      case socket.assigns.item do
+        %Item{uuid: nil} -> %{}
+        %Item{} = item -> Catalogue.catalogue_rule_map(item) |> Map.new(&to_working_entry/1)
+      end
+
+    assign(socket,
+      rule_candidates: candidates,
+      working_rules: existing
+    )
+  end
+
+  defp assign_rule_state(socket, _item, _kind, _catalogue_uuid) do
+    assign(socket, rule_candidates: [], working_rules: %{})
+  end
+
+  # Coerce nil units to "percent" on load. Persisted NULL units are a
+  # legacy of the earlier "inherit from item.default_unit" behavior;
+  # now that the picker no longer inherits, surfacing NULL as "percent"
+  # keeps the dropdown honest (what you see is what will be saved).
+  defp to_working_entry({uuid, %{value: value, unit: unit}}),
+    do: {uuid, %{value: normalize_decimal(value), unit: unit || "percent"}}
 
   # If the item's embedded primary language differs from the global primary,
   # start on the item's language tab and flag that the global primary needs filling in.
@@ -94,19 +169,22 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   # Always assigns `needs_primary_translation` and `item_primary_language`
   # — even when multilang is disabled — so the render path can reference
   # them unconditionally without crashing on a missing key.
-  # Loads just the catalogue's markup so the form can show it as a hint
-  # next to the per-item override field. Returns nil if the item isn't
-  # scoped to a catalogue yet (shouldn't happen in practice, since
-  # create/edit always run inside a catalogue), in which case the hint
-  # is simply omitted.
-  defp catalogue_markup_for(nil), do: nil
+  # Loads the parent catalogue once so the form can surface markup,
+  # discount, kind, and (for smart catalogues) the candidate reference
+  # list. Returns nil if the item isn't scoped to a catalogue yet, in
+  # which case every derived field is nil and the render path omits
+  # kind-specific sections.
+  defp load_parent_catalogue(nil), do: nil
+  defp load_parent_catalogue(catalogue_uuid), do: Catalogue.get_catalogue(catalogue_uuid)
 
-  defp catalogue_markup_for(catalogue_uuid) do
-    case Catalogue.get_catalogue(catalogue_uuid) do
-      %{markup_percentage: markup} -> markup
-      _ -> nil
-    end
-  end
+  defp catalogue_kind(%{kind: kind}) when is_binary(kind), do: kind
+  defp catalogue_kind(_), do: "standard"
+
+  defp markup_from_catalogue(%{markup_percentage: markup}), do: markup
+  defp markup_from_catalogue(_), do: nil
+
+  defp discount_from_catalogue(%{discount_percentage: discount}), do: discount
+  defp discount_from_catalogue(_), do: nil
 
   defp adjust_multilang_for_item(socket, item) do
     if socket.assigns.multilang_enabled do
@@ -155,7 +233,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       |> Catalogue.change_item(params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign(socket, :changeset, changeset)}
+    {:noreply, assign_changeset(socket, changeset)}
   end
 
   def handle_event("save", %{"item" => params}, socket) do
@@ -168,8 +246,63 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     save_item(socket, socket.assigns.action, params)
   end
 
-  def handle_event("select_move_target", %{"category_uuid" => uuid}, socket) do
-    target = if uuid == "", do: nil, else: uuid
+  # ── Smart-catalogue rule picker events ──────────────────────────
+  # All four events mutate `socket.assigns.working_rules`; actual
+  # persistence happens during save via `put_catalogue_rules/3`.
+
+  def handle_event("toggle_catalogue_rule", %{"uuid" => uuid}, socket) do
+    rules = socket.assigns.working_rules
+
+    working_rules =
+      if Map.has_key?(rules, uuid) do
+        Map.delete(rules, uuid)
+      else
+        # Unit is always explicit per rule — it does not inherit from the
+        # item's default_unit. Value is left nil so it can still inherit
+        # via the "Inherit: N" placeholder flow.
+        Map.put(rules, uuid, %{value: nil, unit: "percent"})
+      end
+
+    {:noreply, assign(socket, :working_rules, working_rules)}
+  end
+
+  def handle_event("set_catalogue_rule_value", %{"uuid" => uuid, "value" => raw}, socket) do
+    rules = socket.assigns.working_rules
+
+    case Map.get(rules, uuid) do
+      nil ->
+        {:noreply, socket}
+
+      entry ->
+        new_value = parse_decimal_or_nil(raw)
+        working_rules = Map.put(rules, uuid, %{entry | value: new_value})
+        {:noreply, assign(socket, :working_rules, working_rules)}
+    end
+  end
+
+  def handle_event("set_catalogue_rule_unit", %{"uuid" => uuid, "unit" => unit}, socket) do
+    rules = socket.assigns.working_rules
+
+    case Map.get(rules, uuid) do
+      nil ->
+        {:noreply, socket}
+
+      entry ->
+        new_unit = if unit in ["", nil], do: nil, else: unit
+        working_rules = Map.put(rules, uuid, %{entry | unit: new_unit})
+        {:noreply, assign(socket, :working_rules, working_rules)}
+    end
+  end
+
+  def handle_event("clear_catalogue_rules", _params, socket) do
+    {:noreply, assign(socket, :working_rules, %{})}
+  end
+
+  def handle_event("select_move_target", params, socket) do
+    # Accept the UUID under either key depending on which select fired —
+    # standard forms use `category_uuid`, smart forms use `catalogue_uuid`.
+    uuid = params["category_uuid"] || params["catalogue_uuid"]
+    target = if uuid in [nil, ""], do: nil, else: uuid
     {:noreply, assign(socket, :move_target, target)}
   end
 
@@ -177,23 +310,39 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     target = socket.assigns.move_target
 
     if target do
-      case Catalogue.move_item_to_category(socket.assigns.item, target, actor_opts(socket)) do
-        {:ok, item} ->
-          {:noreply,
-           socket
-           |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item moved."))
-           |> push_navigate(to: redirect_target(socket, item))}
-
-        {:error, _} ->
-          {:noreply,
-           put_flash(
-             socket,
-             :error,
-             Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move item.")
-           )}
-      end
+      perform_move(socket, target)
     else
       {:noreply, socket}
+    end
+  end
+
+  # Routes on the parent catalogue's kind: smart items move across
+  # catalogues (categories don't apply), standard items move between
+  # categories (the catalogue is derived from the target category).
+  defp perform_move(socket, target) do
+    result =
+      case socket.assigns.catalogue_kind do
+        "smart" ->
+          Catalogue.move_item_to_catalogue(socket.assigns.item, target, actor_opts(socket))
+
+        _ ->
+          Catalogue.move_item_to_category(socket.assigns.item, target, actor_opts(socket))
+      end
+
+    case result do
+      {:ok, item} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item moved."))
+         |> push_navigate(to: redirect_target(socket, item))}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move item.")
+         )}
     end
   end
 
@@ -207,15 +356,26 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   defp save_item(socket, :new, params) do
     params = Map.put_new(params, "catalogue_uuid", socket.assigns.catalogue_uuid)
 
-    case Catalogue.create_item(params, actor_opts(socket)) do
-      {:ok, item} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item created."))
-         |> push_navigate(to: redirect_target(socket, item))}
+    with {:ok, item} <- Catalogue.create_item(params, actor_opts(socket)),
+         {:ok, _rules} <- maybe_put_rules(socket, item) do
+      {:noreply,
+       socket
+       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item created."))
+       |> push_navigate(to: redirect_target(socket, item))}
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_changeset(socket, changeset)}
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+      {:error, {:duplicate_referenced_catalogue, _uuid}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Each catalogue can only appear once in the rules list."
+           )
+         )}
     end
   end
 
@@ -230,15 +390,62 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         params
       end
 
-    case Catalogue.update_item(socket.assigns.item, params, actor_opts(socket)) do
-      {:ok, item} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item updated."))
-         |> push_navigate(to: redirect_target(socket, item))}
+    with {:ok, item} <- Catalogue.update_item(socket.assigns.item, params, actor_opts(socket)),
+         {:ok, _rules} <- maybe_put_rules(socket, item) do
+      {:noreply,
+       socket
+       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item updated."))
+       |> push_navigate(to: redirect_target(socket, item))}
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_changeset(socket, changeset)}
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+      {:error, {:duplicate_referenced_catalogue, _uuid}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Each catalogue can only appear once in the rules list."
+           )
+         )}
+    end
+  end
+
+  # Only persist rules when the parent catalogue is smart. On standard
+  # catalogues the picker is never rendered, `working_rules` stays `%{}`,
+  # and we skip the context call entirely.
+  defp maybe_put_rules(socket, item) do
+    case socket.assigns.catalogue_kind do
+      "smart" ->
+        rules = working_rules_to_specs(socket.assigns.working_rules)
+        Catalogue.put_catalogue_rules(item, rules, actor_opts(socket))
+
+      _ ->
+        {:ok, :skipped}
+    end
+  end
+
+  defp working_rules_to_specs(working_rules) do
+    working_rules
+    |> Enum.with_index()
+    |> Enum.map(fn {{uuid, %{value: v, unit: u}}, idx} ->
+      %{referenced_catalogue_uuid: uuid, value: v, unit: u, position: idx}
+    end)
+  end
+
+  # Accepts the blur-event string, returns a Decimal or nil (for blank /
+  # unparseable). Lets the user clear the field to revert to "inherit
+  # from item default".
+  defp parse_decimal_or_nil(""), do: nil
+  defp parse_decimal_or_nil(nil), do: nil
+
+  defp parse_decimal_or_nil(s) when is_binary(s) do
+    case Decimal.parse(s) do
+      {decimal, ""} -> decimal
+      {decimal, _rest} -> decimal
+      :error -> nil
     end
   end
 
@@ -283,11 +490,16 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         </div>
       </div>
 
-      <.form for={to_form(@changeset)} action="#" phx-change="validate" phx-submit="save">
+      <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
           <.multilang_tabs multilang_enabled={@multilang_enabled} language_tabs={@language_tabs} current_lang={@current_lang} />
 
-          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5">
+          <%!-- Only translatable fields live inside the wrapper. When the
+               user switches languages, the wrapper's ID changes and
+               morphdom remounts its children — so we keep the scope as
+               small as possible (name + description), not the whole
+               form. Everything else renders as a sibling below. --%>
+          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5 pb-0">
             <:skeleton>
               <%!-- Name --%>
               <div class="space-y-2">
@@ -299,51 +511,8 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 <div class="skeleton h-4 w-28"></div>
                 <div class="skeleton h-24 w-full"></div>
               </div>
-              <div class="divider my-0"></div>
-              <%!-- Pricing header --%>
-              <div class="skeleton h-5 w-44"></div>
-              <%!-- SKU + Price + Unit grid --%>
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-12"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-14"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-12"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Classification header --%>
-              <div class="skeleton h-5 w-32"></div>
-              <%!-- Category + Manufacturer grid --%>
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-20"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-                <div class="space-y-2">
-                  <div class="skeleton h-4 w-28"></div>
-                  <div class="skeleton h-12 w-full"></div>
-                </div>
-              </div>
-              <%!-- Status --%>
-              <div class="space-y-2">
-                <div class="skeleton h-4 w-16"></div>
-                <div class="skeleton h-12 w-full"></div>
-              </div>
-              <div class="divider my-0"></div>
-              <%!-- Buttons --%>
-              <div class="flex justify-end gap-3">
-                <div class="skeleton h-12 w-20"></div>
-                <div class="skeleton h-12 w-32"></div>
-              </div>
             </:skeleton>
-            <div class="card-body flex flex-col gap-5">
+            <div class="card-body flex flex-col gap-5 pb-0">
               <.translatable_field
                 field_name="name" form_prefix="item" changeset={@changeset}
                 schema_field={:name} multilang_enabled={@multilang_enabled}
@@ -360,45 +529,56 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Product specifications, dimensions, materials...")}
                 class="w-full"
               />
+            </div>
+          </.multilang_fields_wrapper>
 
-              <div class="divider my-0"></div>
+          <div class="card-body flex flex-col gap-5 pt-0">
+              <%!-- Pricing & identification — hidden for smart catalogues,
+                   whose items are priced entirely by the rules picker below. --%>
+              <div :if={@catalogue_kind != "smart"} class="flex flex-col gap-5">
+                <div class="divider my-0"></div>
 
-              <%!-- Pricing & identification --%>
-              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-                </svg>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Pricing & Identification")}
-              </h2>
+                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+                  </svg>
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Pricing & Identification")}
+                </h2>
 
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")}</span>
-                  <input type="text" name="item[sku]" value={Ecto.Changeset.get_field(@changeset, :sku) || ""} class="input input-bordered w-full font-mono transition-colors focus:input-primary" placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., KF-001")} />
-                </div>
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")}</span>
-                  <input type="number" name="item[base_price]" value={Ecto.Changeset.get_field(@changeset, :base_price)} class="input input-bordered w-full transition-colors focus:input-primary" step="0.01" min="0" placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "0.00")} />
-                  <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cost/purchase price before catalogue markup.")}</span>
-                </div>
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}</span>
-                  <label class="select w-full transition-colors focus-within:select-primary">
-                    <select name="item[unit]">
-                      <option value="piece" selected={Ecto.Changeset.get_field(@changeset, :unit) == "piece"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Piece")}</option>
-                      <option value="m2" selected={Ecto.Changeset.get_field(@changeset, :unit) == "m2"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "m² (square meter)")}</option>
-                      <option value="running_meter" selected={Ecto.Changeset.get_field(@changeset, :unit) == "running_meter"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Running meter")}</option>
-                    </select>
-                  </label>
-                </div>
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Override")}</span>
-                  <div class="relative">
-                    <input
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <.input
+                    field={@form[:sku]}
+                    type="text"
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")}
+                    class="font-mono"
+                    placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., KF-001")}
+                  />
+                  <div class="form-control">
+                    <.input
+                      field={@form[:base_price]}
                       type="number"
-                      name="item[markup_percentage]"
-                      value={Ecto.Changeset.get_field(@changeset, :markup_percentage)}
-                      class="input input-bordered w-full transition-colors focus:input-primary pr-8"
+                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")}
+                      step="0.01"
+                      min="0"
+                      placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "0.00")}
+                    />
+                    <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cost/purchase price before catalogue markup.")}</span>
+                  </div>
+                  <.select
+                    field={@form[:unit]}
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}
+                    class="transition-colors focus-within:select-primary"
+                    options={[
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Piece"), "piece"},
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "m² (square meter)"), "m2"},
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Running meter"), "running_meter"}
+                    ]}
+                  />
+                  <div class="form-control">
+                    <.input
+                      field={@form[:markup_percentage]}
+                      type="number"
+                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Override (%)")}
                       step="0.01"
                       min="0"
                       placeholder={
@@ -407,66 +587,120 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                           else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue markup")
                       }
                     />
-                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/40 text-sm">%</span>
+                    <span class="label-text-alt text-base-content/50 mt-1">
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Leave blank to inherit the catalogue's markup. Set (including 0) to override just this item.")}
+                    </span>
                   </div>
-                  <span class="label-text-alt text-base-content/50 mt-1">
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Leave blank to inherit the catalogue's markup. Set (including 0) to override just this item.")}
-                  </span>
+                  <div class="form-control">
+                    <.input
+                      field={@form[:discount_percentage]}
+                      type="number"
+                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Discount Override (%)")}
+                      step="0.01"
+                      min="0"
+                      max="100"
+                      placeholder={
+                        if @catalogue_discount,
+                          do: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{discount}%", discount: Decimal.to_string(@catalogue_discount, :normal)),
+                          else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue discount")
+                      }
+                    />
+                    <span class="label-text-alt text-base-content/50 mt-1">
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Leave blank to inherit the catalogue's discount. Set (including 0) to override just this item.")}
+                    </span>
+                  </div>
                 </div>
               </div>
 
-              <div class="divider my-0"></div>
+              <%!-- Smart-catalogue rules (only for kind: "smart") --%>
+              <div :if={@catalogue_kind == "smart"} class="flex flex-col gap-4">
+                <div class="divider my-0"></div>
+                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                  <.icon name="hero-link" class="w-4 h-4" />
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue Rules")}
+                </h2>
+                <p class="text-sm text-base-content/60 -mt-2">
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Pick which catalogues this item applies to and set a value + unit per catalogue. Rows left blank inherit the defaults below.")}
+                </p>
 
-              <%!-- Classification --%>
-              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                </svg>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Classification")}
-              </h2>
-
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}</span>
-                  <label class="select w-full transition-colors focus-within:select-primary">
-                    <select name="item[category_uuid]">
-                      <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- No category --")}</option>
-                      <option
-                        :for={cat <- @categories}
-                        value={cat.uuid}
-                        selected={to_string(Ecto.Changeset.get_field(@changeset, :category_uuid)) == to_string(cat.uuid)}
-                      >
-                        {cat.name}
-                      </option>
-                    </select>
-                  </label>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div class="form-control">
+                    <.input
+                      field={@form[:default_value]}
+                      type="number"
+                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Value")}
+                      step="0.0001"
+                      min="0"
+                      placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 5")}
+                    />
+                    <span class="label-text-alt text-base-content/50 mt-1">
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Used for any selected catalogue that doesn't have its own value. If no catalogues are selected, this is the item's standalone fee (e.g. $50 flat).")}
+                    </span>
+                  </div>
+                  <div class="form-control">
+                    <.select
+                      field={@form[:default_unit]}
+                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Unit")}
+                      class="transition-colors focus-within:select-primary"
+                      options={[
+                        {Gettext.gettext(PhoenixKitWeb.Gettext, "Percent (%)"), "percent"},
+                        {Gettext.gettext(PhoenixKitWeb.Gettext, "Flat amount"), "flat"}
+                      ]}
+                    />
+                    <span class="label-text-alt text-base-content/50 mt-1">
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Used for any selected catalogue that doesn't have its own unit.")}
+                    </span>
+                  </div>
                 </div>
-                <div class="form-control">
-                  <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")}</span>
-                  <label class="select w-full transition-colors focus-within:select-primary">
-                    <select name="item[manufacturer_uuid]">
-                      <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- No manufacturer --")}</option>
-                      <option
-                        :for={m <- @manufacturers}
-                        value={m.uuid}
-                        selected={to_string(Ecto.Changeset.get_field(@changeset, :manufacturer_uuid)) == to_string(m.uuid)}
-                      >
-                        {m.name}
-                      </option>
-                    </select>
-                  </label>
+
+                <.catalogue_rules_picker
+                  catalogues={@rule_candidates}
+                  rules={@working_rules}
+                  item_default_value={Ecto.Changeset.get_field(@changeset, :default_value)}
+                />
+              </div>
+
+              <%!-- Classification — hidden for smart catalogues, whose items
+                   don't belong to a category/manufacturer in the usual sense. --%>
+              <div :if={@catalogue_kind != "smart"} class="flex flex-col gap-5">
+                <div class="divider my-0"></div>
+
+                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                  </svg>
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Classification")}
+                </h2>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <.select
+                    field={@form[:category_uuid]}
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}
+                    class="transition-colors focus-within:select-primary"
+                    prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No category --")}
+                    options={Enum.map(@categories, &{&1.name, &1.uuid})}
+                  />
+                  <.select
+                    field={@form[:manufacturer_uuid]}
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")}
+                    class="transition-colors focus-within:select-primary"
+                    prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No manufacturer --")}
+                    options={Enum.map(@manufacturers, &{&1.name, &1.uuid})}
+                  />
                 </div>
               </div>
 
               <div class="form-control">
-                <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-                <label class="select w-full transition-colors focus-within:select-primary">
-                  <select name="item[status]">
-                    <option value="active" selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}</option>
-                    <option value="inactive" selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")}</option>
-                    <option value="discontinued" selected={Ecto.Changeset.get_field(@changeset, :status) == "discontinued"}>{Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued")}</option>
-                  </select>
-                </label>
+                <.select
+                  field={@form[:status]}
+                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                  class="transition-colors focus-within:select-primary"
+                  options={[
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"},
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued"), "discontinued"}
+                  ]}
+                />
                 <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued items are kept for reference but hidden from active listings.")}</span>
               </div>
 
@@ -475,26 +709,63 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
 
               <div class="flex justify-end gap-3">
                 <.link navigate={if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
-                <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">{if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Item"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}</button>
+                <button
+                  type="submit"
+                  class="btn btn-primary phx-submit-loading:opacity-75"
+                  phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+                >{if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Item"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}</button>
               </div>
-            </div>
-          </.multilang_fields_wrapper>
+          </div>
         </div>
       </.form>
 
-      <%!-- Move to another category — only in edit mode --%>
-      <div :if={@action == :edit && @all_categories != []} class="card bg-base-100 shadow-lg">
+      <%!-- Move — standard items move to a category anywhere; smart
+           items move across smart catalogues (no category). Each card
+           only renders when its own target list is non-empty so we
+           never show an empty-dropdown dead end. --%>
+      <div :if={@action == :edit && @catalogue_kind != "smart" && @all_categories != []} class="card bg-base-100 shadow-lg">
         <div class="card-body flex flex-col gap-3">
           <h3 class="text-sm font-semibold text-base-content/80">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Category")}</h3>
           <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item to a category in any catalogue.")}</p>
           <div class="flex items-end gap-3">
             <div class="form-control flex-1">
-              <label class="select w-full select-sm transition-colors focus-within:select-primary">
-                <select phx-change="select_move_target" name="category_uuid">
-                  <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}</option>
-                  <option :for={cat <- @all_categories} value={cat.uuid}>{cat.name}</option>
-                </select>
-              </label>
+              <.select
+                name="category_uuid"
+                id="item-move-category"
+                value={@move_target}
+                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}
+                options={Enum.map(@all_categories, &{&1.name, &1.uuid})}
+                class="select-sm transition-colors focus-within:select-primary"
+                phx-change="select_move_target"
+              />
+            </div>
+            <button
+              type="button"
+              phx-click="move_item"
+              disabled={is_nil(@move_target)}
+              class="btn btn-sm btn-outline"
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div :if={@action == :edit && @catalogue_kind == "smart" && @smart_move_targets != []} class="card bg-base-100 shadow-lg">
+        <div class="card-body flex flex-col gap-3">
+          <h3 class="text-sm font-semibold text-base-content/80">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Smart Catalogue")}</h3>
+          <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item into a different smart catalogue. Its catalogue rules stay attached.")}</p>
+          <div class="flex items-end gap-3">
+            <div class="form-control flex-1">
+              <.select
+                name="catalogue_uuid"
+                id="item-move-smart-catalogue"
+                value={@move_target}
+                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
+                options={Enum.map(@smart_move_targets, &{&1.name, &1.uuid})}
+                class="select-sm transition-colors focus-within:select-primary"
+                phx-change="select_move_target"
+              />
             </div>
             <button
               type="button"

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -6,6 +6,10 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
+  import PhoenixKitWeb.Components.Core.Textarea, only: [textarea: 1]
 
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
@@ -42,7 +46,8 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
       all_suppliers = Catalogue.list_suppliers(status: "active")
 
       {:ok,
-       assign(socket,
+       socket
+       |> assign(
          page_title:
            if(action == :new,
              do: Gettext.gettext(PhoenixKitWeb.Gettext, "New Manufacturer"),
@@ -50,11 +55,17 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
            ),
          action: action,
          manufacturer: manufacturer,
-         changeset: changeset,
          all_suppliers: all_suppliers,
          linked_supplier_uuids: MapSet.new(linked_supplier_uuids)
-       )}
+       )
+       |> assign_changeset(changeset)}
     end
+  end
+
+  defp assign_changeset(socket, changeset) do
+    socket
+    |> assign(:changeset, changeset)
+    |> assign(:form, to_form(changeset))
   end
 
   @impl true
@@ -64,7 +75,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
       |> Catalogue.change_manufacturer(params)
       |> Map.put(:action, socket.assigns.changeset.action)
 
-    {:noreply, assign(socket, :changeset, changeset)}
+    {:noreply, assign_changeset(socket, changeset)}
   end
 
   def handle_event("toggle_supplier", %{"uuid" => uuid}, socket) do
@@ -119,7 +130,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
         end
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -153,7 +164,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
         end
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -168,118 +179,74 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
         subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Add a new manufacturer to your catalogue system."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update manufacturer details and supplier links.")}
       />
 
-      <.form for={to_form(@changeset)} action="#" phx-change="validate" phx-submit="save">
+      <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
           <div class="card-body flex flex-col gap-5">
-            <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} *</span>
-              <input
-                type="text"
-                name="manufacturer[name]"
-                value={Ecto.Changeset.get_field(@changeset, :name) || ""}
-                class="input input-bordered w-full transition-colors focus:input-primary"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Blum, Hettich")}
-              />
-              <p :for={msg <- changeset_errors(@changeset, :name)} class="text-error text-sm mt-1">
-                {msg}
-              </p>
-            </div>
+            <.input
+              field={@form[:name]}
+              type="text"
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name *")}
+              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Blum, Hettich")}
+              required
+            />
 
-            <div class="form-control">
-              <span class="label-text font-semibold mb-2">Description</span>
-              <textarea
-                name="manufacturer[description]"
-                class="textarea textarea-bordered w-full transition-colors focus:textarea-primary"
-                rows="3"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Brief description of this manufacturer...")}
-              >{Ecto.Changeset.get_field(@changeset, :description) || ""}</textarea>
-            </div>
+            <.textarea
+              field={@form[:description]}
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+              rows="3"
+              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Brief description of this manufacturer...")}
+            />
 
             <div class="divider my-0"></div>
 
             <%!-- Contact & web --%>
             <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                />
-              </svg>
+              <.icon name="hero-envelope" class="h-4 w-4" />
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Contact & Web")}
             </h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div class="form-control">
-                <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}</span>
-                <input
-                  type="url"
-                  name="manufacturer[website]"
-                  value={Ecto.Changeset.get_field(@changeset, :website) || ""}
-                  class="input input-bordered w-full transition-colors focus:input-primary"
-                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
-                />
-              </div>
-              <div class="form-control">
-                <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Contact Info")}</span>
-                <input
-                  type="text"
-                  name="manufacturer[contact_info]"
-                  value={Ecto.Changeset.get_field(@changeset, :contact_info) || ""}
-                  class="input input-bordered w-full transition-colors focus:input-primary"
-                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Email or phone")}
-                />
-              </div>
-            </div>
-
-            <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Logo URL")}</span>
-              <input
+              <.input
+                field={@form[:website]}
                 type="url"
-                name="manufacturer[logo_url]"
-                value={Ecto.Changeset.get_field(@changeset, :logo_url) || ""}
-                class="input input-bordered w-full transition-colors focus:input-primary"
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}
                 placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
+              />
+              <.input
+                field={@form[:contact_info]}
+                type="text"
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Contact Info")}
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Email or phone")}
               />
             </div>
 
-            <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Notes")}</span>
-              <textarea
-                name="manufacturer[notes]"
-                class="textarea textarea-bordered w-full min-h-[5rem] transition-colors focus:textarea-primary"
-                rows="2"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Internal notes about this manufacturer...")}
-              >{Ecto.Changeset.get_field(@changeset, :notes) || ""}</textarea>
-            </div>
+            <.input
+              field={@form[:logo_url]}
+              type="url"
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Logo URL")}
+              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
+            />
+
+            <.textarea
+              field={@form[:notes]}
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Notes")}
+              rows="2"
+              class="min-h-[5rem]"
+              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Internal notes about this manufacturer...")}
+            />
 
             <div class="divider my-0"></div>
 
             <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-              <label class="select w-full transition-colors focus-within:select-primary">
-                <select name="manufacturer[status]">
-                  <option
-                    value="active"
-                    selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
-                  >
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
-                  </option>
-                  <option
-                    value="inactive"
-                    selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}
-                  >
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")}
-                  </option>
-                </select>
-              </label>
+              <.select
+                field={@form[:status]}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                class="transition-colors focus-within:select-primary"
+                options={[
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"}
+                ]}
+              />
               <span class="label-text-alt text-base-content/50 mt-1">
                 {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive manufacturers won't appear in item dropdowns.")}
               </span>
@@ -290,23 +257,12 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
               <div class="divider my-0"></div>
 
               <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                  />
-                </svg>
-                Linked Suppliers
+                <.icon name="hero-link" class="h-4 w-4" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Linked Suppliers")}
               </h2>
-              <p class="text-sm text-base-content/50 -mt-2">Click to toggle supplier associations.</p>
+              <p class="text-sm text-base-content/50 -mt-2">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Click to toggle supplier associations.")}
+              </p>
 
               <div class="flex flex-wrap gap-2">
                 <label
@@ -321,21 +277,11 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
                   phx-click="toggle_supplier"
                   phx-value-uuid={supplier.uuid}
                 >
-                  <svg
+                  <.icon
                     :if={MapSet.member?(@linked_supplier_uuids, supplier.uuid)}
-                    xmlns="http://www.w3.org/2000/svg"
+                    name="hero-check"
                     class="h-3.5 w-3.5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
+                  />
                   {supplier.name}
                 </label>
               </div>
@@ -346,7 +292,11 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
 
             <div class="flex justify-end gap-3">
               <.link navigate={Paths.manufacturers()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
-              <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">
+              <button
+                type="submit"
+                class="btn btn-primary phx-submit-loading:opacity-75"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+              >
                 {if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Manufacturer"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}
               </button>
             </div>
@@ -355,20 +305,5 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
       </.form>
     </div>
     """
-  end
-
-  defp changeset_errors(%Ecto.Changeset{action: action, errors: errors}, field)
-       when not is_nil(action) do
-    errors
-    |> Keyword.get_values(field)
-    |> Enum.map(&translate_error/1)
-  end
-
-  defp changeset_errors(_changeset, _field), do: []
-
-  defp translate_error({msg, opts}) do
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-    end)
   end
 end

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -6,6 +6,10 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
+  import PhoenixKitWeb.Components.Core.Textarea, only: [textarea: 1]
 
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
@@ -42,7 +46,8 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
       all_manufacturers = Catalogue.list_manufacturers(status: "active")
 
       {:ok,
-       assign(socket,
+       socket
+       |> assign(
          page_title:
            if(action == :new,
              do: Gettext.gettext(PhoenixKitWeb.Gettext, "New Supplier"),
@@ -50,11 +55,17 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
            ),
          action: action,
          supplier: supplier,
-         changeset: changeset,
          all_manufacturers: all_manufacturers,
          linked_manufacturer_uuids: MapSet.new(linked_manufacturer_uuids)
-       )}
+       )
+       |> assign_changeset(changeset)}
     end
+  end
+
+  defp assign_changeset(socket, changeset) do
+    socket
+    |> assign(:changeset, changeset)
+    |> assign(:form, to_form(changeset))
   end
 
   @impl true
@@ -64,7 +75,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
       |> Catalogue.change_supplier(params)
       |> Map.put(:action, socket.assigns.changeset.action)
 
-    {:noreply, assign(socket, :changeset, changeset)}
+    {:noreply, assign_changeset(socket, changeset)}
   end
 
   def handle_event("toggle_manufacturer", %{"uuid" => uuid}, socket) do
@@ -119,7 +130,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
         end
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -153,7 +164,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
         end
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign_changeset(socket, changeset)}
     end
   end
 
@@ -168,107 +179,67 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
         subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Add a new supplier to your catalogue system."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update supplier details and manufacturer links.")}
       />
 
-      <.form for={to_form(@changeset)} action="#" phx-change="validate" phx-submit="save">
+      <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
           <div class="card-body flex flex-col gap-5">
-            <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} *</span>
-              <input
-                type="text"
-                name="supplier[name]"
-                value={Ecto.Changeset.get_field(@changeset, :name) || ""}
-                class="input input-bordered w-full transition-colors focus:input-primary"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Regional Distributors Inc.")}
-              />
-              <p :for={msg <- changeset_errors(@changeset, :name)} class="text-error text-sm mt-1">
-                {msg}
-              </p>
-            </div>
+            <.input
+              field={@form[:name]}
+              type="text"
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name *")}
+              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Regional Distributors Inc.")}
+              required
+            />
 
-            <div class="form-control">
-              <span class="label-text font-semibold mb-2">Description</span>
-              <textarea
-                name="supplier[description]"
-                class="textarea textarea-bordered w-full transition-colors focus:textarea-primary"
-                rows="3"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Brief description of this supplier...")}
-              >{Ecto.Changeset.get_field(@changeset, :description) || ""}</textarea>
-            </div>
+            <.textarea
+              field={@form[:description]}
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+              rows="3"
+              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Brief description of this supplier...")}
+            />
 
             <div class="divider my-0"></div>
 
             <%!-- Contact & web --%>
             <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                />
-              </svg>
+              <.icon name="hero-envelope" class="h-4 w-4" />
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Contact & Web")}
             </h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div class="form-control">
-                <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}</span>
-                <input
-                  type="url"
-                  name="supplier[website]"
-                  value={Ecto.Changeset.get_field(@changeset, :website) || ""}
-                  class="input input-bordered w-full transition-colors focus:input-primary"
-                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
-                />
-              </div>
-              <div class="form-control">
-                <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Contact Info")}</span>
-                <input
-                  type="text"
-                  name="supplier[contact_info]"
-                  value={Ecto.Changeset.get_field(@changeset, :contact_info) || ""}
-                  class="input input-bordered w-full transition-colors focus:input-primary"
-                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Email or phone")}
-                />
-              </div>
+              <.input
+                field={@form[:website]}
+                type="url"
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
+              />
+              <.input
+                field={@form[:contact_info]}
+                type="text"
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Contact Info")}
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Email or phone")}
+              />
             </div>
 
-            <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Notes")}</span>
-              <textarea
-                name="supplier[notes]"
-                class="textarea textarea-bordered w-full min-h-[5rem] transition-colors focus:textarea-primary"
-                rows="2"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Internal notes about this supplier...")}
-              >{Ecto.Changeset.get_field(@changeset, :notes) || ""}</textarea>
-            </div>
+            <.textarea
+              field={@form[:notes]}
+              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Notes")}
+              rows="2"
+              class="min-h-[5rem]"
+              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Internal notes about this supplier...")}
+            />
 
             <div class="divider my-0"></div>
 
             <div class="form-control">
-              <span class="label-text font-semibold mb-2">{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</span>
-              <label class="select w-full transition-colors focus-within:select-primary">
-                <select name="supplier[status]">
-                  <option
-                    value="active"
-                    selected={Ecto.Changeset.get_field(@changeset, :status) == "active"}
-                  >
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
-                  </option>
-                  <option
-                    value="inactive"
-                    selected={Ecto.Changeset.get_field(@changeset, :status) == "inactive"}
-                  >
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")}
-                  </option>
-                </select>
-              </label>
+              <.select
+                field={@form[:status]}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                class="transition-colors focus-within:select-primary"
+                options={[
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"}
+                ]}
+              />
               <span class="label-text-alt text-base-content/50 mt-1">
                 {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive suppliers won't appear in manufacturer linking.")}
               </span>
@@ -279,24 +250,11 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
               <div class="divider my-0"></div>
 
               <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                  />
-                </svg>
-                Linked Manufacturers
+                <.icon name="hero-link" class="h-4 w-4" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Linked Manufacturers")}
               </h2>
               <p class="text-sm text-base-content/50 -mt-2">
-                Click to toggle manufacturer associations.
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Click to toggle manufacturer associations.")}
               </p>
 
               <div class="flex flex-wrap gap-2">
@@ -312,21 +270,11 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
                   phx-click="toggle_manufacturer"
                   phx-value-uuid={m.uuid}
                 >
-                  <svg
+                  <.icon
                     :if={MapSet.member?(@linked_manufacturer_uuids, m.uuid)}
-                    xmlns="http://www.w3.org/2000/svg"
+                    name="hero-check"
                     class="h-3.5 w-3.5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
+                  />
                   {m.name}
                 </label>
               </div>
@@ -337,7 +285,11 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
 
             <div class="flex justify-end gap-3">
               <.link navigate={Paths.suppliers()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
-              <button type="submit" class="btn btn-primary phx-submit-loading:opacity-75">
+              <button
+                type="submit"
+                class="btn btn-primary phx-submit-loading:opacity-75"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+              >
                 {if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Supplier"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}
               </button>
             </div>
@@ -346,20 +298,5 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
       </.form>
     </div>
     """
-  end
-
-  defp changeset_errors(%Ecto.Changeset{action: action, errors: errors}, field)
-       when not is_nil(action) do
-    errors
-    |> Keyword.get_values(field)
-    |> Enum.map(&translate_error/1)
-  end
-
-  defp changeset_errors(_changeset, _field), do: []
-
-  defp translate_error({msg, opts}) do
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-    end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKitCatalogue.MixProject do
   use Mix.Project
 
-  @version "0.1.9"
+  @version "0.1.12"
   @source_url "https://github.com/BeamLabEU/phoenix_kit_catalogue"
 
   def project do
@@ -10,6 +10,13 @@ defmodule PhoenixKitCatalogue.MixProject do
       version: @version,
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
+      # Elixir 1.19 mix test requires explicit filters to know which test
+      # files to load and which to ignore. Without this it warns about
+      # `test/support/*.ex` not matching either filter and skips running
+      # the support modules through its loader, which means
+      # `test_helper.exs` runs before they're available.
+      test_load_filters: [~r/_test\.exs$/],
+      test_ignore_filters: [~r{^test/support/}],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description:

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -1,6 +1,7 @@
 defmodule PhoenixKitCatalogue.CatalogueTest do
   use PhoenixKitCatalogue.DataCase, async: true
 
+  alias Ecto.Adapters.SQL
   alias PhoenixKitCatalogue.Catalogue
 
   # ── Helpers ──────────────────────────────────────────────────────
@@ -968,7 +969,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
 
       assert Decimal.equal?(pricing.base_price, Decimal.new("100.00"))
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("20"))
-      assert Decimal.equal?(pricing.price, Decimal.new("120.00"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("120.00"))
     end
 
     test "uses 0% markup when catalogue has default" do
@@ -979,7 +980,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       pricing = Catalogue.item_pricing(item)
 
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("0"))
-      assert Decimal.equal?(pricing.price, Decimal.new("50.00"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("50.00"))
     end
 
     test "uses 0% markup for uncategorized items" do
@@ -988,7 +989,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       pricing = Catalogue.item_pricing(item)
 
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("0"))
-      assert Decimal.equal?(pricing.price, Decimal.new("75.00"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("75.00"))
     end
 
     test "returns nil price when base_price is nil" do
@@ -999,7 +1000,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       pricing = Catalogue.item_pricing(item)
 
       assert is_nil(pricing.base_price)
-      assert is_nil(pricing.price)
+      assert is_nil(pricing.sale_price)
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("10"))
     end
 
@@ -1021,7 +1022,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Decimal.equal?(pricing.item_markup, Decimal.new("50"))
       # Effective markup is the item's override
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("50"))
-      assert Decimal.equal?(pricing.price, Decimal.new("150.00"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("150.00"))
     end
 
     test "item_markup is nil when there is no override" do
@@ -1053,7 +1054,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Decimal.equal?(pricing.catalogue_markup, Decimal.new("25"))
       assert Decimal.equal?(pricing.item_markup, Decimal.new("0"))
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("0"))
-      assert Decimal.equal?(pricing.price, Decimal.new("100.00"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("100.00"))
     end
 
     test "falls back to 0% markup when the catalogue association is unloaded and preload fails" do
@@ -1075,7 +1076,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
 
       assert Decimal.equal?(pricing.base_price, Decimal.new("42.00"))
       assert Decimal.equal?(pricing.markup_percentage, Decimal.new("0"))
-      assert Decimal.equal?(pricing.price, Decimal.new("42.00"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("42.00"))
     end
   end
 
@@ -1956,7 +1957,7 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
 
       pricing = Catalogue.item_pricing(item)
       # 99.99 * 1.3333 = 133.316667 → rounds to 133.32
-      assert Decimal.equal?(pricing.price, Decimal.new("133.32"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("133.32"))
     end
 
     test "list_items_for_catalogue on a catalogue with no items returns []" do
@@ -2018,6 +2019,856 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Catalogue.get_catalogue(cat.uuid).status == "active"
       assert Catalogue.get_category(category.uuid).status == "active"
       assert Catalogue.get_item(item.uuid).status == "active"
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Prefix lookup + scoped search (0.1.10)
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "list_catalogues_by_name_prefix/2" do
+    test "matches case-insensitively at the start of the name" do
+      create_catalogue(%{name: "Kitchen Furniture"})
+      create_catalogue(%{name: "Kits and Tools"})
+      create_catalogue(%{name: "Bathroom"})
+
+      names =
+        "kit"
+        |> Catalogue.list_catalogues_by_name_prefix()
+        |> Enum.map(& &1.name)
+
+      assert "Kitchen Furniture" in names
+      assert "Kits and Tools" in names
+      refute "Bathroom" in names
+    end
+
+    test "is anchored — does not match mid-name" do
+      create_catalogue(%{name: "Bathroom Kits"})
+      create_catalogue(%{name: "Kitchen"})
+
+      names =
+        "kit"
+        |> Catalogue.list_catalogues_by_name_prefix()
+        |> Enum.map(& &1.name)
+
+      assert "Kitchen" in names
+      refute "Bathroom Kits" in names
+    end
+
+    test "excludes deleted by default" do
+      cat = create_catalogue(%{name: "Kitchen"})
+      Catalogue.trash_catalogue(cat)
+
+      assert Catalogue.list_catalogues_by_name_prefix("Kit") == []
+    end
+
+    test ":status opt narrows to a specific status" do
+      cat = create_catalogue(%{name: "Kitchen"})
+      Catalogue.trash_catalogue(cat)
+
+      [result] = Catalogue.list_catalogues_by_name_prefix("Kit", status: "deleted")
+      assert result.name == "Kitchen"
+    end
+
+    test ":limit opt caps results" do
+      for n <- 1..5, do: create_catalogue(%{name: "Kit #{n}"})
+
+      assert length(Catalogue.list_catalogues_by_name_prefix("Kit", limit: 3)) == 3
+    end
+
+    test "empty prefix returns all non-deleted" do
+      create_catalogue(%{name: "Alpha"})
+      create_catalogue(%{name: "Beta"})
+
+      names =
+        ""
+        |> Catalogue.list_catalogues_by_name_prefix()
+        |> Enum.map(& &1.name)
+
+      assert "Alpha" in names
+      assert "Beta" in names
+    end
+
+    test "escapes LIKE metacharacters in the prefix" do
+      create_catalogue(%{name: "100% Pure"})
+      create_catalogue(%{name: "Anything"})
+
+      # Without escaping, `%` would match any prefix.
+      names =
+        "100%"
+        |> Catalogue.list_catalogues_by_name_prefix()
+        |> Enum.map(& &1.name)
+
+      assert names == ["100% Pure"]
+    end
+  end
+
+  describe "search_items/2 with scope filters" do
+    test ":catalogue_uuids narrows to the listed catalogues" do
+      cat_a = create_catalogue(%{name: "A"})
+      cat_b = create_catalogue(%{name: "B"})
+      cat_c = create_catalogue(%{name: "C"})
+      cat_a_cat = create_category(cat_a)
+      cat_b_cat = create_category(cat_b)
+      cat_c_cat = create_category(cat_c)
+      create_item(%{name: "Oak A", category_uuid: cat_a_cat.uuid})
+      create_item(%{name: "Oak B", category_uuid: cat_b_cat.uuid})
+      create_item(%{name: "Oak C", category_uuid: cat_c_cat.uuid})
+
+      names =
+        "oak"
+        |> Catalogue.search_items(catalogue_uuids: [cat_a.uuid, cat_b.uuid])
+        |> Enum.map(& &1.name)
+
+      assert Enum.sort(names) == ["Oak A", "Oak B"]
+    end
+
+    test ":category_uuids narrows to the listed categories and excludes uncategorized" do
+      cat = create_catalogue()
+      c1 = create_category(cat, %{name: "One"})
+      c2 = create_category(cat, %{name: "Two"})
+      create_item(%{name: "Oak Cat1", category_uuid: c1.uuid})
+      create_item(%{name: "Oak Cat2", category_uuid: c2.uuid})
+      create_item(%{name: "Oak Uncat", catalogue_uuid: cat.uuid, category_uuid: nil})
+
+      names =
+        "oak"
+        |> Catalogue.search_items(category_uuids: [c1.uuid])
+        |> Enum.map(& &1.name)
+
+      assert names == ["Oak Cat1"]
+    end
+
+    test ":catalogue_uuids and :category_uuids compose with AND" do
+      cat_a = create_catalogue(%{name: "A"})
+      cat_b = create_catalogue(%{name: "B"})
+      c_a1 = create_category(cat_a)
+      c_b1 = create_category(cat_b)
+      create_item(%{name: "Oak A1", category_uuid: c_a1.uuid})
+      create_item(%{name: "Oak B1", category_uuid: c_b1.uuid})
+
+      # Category is in cat_b, but we scope to cat_a → no results
+      assert Catalogue.search_items("oak",
+               catalogue_uuids: [cat_a.uuid],
+               category_uuids: [c_b1.uuid]
+             ) == []
+
+      # Category matches its catalogue → gets the item
+      [item] =
+        Catalogue.search_items("oak",
+          catalogue_uuids: [cat_a.uuid],
+          category_uuids: [c_a1.uuid]
+        )
+
+      assert item.name == "Oak A1"
+    end
+
+    test "nil and empty lists are treated as 'no filter'" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      create_item(%{name: "Oak", category_uuid: category.uuid})
+
+      assert length(Catalogue.search_items("oak", catalogue_uuids: nil)) == 1
+      assert length(Catalogue.search_items("oak", catalogue_uuids: [])) == 1
+      assert length(Catalogue.search_items("oak", category_uuids: nil)) == 1
+      assert length(Catalogue.search_items("oak", category_uuids: [])) == 1
+    end
+
+    test "count_search_items/2 accepts the same scope filters" do
+      cat_a = create_catalogue(%{name: "A"})
+      cat_b = create_catalogue(%{name: "B"})
+      c_a = create_category(cat_a)
+      c_b = create_category(cat_b)
+      for n <- 1..3, do: create_item(%{name: "Oak A#{n}", category_uuid: c_a.uuid})
+      for n <- 1..2, do: create_item(%{name: "Oak B#{n}", category_uuid: c_b.uuid})
+
+      assert Catalogue.count_search_items("oak") == 5
+      assert Catalogue.count_search_items("oak", catalogue_uuids: [cat_a.uuid]) == 3
+      assert Catalogue.count_search_items("oak", catalogue_uuids: [cat_b.uuid]) == 2
+
+      assert Catalogue.count_search_items("oak",
+               catalogue_uuids: [cat_a.uuid, cat_b.uuid]
+             ) == 5
+    end
+
+    test "count_search_items/1 (no opts) still works for backwards compatibility" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      for n <- 1..3, do: create_item(%{name: "Oak #{n}", category_uuid: category.uuid})
+
+      assert Catalogue.count_search_items("oak") == 3
+    end
+
+    test "list_catalogues_by_name_prefix/2 + search_items/2 composition" do
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      kits = create_catalogue(%{name: "Kits and Tools"})
+      bathroom = create_catalogue(%{name: "Bathroom"})
+      kitchen_cat = create_category(kitchen)
+      kits_cat = create_category(kits)
+      bathroom_cat = create_category(bathroom)
+      create_item(%{name: "Oak Kitchen", category_uuid: kitchen_cat.uuid})
+      create_item(%{name: "Oak Kits", category_uuid: kits_cat.uuid})
+      create_item(%{name: "Oak Bath", category_uuid: bathroom_cat.uuid})
+
+      uuids =
+        "Kit"
+        |> Catalogue.list_catalogues_by_name_prefix()
+        |> Enum.map(& &1.uuid)
+
+      names =
+        "oak"
+        |> Catalogue.search_items(catalogue_uuids: uuids)
+        |> Enum.map(& &1.name)
+        |> Enum.sort()
+
+      assert names == ["Oak Kitchen", "Oak Kits"]
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Discount (V102 / 0.1.11)
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "catalogue discount_percentage" do
+    test "defaults to 0 when not provided" do
+      cat = create_catalogue()
+      assert Decimal.equal?(cat.discount_percentage, Decimal.new("0"))
+    end
+
+    test "can be set on create" do
+      cat = create_catalogue(%{discount_percentage: "15.5"})
+      assert Decimal.equal?(cat.discount_percentage, Decimal.new("15.5"))
+    end
+
+    test "can be updated" do
+      cat = create_catalogue()
+      {:ok, updated} = Catalogue.update_catalogue(cat, %{discount_percentage: "25"})
+      assert Decimal.equal?(updated.discount_percentage, Decimal.new("25"))
+    end
+
+    test "rejects discount above 100" do
+      {:error, changeset} =
+        Catalogue.create_catalogue(%{name: "Bad", discount_percentage: "150"})
+
+      assert %{discount_percentage: [_ | _]} = errors_on(changeset)
+    end
+
+    test "rejects negative discount" do
+      {:error, changeset} =
+        Catalogue.create_catalogue(%{name: "Bad", discount_percentage: "-1"})
+
+      assert %{discount_percentage: [_ | _]} = errors_on(changeset)
+    end
+  end
+
+  describe "item discount_percentage override" do
+    test "defaults to nil (inherits from catalogue)" do
+      cat = create_catalogue(%{discount_percentage: "10"})
+      category = create_category(cat)
+      item = create_item(%{name: "Inheritor", category_uuid: category.uuid})
+      assert is_nil(item.discount_percentage)
+    end
+
+    test "can be set to 0 (explicit 'no discount' override)" do
+      cat = create_catalogue(%{discount_percentage: "25"})
+      category = create_category(cat)
+
+      item =
+        create_item(%{
+          name: "Full Price",
+          base_price: "100.00",
+          discount_percentage: "0",
+          category_uuid: category.uuid
+        })
+
+      assert Decimal.equal?(item.discount_percentage, Decimal.new("0"))
+    end
+
+    test "rejects discount above 100" do
+      cat = create_catalogue()
+      category = create_category(cat)
+
+      {:error, changeset} =
+        Catalogue.create_item(%{
+          name: "Bad",
+          base_price: "10",
+          discount_percentage: "150",
+          category_uuid: category.uuid
+        })
+
+      assert %{discount_percentage: [_ | _]} = errors_on(changeset)
+    end
+  end
+
+  describe "item_pricing/1 with discount" do
+    test "surfaces catalogue and item discount fields" do
+      cat = create_catalogue(%{markup_percentage: "20", discount_percentage: "10"})
+      category = create_category(cat)
+      item = create_item(%{name: "Panel", base_price: "100.00", category_uuid: category.uuid})
+
+      pricing = Catalogue.item_pricing(item)
+
+      # Markups
+      assert Decimal.equal?(pricing.catalogue_markup, Decimal.new("20"))
+      assert is_nil(pricing.item_markup)
+      assert Decimal.equal?(pricing.markup_percentage, Decimal.new("20"))
+      assert Decimal.equal?(pricing.sale_price, Decimal.new("120.00"))
+
+      # Discounts
+      assert Decimal.equal?(pricing.catalogue_discount, Decimal.new("10"))
+      assert is_nil(pricing.item_discount)
+      assert Decimal.equal?(pricing.discount_percentage, Decimal.new("10"))
+
+      # Final: 100 * 1.20 * 0.90 = 108.00
+      assert Decimal.equal?(pricing.final_price, Decimal.new("108.00"))
+      # Savings: 120 - 108 = 12
+      assert Decimal.equal?(pricing.discount_amount, Decimal.new("12.00"))
+    end
+
+    test "item discount override wins over catalogue discount" do
+      cat = create_catalogue(%{markup_percentage: "0", discount_percentage: "10"})
+      category = create_category(cat)
+
+      item =
+        create_item(%{
+          name: "Big Sale",
+          base_price: "100.00",
+          discount_percentage: "50",
+          category_uuid: category.uuid
+        })
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert Decimal.equal?(pricing.catalogue_discount, Decimal.new("10"))
+      assert Decimal.equal?(pricing.item_discount, Decimal.new("50"))
+      assert Decimal.equal?(pricing.discount_percentage, Decimal.new("50"))
+      assert Decimal.equal?(pricing.final_price, Decimal.new("50.00"))
+      assert Decimal.equal?(pricing.discount_amount, Decimal.new("50.00"))
+    end
+
+    test "item discount of 0 overrides a catalogue discount" do
+      cat = create_catalogue(%{markup_percentage: "0", discount_percentage: "25"})
+      category = create_category(cat)
+
+      item =
+        create_item(%{
+          name: "No Discount For Me",
+          base_price: "100.00",
+          discount_percentage: "0",
+          category_uuid: category.uuid
+        })
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert Decimal.equal?(pricing.discount_percentage, Decimal.new("0"))
+      # sale_price = final_price when discount is 0
+      assert Decimal.equal?(pricing.final_price, Decimal.new("100.00"))
+      assert Decimal.equal?(pricing.discount_amount, Decimal.new("0.00"))
+    end
+
+    test "no discount anywhere → final_price equals sale_price, discount_amount is nil" do
+      cat = create_catalogue(%{markup_percentage: "15"})
+      category = create_category(cat)
+      item = create_item(%{name: "Plain", base_price: "100.00", category_uuid: category.uuid})
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert Decimal.equal?(pricing.catalogue_discount, Decimal.new("0"))
+      assert is_nil(pricing.item_discount)
+      assert Decimal.equal?(pricing.discount_percentage, Decimal.new("0"))
+      # With 0% discount, final equals sale
+      assert Decimal.equal?(pricing.final_price, pricing.sale_price)
+      # discount_amount is nil when no discount applies (catalogue=0, item=nil
+      # ⇒ effective is 0, which is truthy — amount is Decimal 0.00 here)
+      assert Decimal.equal?(pricing.discount_amount, Decimal.new("0.00"))
+    end
+
+    test "all-nil discount (no catalogue association) → nil discount fields" do
+      # Detached item with no catalogue loaded → safe_pricing_for_item logs
+      # a warning and returns {0, 0}.
+      item = %PhoenixKitCatalogue.Schemas.Item{
+        uuid: "00000000-0000-0000-0000-000000000000",
+        base_price: Decimal.new("100.00"),
+        catalogue: %Ecto.Association.NotLoaded{
+          __field__: :catalogue,
+          __owner__: PhoenixKitCatalogue.Schemas.Item,
+          __cardinality__: :one
+        }
+      }
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert Decimal.equal?(pricing.catalogue_discount, Decimal.new("0"))
+      assert Decimal.equal?(pricing.final_price, Decimal.new("100.00"))
+    end
+
+    test "final_price is nil when base_price is nil" do
+      cat = create_catalogue(%{markup_percentage: "20", discount_percentage: "10"})
+      category = create_category(cat)
+      item = create_item(%{name: "Priceless", category_uuid: category.uuid})
+
+      pricing = Catalogue.item_pricing(item)
+
+      assert is_nil(pricing.base_price)
+      assert is_nil(pricing.sale_price)
+      assert is_nil(pricing.final_price)
+      assert is_nil(pricing.discount_amount)
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Smart catalogues (V102 / 0.1.12)
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "list_catalogues/1 with :kind filter" do
+    test "returns only the requested kind" do
+      standard = create_catalogue(%{name: "Kitchen"})
+      smart = create_catalogue(%{name: "Services", kind: "smart"})
+
+      smart_names = Catalogue.list_catalogues(kind: :smart) |> Enum.map(& &1.name)
+      standard_names = Catalogue.list_catalogues(kind: :standard) |> Enum.map(& &1.name)
+
+      assert smart.name in smart_names
+      refute standard.name in smart_names
+
+      assert standard.name in standard_names
+      refute smart.name in standard_names
+    end
+
+    test "accepts string kind too" do
+      create_catalogue(%{name: "Svc", kind: "smart"})
+      assert [%{kind: "smart"}] = Catalogue.list_catalogues(kind: "smart")
+    end
+  end
+
+  describe "put_catalogue_rules/3 and list_catalogue_rules/1" do
+    test "atomically replaces rules — add, update, remove in one shot" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      plumbing = create_catalogue(%{name: "Plumbing"})
+      hardware = create_catalogue(%{name: "Hardware"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      # Initial state: two rules
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"},
+          %{referenced_catalogue_uuid: plumbing.uuid, value: 3, unit: "percent"}
+        ])
+
+      rules = Catalogue.list_catalogue_rules(delivery)
+      assert length(rules) == 2
+
+      # Replace-all: kitchen updated, plumbing removed, hardware added
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 10, unit: "percent"},
+          %{referenced_catalogue_uuid: hardware.uuid, value: 20, unit: "flat"}
+        ])
+
+      rules = Catalogue.list_catalogue_rules(delivery)
+      by_uuid = Map.new(rules, &{&1.referenced_catalogue_uuid, &1})
+
+      assert Map.has_key?(by_uuid, kitchen.uuid)
+      assert Map.has_key?(by_uuid, hardware.uuid)
+      refute Map.has_key?(by_uuid, plumbing.uuid)
+
+      assert Decimal.equal?(by_uuid[kitchen.uuid].value, Decimal.new("10"))
+      assert by_uuid[kitchen.uuid].unit == "percent"
+      assert Decimal.equal?(by_uuid[hardware.uuid].value, Decimal.new("20"))
+      assert by_uuid[hardware.uuid].unit == "flat"
+    end
+
+    test "empty rules list clears all existing rules" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"}
+        ])
+
+      {:ok, _} = Catalogue.put_catalogue_rules(delivery, [])
+      assert Catalogue.list_catalogue_rules(delivery) == []
+    end
+
+    test "nil value/unit is stored as-is (inherits from item defaults at read time)" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+
+      delivery =
+        create_item(%{
+          name: "Delivery",
+          catalogue_uuid: services.uuid,
+          default_value: "5",
+          default_unit: "percent"
+        })
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid}
+        ])
+
+      [rule] = Catalogue.list_catalogue_rules(delivery)
+      assert is_nil(rule.value)
+      assert is_nil(rule.unit)
+
+      # Effective values fall back to the item's defaults
+      alias PhoenixKitCatalogue.Schemas.CatalogueRule
+      {value, unit} = CatalogueRule.effective(rule, delivery)
+      assert Decimal.equal?(value, Decimal.new("5"))
+      assert unit == "percent"
+    end
+
+    test "rejects duplicate referenced_catalogue_uuid in one call" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      assert {:error, {:duplicate_referenced_catalogue, _}} =
+               Catalogue.put_catalogue_rules(delivery, [
+                 %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"},
+                 %{referenced_catalogue_uuid: kitchen.uuid, value: 10, unit: "flat"}
+               ])
+
+      assert Catalogue.list_catalogue_rules(delivery) == []
+    end
+
+    test "rolls back the whole replace if any rule is invalid" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      # Seed a good rule first
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"}
+        ])
+
+      plumbing = create_catalogue(%{name: "Plumbing"})
+
+      # Second put contains a bad unit → entire replace rolls back
+      # (kitchen stays untouched at value=5, plumbing is NOT added)
+      assert {:error, %Ecto.Changeset{}} =
+               Catalogue.put_catalogue_rules(delivery, [
+                 %{referenced_catalogue_uuid: kitchen.uuid, value: 99, unit: "percent"},
+                 %{referenced_catalogue_uuid: plumbing.uuid, value: 3, unit: "bogus"}
+               ])
+
+      [rule] = Catalogue.list_catalogue_rules(delivery)
+      assert rule.referenced_catalogue_uuid == kitchen.uuid
+      assert Decimal.equal?(rule.value, Decimal.new("5"))
+    end
+
+    test "preloads the referenced catalogue and orders by position then name" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      beta = create_catalogue(%{name: "Beta"})
+      alpha = create_catalogue(%{name: "Alpha"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      # Explicit positions: Beta at 0, Alpha at 1 → Beta first despite alphabetical
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: beta.uuid, position: 0},
+          %{referenced_catalogue_uuid: alpha.uuid, position: 1}
+        ])
+
+      rules = Catalogue.list_catalogue_rules(delivery)
+      assert Enum.map(rules, & &1.referenced_catalogue.name) == ["Beta", "Alpha"]
+    end
+  end
+
+  describe "catalogue_rule_map/1" do
+    test "returns the rules keyed by referenced_catalogue_uuid" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"}
+        ])
+
+      map = Catalogue.catalogue_rule_map(delivery)
+      assert Map.has_key?(map, kitchen.uuid)
+      assert Decimal.equal?(map[kitchen.uuid].value, Decimal.new("5"))
+    end
+  end
+
+  describe "list_items_referencing_catalogue/1 and catalogue_reference_count/1" do
+    test "returns smart items that reference a given catalogue" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      plumbing = create_catalogue(%{name: "Plumbing"})
+
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+      install = create_item(%{name: "Install", catalogue_uuid: services.uuid})
+      irrelevant = create_item(%{name: "Irrelevant", catalogue_uuid: services.uuid})
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"}
+        ])
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(install, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 10, unit: "flat"},
+          %{referenced_catalogue_uuid: plumbing.uuid, value: 3, unit: "percent"}
+        ])
+
+      # No rules on irrelevant
+
+      kitchen_referencers = Catalogue.list_items_referencing_catalogue(kitchen.uuid)
+      names = Enum.map(kitchen_referencers, & &1.name) |> Enum.sort()
+
+      assert names == ["Delivery", "Install"]
+      refute irrelevant.name in names
+
+      assert Catalogue.catalogue_reference_count(kitchen.uuid) == 2
+      assert Catalogue.catalogue_reference_count(plumbing.uuid) == 1
+    end
+
+    test "excludes deleted items" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"}
+        ])
+
+      assert length(Catalogue.list_items_referencing_catalogue(kitchen.uuid)) == 1
+
+      Catalogue.trash_item(delivery)
+
+      assert Catalogue.list_items_referencing_catalogue(kitchen.uuid) == []
+      assert Catalogue.catalogue_reference_count(kitchen.uuid) == 0
+    end
+
+    test "cascades: force-deleting a referenced catalogue wipes the rule" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"}
+        ])
+
+      # `permanently_delete_catalogue/2` now refuses to nuke a catalogue
+      # that smart items still reference unless `force: true` is passed.
+      assert {:error, {:referenced_by_smart_items, 1}} =
+               Catalogue.permanently_delete_catalogue(kitchen)
+
+      # With force, the FK cascade removes the rule row.
+      assert {:ok, _} = Catalogue.permanently_delete_catalogue(kitchen, force: true)
+      assert Catalogue.list_catalogue_rules(delivery) == []
+    end
+
+    test "permanently_delete_catalogue refuses without :force when smart-rule references exist" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      hardware = create_catalogue(%{name: "Hardware"})
+
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+      install = create_item(%{name: "Install", catalogue_uuid: services.uuid})
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"}
+        ])
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(install, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 10, unit: "percent"}
+        ])
+
+      assert {:error, {:referenced_by_smart_items, 2}} =
+               Catalogue.permanently_delete_catalogue(kitchen)
+
+      # Hardware has no references — guard doesn't fire.
+      assert {:ok, _} = Catalogue.permanently_delete_catalogue(hardware)
+    end
+
+    test "self-reference: a smart item can reference its own catalogue" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      assert {:ok, [_rule]} =
+               Catalogue.put_catalogue_rules(delivery, [
+                 %{referenced_catalogue_uuid: services.uuid, value: 5, unit: "percent"}
+               ])
+
+      assert [rule] = Catalogue.list_catalogue_rules(delivery)
+      assert rule.referenced_catalogue_uuid == services.uuid
+    end
+
+    test "smart-to-smart: a smart item can reference another smart catalogue" do
+      services_a = create_catalogue(%{name: "Services A", kind: "smart"})
+      services_b = create_catalogue(%{name: "Services B", kind: "smart"})
+      item = create_item(%{name: "X", catalogue_uuid: services_a.uuid})
+
+      assert {:ok, [rule]} =
+               Catalogue.put_catalogue_rules(item, [
+                 %{referenced_catalogue_uuid: services_b.uuid, value: 7, unit: "percent"}
+               ])
+
+      assert rule.referenced_catalogue_uuid == services_b.uuid
+    end
+
+    test "duplicate detection: nil referenced_catalogue_uuid returns {:duplicate, nil}" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      assert {:error, {:duplicate_referenced_catalogue, nil}} =
+               Catalogue.put_catalogue_rules(delivery, [
+                 %{referenced_catalogue_uuid: nil, value: 5, unit: "percent"}
+               ])
+    end
+  end
+
+  describe "single-rule CRUD (V102)" do
+    test "create_catalogue_rule/2 logs and returns the inserted rule" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      assert {:ok, rule} =
+               Catalogue.create_catalogue_rule(%{
+                 item_uuid: delivery.uuid,
+                 referenced_catalogue_uuid: kitchen.uuid,
+                 value: Decimal.new("12"),
+                 unit: "percent"
+               })
+
+      assert rule.item_uuid == delivery.uuid
+      assert rule.referenced_catalogue_uuid == kitchen.uuid
+    end
+
+    test "update_catalogue_rule/3 mutates value and unit" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      {:ok, rule} =
+        Catalogue.create_catalogue_rule(%{
+          item_uuid: delivery.uuid,
+          referenced_catalogue_uuid: kitchen.uuid,
+          value: Decimal.new("5"),
+          unit: "percent"
+        })
+
+      assert {:ok, updated} =
+               Catalogue.update_catalogue_rule(rule, %{value: Decimal.new("9"), unit: "flat"})
+
+      assert Decimal.equal?(updated.value, Decimal.new("9"))
+      assert updated.unit == "flat"
+    end
+
+    test "delete_catalogue_rule/2 removes one rule without affecting siblings" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      hardware = create_catalogue(%{name: "Hardware"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(delivery, [
+          %{referenced_catalogue_uuid: kitchen.uuid, value: 5, unit: "percent"},
+          %{referenced_catalogue_uuid: hardware.uuid, value: 20, unit: "flat"}
+        ])
+
+      kitchen_rule = Catalogue.get_catalogue_rule(delivery.uuid, kitchen.uuid)
+      assert {:ok, _} = Catalogue.delete_catalogue_rule(kitchen_rule)
+
+      remaining = Catalogue.list_catalogue_rules(delivery)
+      assert length(remaining) == 1
+      assert hd(remaining).referenced_catalogue_uuid == hardware.uuid
+    end
+
+    test "change_catalogue_rule/2 returns a changeset for forms" do
+      cs = Catalogue.change_catalogue_rule(%PhoenixKitCatalogue.Schemas.CatalogueRule{})
+      assert %Ecto.Changeset{valid?: false} = cs
+      assert {_, _} = cs.errors[:referenced_catalogue_uuid]
+    end
+
+    test "V102 CHECK constraint on kind refuses an invalid enum via raw SQL" do
+      # Ecto's changeset validates `kind` before it hits the DB, so the
+      # CHECK constraint is only visible on direct inserts. This guards
+      # against a future changeset regression silently dropping the check
+      # AND verifies the test migration mirrors the prod constraint.
+      repo = PhoenixKitCatalogue.Test.Repo
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      assert_raise Postgrex.Error, ~r/kind_check/i, fn ->
+        SQL.query!(
+          repo,
+          """
+          INSERT INTO phoenix_kit_cat_catalogues
+            (uuid, name, status, kind, markup_percentage, discount_percentage, data, inserted_at, updated_at)
+          VALUES
+            (uuid_generate_v7(), 'Invalid Kind', 'active', 'not-a-real-kind', 0, 0, '{}'::jsonb, $1, $1)
+          """,
+          [now]
+        )
+      end
+    end
+
+    test "create_catalogue_rule/2 with a duplicate (item_uuid, referenced_catalogue_uuid) pair is rejected by the UNIQUE constraint" do
+      services = create_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      delivery = create_item(%{name: "Delivery", catalogue_uuid: services.uuid})
+
+      assert {:ok, _} =
+               Catalogue.create_catalogue_rule(%{
+                 item_uuid: delivery.uuid,
+                 referenced_catalogue_uuid: kitchen.uuid,
+                 value: Decimal.new("5"),
+                 unit: "percent"
+               })
+
+      # Second insert with the same pair must surface the unique_constraint
+      # error on the pair — proves the V102 UNIQUE index is in force and
+      # the schema's `unique_constraint/2` call converts it to a useful
+      # changeset error rather than raising a Postgrex error.
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Catalogue.create_catalogue_rule(%{
+                 item_uuid: delivery.uuid,
+                 referenced_catalogue_uuid: kitchen.uuid,
+                 value: Decimal.new("9"),
+                 unit: "flat"
+               })
+
+      refute cs.valid?
+
+      assert Enum.any?(cs.errors, fn {field, _} ->
+               field in [:item_uuid, :referenced_catalogue_uuid]
+             end)
+    end
+  end
+
+  describe "category_counts_by_catalogue/0" do
+    test "returns a map of non-deleted category counts per catalogue" do
+      kitchen = create_catalogue(%{name: "Kitchen"})
+      bathroom = create_catalogue(%{name: "Bathroom"})
+      _empty = create_catalogue(%{name: "Empty"})
+
+      _ = create_category(kitchen, %{name: "Frames"})
+      _ = create_category(kitchen, %{name: "Doors"})
+      _ = create_category(bathroom, %{name: "Tiles"})
+      trashed_cat = create_category(kitchen, %{name: "To Trash"})
+      Catalogue.trash_category(trashed_cat)
+
+      counts = Catalogue.category_counts_by_catalogue()
+
+      assert counts[kitchen.uuid] == 2
+      assert counts[bathroom.uuid] == 1
+      refute Map.has_key?(counts, "missing-catalogue-uuid")
+    end
+
+    test "returns empty map when there are no categories" do
+      assert Catalogue.category_counts_by_catalogue() == %{}
     end
   end
 end

--- a/test/phoenix_kit_catalogue_test.exs
+++ b/test/phoenix_kit_catalogue_test.exs
@@ -216,7 +216,7 @@ defmodule PhoenixKitCatalogueTest do
 
   describe "version/0" do
     test "returns version string" do
-      assert PhoenixKitCatalogue.version() == "0.1.6"
+      assert PhoenixKitCatalogue.version() == "0.1.12"
     end
   end
 

--- a/test/schemas_test.exs
+++ b/test/schemas_test.exs
@@ -9,6 +9,7 @@ defmodule PhoenixKitCatalogue.SchemasTest do
 
   alias PhoenixKitCatalogue.Schemas.{
     Catalogue,
+    CatalogueRule,
     Category,
     Item,
     Manufacturer,
@@ -418,6 +419,107 @@ defmodule PhoenixKitCatalogue.SchemasTest do
     end
   end
 
+  describe "Item.effective_discount/2" do
+    test "returns the item's override when set" do
+      item = %Item{discount_percentage: Decimal.new("25")}
+      assert Decimal.equal?(Item.effective_discount(item, Decimal.new("10")), Decimal.new("25"))
+    end
+
+    test "returns the item's override even when it's zero" do
+      item = %Item{discount_percentage: Decimal.new("0")}
+      assert Decimal.equal?(Item.effective_discount(item, Decimal.new("10")), Decimal.new("0"))
+    end
+
+    test "falls back to catalogue when item override is nil" do
+      item = %Item{discount_percentage: nil}
+      assert Decimal.equal?(Item.effective_discount(item, Decimal.new("15")), Decimal.new("15"))
+    end
+
+    test "returns nil when both are nil" do
+      item = %Item{discount_percentage: nil}
+      assert Item.effective_discount(item, nil) == nil
+    end
+  end
+
+  describe "Item.final_price/3" do
+    test "returns nil when base_price is nil" do
+      item = %Item{base_price: nil}
+      assert Item.final_price(item, Decimal.new("20"), Decimal.new("10")) == nil
+    end
+
+    test "applies markup then discount in that order" do
+      item = %Item{base_price: Decimal.new("100")}
+      # 100 * 1.20 * 0.90 = 108.00
+      result = Item.final_price(item, Decimal.new("20"), Decimal.new("10"))
+      assert Decimal.equal?(result, Decimal.new("108.00"))
+    end
+
+    test "rounds to 2 decimal places" do
+      item = %Item{base_price: Decimal.new("33.33")}
+      # 33.33 * 1.15 * 0.95 = 36.41... → rounds
+      result = Item.final_price(item, Decimal.new("15"), Decimal.new("5"))
+      assert Decimal.equal?(result, Decimal.new("36.41"))
+    end
+
+    test "nil discount leaves sale_price unchanged (no discount leg)" do
+      item = %Item{base_price: Decimal.new("100")}
+      result = Item.final_price(item, Decimal.new("20"), nil)
+      assert Decimal.equal?(result, Decimal.new("120.00"))
+    end
+
+    test "nil markup leaves base untouched by markup (discount still applies)" do
+      item = %Item{base_price: Decimal.new("100")}
+      result = Item.final_price(item, nil, Decimal.new("10"))
+      assert Decimal.equal?(result, Decimal.new("90.00"))
+    end
+
+    test "item discount 0 overrides a non-zero catalogue discount" do
+      item = %Item{base_price: Decimal.new("100"), discount_percentage: Decimal.new("0")}
+      # Catalogue says 25% discount, but item overrides to 0 → no discount
+      result = Item.final_price(item, Decimal.new("20"), Decimal.new("25"))
+      assert Decimal.equal?(result, Decimal.new("120.00"))
+    end
+
+    test "item discount overrides catalogue discount" do
+      item = %Item{base_price: Decimal.new("100"), discount_percentage: Decimal.new("50")}
+      # Catalogue says 10%, item says 50% → 50% applies
+      result = Item.final_price(item, Decimal.new("0"), Decimal.new("10"))
+      assert Decimal.equal?(result, Decimal.new("50.00"))
+    end
+
+    test "100% discount yields 0" do
+      item = %Item{base_price: Decimal.new("100")}
+      result = Item.final_price(item, Decimal.new("0"), Decimal.new("100"))
+      assert Decimal.equal?(result, Decimal.new("0.00"))
+    end
+  end
+
+  describe "Item.discount_amount/3" do
+    test "returns nil when base_price is nil" do
+      item = %Item{base_price: nil}
+      assert Item.discount_amount(item, Decimal.new("20"), Decimal.new("10")) == nil
+    end
+
+    test "returns nil when both discount sources are nil" do
+      item = %Item{base_price: Decimal.new("100"), discount_percentage: nil}
+      assert Item.discount_amount(item, Decimal.new("20"), nil) == nil
+    end
+
+    test "returns the difference between sale_price and final_price" do
+      item = %Item{base_price: Decimal.new("100")}
+      # sale = 100 * 1.20 = 120; final = 120 * 0.90 = 108; amount = 12
+      result = Item.discount_amount(item, Decimal.new("20"), Decimal.new("10"))
+      assert Decimal.equal?(result, Decimal.new("12.00"))
+    end
+
+    test "zero when effective discount is 0 (not nil)" do
+      item = %Item{base_price: Decimal.new("100"), discount_percentage: Decimal.new("0")}
+      result = Item.discount_amount(item, Decimal.new("20"), Decimal.new("25"))
+      # item override of 0 means no discount → amount is 0, not nil
+      assert Decimal.equal?(result, Decimal.new("0.00"))
+    end
+  end
+
   # ═══════════════════════════════════════════════════════════════════
   # Manufacturer
   # ═══════════════════════════════════════════════════════════════════
@@ -485,6 +587,184 @@ defmodule PhoenixKitCatalogue.SchemasTest do
     test "rejects bogus status" do
       cs = Supplier.changeset(%Supplier{}, %{name: "x", status: "bogus"})
       refute cs.valid?
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Smart catalogues (0.1.12)
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "Catalogue.changeset/2 — kind" do
+    test "defaults to 'standard' when omitted" do
+      cs = Catalogue.changeset(%Catalogue{}, %{name: "X"})
+      assert cs.valid?
+      # The default lives on the struct's `:kind` field, not in the
+      # changeset changes — so get_field reads the default.
+      assert Ecto.Changeset.get_field(cs, :kind) == "standard"
+    end
+
+    test "accepts 'smart'" do
+      cs = Catalogue.changeset(%Catalogue{}, %{name: "Services", kind: "smart"})
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :kind) == "smart"
+    end
+
+    test "rejects unknown kind" do
+      cs = Catalogue.changeset(%Catalogue{}, %{name: "X", kind: "weird"})
+      refute cs.valid?
+      assert errors_on(cs)[:kind]
+    end
+  end
+
+  describe "Item.changeset/2 — default_value / default_unit" do
+    test "defaults to nil/nil" do
+      cs = Item.changeset(%Item{}, %{name: "Delivery", catalogue_uuid: UUIDv7.generate()})
+      assert cs.valid?
+      assert is_nil(Ecto.Changeset.get_field(cs, :default_value))
+      assert is_nil(Ecto.Changeset.get_field(cs, :default_unit))
+    end
+
+    test "accepts valid default_value + default_unit" do
+      cs =
+        Item.changeset(%Item{}, %{
+          name: "Delivery",
+          catalogue_uuid: UUIDv7.generate(),
+          default_value: "5",
+          default_unit: "percent"
+        })
+
+      assert cs.valid?
+      assert Decimal.equal?(Ecto.Changeset.get_field(cs, :default_value), Decimal.new("5"))
+    end
+
+    test "rejects negative default_value" do
+      cs =
+        Item.changeset(%Item{}, %{
+          name: "Delivery",
+          catalogue_uuid: UUIDv7.generate(),
+          default_value: "-1"
+        })
+
+      refute cs.valid?
+      assert errors_on(cs)[:default_value]
+    end
+
+    test "rejects unknown default_unit" do
+      cs =
+        Item.changeset(%Item{}, %{
+          name: "Delivery",
+          catalogue_uuid: UUIDv7.generate(),
+          default_unit: "banana"
+        })
+
+      refute cs.valid?
+      assert errors_on(cs)[:default_unit]
+    end
+
+    test "accepts flat default_unit" do
+      cs =
+        Item.changeset(%Item{}, %{
+          name: "Delivery",
+          catalogue_uuid: UUIDv7.generate(),
+          default_unit: "flat"
+        })
+
+      assert cs.valid?
+    end
+
+    test "allowed_default_units/0 exposes the accepted values" do
+      assert Item.allowed_default_units() == ~w(percent flat)
+    end
+  end
+
+  describe "CatalogueRule.changeset/2" do
+    test "accepts minimal valid attrs (all-nil value/unit)" do
+      cs =
+        CatalogueRule.changeset(%CatalogueRule{}, %{
+          item_uuid: UUIDv7.generate(),
+          referenced_catalogue_uuid: UUIDv7.generate()
+        })
+
+      assert cs.valid?
+    end
+
+    test "accepts value + unit" do
+      cs =
+        CatalogueRule.changeset(%CatalogueRule{}, %{
+          item_uuid: UUIDv7.generate(),
+          referenced_catalogue_uuid: UUIDv7.generate(),
+          value: "5",
+          unit: "percent"
+        })
+
+      assert cs.valid?
+    end
+
+    test "requires item_uuid and referenced_catalogue_uuid" do
+      cs = CatalogueRule.changeset(%CatalogueRule{}, %{})
+      refute cs.valid?
+      assert errors_on(cs)[:item_uuid]
+      assert errors_on(cs)[:referenced_catalogue_uuid]
+    end
+
+    test "rejects negative value" do
+      cs =
+        CatalogueRule.changeset(%CatalogueRule{}, %{
+          item_uuid: UUIDv7.generate(),
+          referenced_catalogue_uuid: UUIDv7.generate(),
+          value: "-5"
+        })
+
+      refute cs.valid?
+      assert errors_on(cs)[:value]
+    end
+
+    test "rejects unknown unit" do
+      cs =
+        CatalogueRule.changeset(%CatalogueRule{}, %{
+          item_uuid: UUIDv7.generate(),
+          referenced_catalogue_uuid: UUIDv7.generate(),
+          unit: "bogus"
+        })
+
+      refute cs.valid?
+      assert errors_on(cs)[:unit]
+    end
+  end
+
+  describe "CatalogueRule.effective/2" do
+    test "rule value/unit take precedence over item defaults" do
+      rule = %CatalogueRule{value: Decimal.new("10"), unit: "flat"}
+      item = %Item{default_value: Decimal.new("5"), default_unit: "percent"}
+      assert CatalogueRule.effective(rule, item) == {Decimal.new("10"), "flat"}
+    end
+
+    test "each leg inherits independently" do
+      # Rule has value, no unit → inherits unit only
+      rule = %CatalogueRule{value: Decimal.new("10"), unit: nil}
+      item = %Item{default_value: Decimal.new("5"), default_unit: "percent"}
+      assert CatalogueRule.effective(rule, item) == {Decimal.new("10"), "percent"}
+
+      # Rule has unit, no value → inherits value only
+      rule = %CatalogueRule{value: nil, unit: "flat"}
+      assert CatalogueRule.effective(rule, item) == {Decimal.new("5"), "flat"}
+    end
+
+    test "both nil on rule → inherits both from item" do
+      rule = %CatalogueRule{value: nil, unit: nil}
+      item = %Item{default_value: Decimal.new("5"), default_unit: "percent"}
+      assert CatalogueRule.effective(rule, item) == {Decimal.new("5"), "percent"}
+    end
+
+    test "both nil everywhere → {nil, nil}" do
+      rule = %CatalogueRule{value: nil, unit: nil}
+      item = %Item{default_value: nil, default_unit: nil}
+      assert CatalogueRule.effective(rule, item) == {nil, nil}
+    end
+
+    test "tolerates nil item (handy for detached rules)" do
+      rule = %CatalogueRule{value: Decimal.new("5"), unit: "percent"}
+      assert CatalogueRule.effective(rule, nil) == {Decimal.new("5"), "percent"}
     end
   end
 end

--- a/test/support/postgres/migrations/20260420000000_add_v102_smart_catalogues.exs
+++ b/test/support/postgres/migrations/20260420000000_add_v102_smart_catalogues.exs
@@ -1,0 +1,172 @@
+defmodule PhoenixKitCatalogue.Test.Repo.Migrations.AddV102SmartCatalogues do
+  @moduledoc """
+  Mirrors core PhoenixKit's V102 migration for the catalogue module's
+  local test DB:
+
+    * `phoenix_kit_cat_catalogues.discount_percentage` — per-catalogue
+      default discount (not-null, default 0).
+    * `phoenix_kit_cat_catalogues.kind` — `standard` / `smart`.
+    * `phoenix_kit_cat_items.discount_percentage` — nullable override.
+    * `phoenix_kit_cat_items.default_value` / `default_unit` — fallback
+      for smart-rule rows with NULL `value` / `unit`.
+    * `phoenix_kit_cat_item_catalogue_rules` — one row per
+      `(item, referenced_catalogue)` pair for smart-catalogue items.
+    * CHECK constraints mirroring the prod migration so the DB enforces
+      the closed enum for `kind` and the numeric ranges, catching drift
+      between prod and test schemas.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:phoenix_kit_cat_catalogues) do
+      add_if_not_exists(:discount_percentage, :decimal,
+        precision: 7,
+        scale: 2,
+        null: false,
+        default: 0
+      )
+
+      add_if_not_exists(:kind, :string, size: 20, null: false, default: "standard")
+    end
+
+    alter table(:phoenix_kit_cat_items) do
+      add_if_not_exists(:discount_percentage, :decimal, precision: 7, scale: 2)
+      add_if_not_exists(:default_value, :decimal, precision: 12, scale: 4)
+      add_if_not_exists(:default_unit, :string, size: 20)
+    end
+
+    create_if_not_exists table(:phoenix_kit_cat_item_catalogue_rules, primary_key: false) do
+      add(:uuid, :binary_id, primary_key: true)
+
+      add(
+        :item_uuid,
+        references(:phoenix_kit_cat_items,
+          column: :uuid,
+          type: :binary_id,
+          on_delete: :delete_all
+        ),
+        null: false
+      )
+
+      add(
+        :referenced_catalogue_uuid,
+        references(:phoenix_kit_cat_catalogues,
+          column: :uuid,
+          type: :binary_id,
+          on_delete: :delete_all
+        ),
+        null: false
+      )
+
+      add(:value, :decimal, precision: 12, scale: 4)
+      add(:unit, :string, size: 20)
+      add(:position, :integer, null: false, default: 0)
+
+      timestamps()
+    end
+
+    create_if_not_exists(
+      unique_index(
+        :phoenix_kit_cat_item_catalogue_rules,
+        [:item_uuid, :referenced_catalogue_uuid],
+        name: :phoenix_kit_cat_item_catalogue_rules_pair_index
+      )
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_cat_item_catalogue_rules, [:item_uuid],
+        name: :phoenix_kit_cat_item_catalogue_rules_item_index
+      )
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_cat_item_catalogue_rules, [:referenced_catalogue_uuid],
+        name: :phoenix_kit_cat_item_catalogue_rules_referenced_index
+      )
+    )
+
+    # CHECK constraints — mirror the prod migration so the DB enforces
+    # the closed vocab for `kind` and the numeric ranges. Keeps prod
+    # and test schemas aligned and catches regressions at the DB layer.
+    execute(
+      """
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT FROM pg_constraint
+          WHERE conname = 'phoenix_kit_cat_catalogues_kind_check'
+        ) THEN
+          ALTER TABLE phoenix_kit_cat_catalogues
+            ADD CONSTRAINT phoenix_kit_cat_catalogues_kind_check
+            CHECK (kind IN ('standard', 'smart'));
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT FROM pg_constraint
+          WHERE conname = 'phoenix_kit_cat_catalogues_discount_pct_check'
+        ) THEN
+          ALTER TABLE phoenix_kit_cat_catalogues
+            ADD CONSTRAINT phoenix_kit_cat_catalogues_discount_pct_check
+            CHECK (discount_percentage >= 0 AND discount_percentage <= 100);
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT FROM pg_constraint
+          WHERE conname = 'phoenix_kit_cat_items_discount_pct_check'
+        ) THEN
+          ALTER TABLE phoenix_kit_cat_items
+            ADD CONSTRAINT phoenix_kit_cat_items_discount_pct_check
+            CHECK (discount_percentage IS NULL OR
+                   (discount_percentage >= 0 AND discount_percentage <= 100));
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT FROM pg_constraint
+          WHERE conname = 'phoenix_kit_cat_items_default_value_check'
+        ) THEN
+          ALTER TABLE phoenix_kit_cat_items
+            ADD CONSTRAINT phoenix_kit_cat_items_default_value_check
+            CHECK (default_value IS NULL OR default_value >= 0);
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT FROM pg_constraint
+          WHERE conname = 'phoenix_kit_cat_item_catalogue_rules_value_check'
+        ) THEN
+          ALTER TABLE phoenix_kit_cat_item_catalogue_rules
+            ADD CONSTRAINT phoenix_kit_cat_item_catalogue_rules_value_check
+            CHECK (value IS NULL OR value >= 0);
+        END IF;
+      END $$;
+      """,
+      """
+      ALTER TABLE phoenix_kit_cat_item_catalogue_rules
+        DROP CONSTRAINT IF EXISTS phoenix_kit_cat_item_catalogue_rules_value_check;
+
+      ALTER TABLE phoenix_kit_cat_items
+        DROP CONSTRAINT IF EXISTS phoenix_kit_cat_items_default_value_check,
+        DROP CONSTRAINT IF EXISTS phoenix_kit_cat_items_discount_pct_check;
+
+      ALTER TABLE phoenix_kit_cat_catalogues
+        DROP CONSTRAINT IF EXISTS phoenix_kit_cat_catalogues_kind_check,
+        DROP CONSTRAINT IF EXISTS phoenix_kit_cat_catalogues_discount_pct_check;
+      """
+    )
+  end
+
+  def down do
+    drop_if_exists(table(:phoenix_kit_cat_item_catalogue_rules))
+
+    alter table(:phoenix_kit_cat_items) do
+      remove_if_exists(:default_unit, :string)
+      remove_if_exists(:default_value, :decimal)
+      remove_if_exists(:discount_percentage, :decimal)
+    end
+
+    alter table(:phoenix_kit_cat_catalogues) do
+      remove_if_exists(:kind, :string)
+      remove_if_exists(:discount_percentage, :decimal)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,21 @@
+# Elixir 1.19's `mix test` no longer auto-loads modules from the
+# `:elixirc_paths` test directories at test-helper time — only files
+# matching `:test_load_filters` get loaded by the test runner. Our
+# support modules (`PhoenixKitCatalogue.Test.Repo`, `Test.Endpoint`,
+# etc.) are compiled but not loaded, so explicit `Code.require_file/2`
+# calls are needed before `test_helper.exs` references them.
+support_dir = Path.expand("support", __DIR__)
+
+[
+  "test_repo.ex",
+  "test_layouts.ex",
+  "test_router.ex",
+  "test_endpoint.ex",
+  "data_case.ex",
+  "live_case.ex"
+]
+|> Enum.each(&Code.require_file(&1, support_dir))
+
 # Check if the test database exists
 db_name =
   Application.get_env(:phoenix_kit_catalogue, PhoenixKitCatalogue.Test.Repo)[:database] ||

--- a/test/web/form_lives_test.exs
+++ b/test/web/form_lives_test.exs
@@ -57,6 +57,28 @@ defmodule PhoenixKitCatalogue.Web.FormLivesTest do
       assert html =~ "New Catalogue"
       assert Catalogue.list_catalogues() == []
     end
+
+    test "creates a smart catalogue with discount + markup percentages", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "#{@base}/new")
+
+      view
+      |> form(form_selector(), %{
+        "catalogue" => %{
+          "name" => "Services",
+          "description" => "Smart catalogue",
+          "markup_percentage" => "5",
+          "discount_percentage" => "10",
+          "kind" => "smart",
+          "status" => "active"
+        }
+      })
+      |> render_submit()
+
+      assert [%{name: "Services"} = c] = Catalogue.list_catalogues(kind: :smart)
+      assert c.kind == "smart"
+      assert Decimal.equal?(c.discount_percentage, Decimal.new("10"))
+      assert Decimal.equal?(c.markup_percentage, Decimal.new("5"))
+    end
   end
 
   describe "CatalogueFormLive :edit" do

--- a/test/web/item_form_live_test.exs
+++ b/test/web/item_form_live_test.exs
@@ -273,4 +273,119 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
       assert reloaded.category_uuid == category.uuid
     end
   end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Smart-catalogue rules — toggle/set_value/set_unit/clear_all
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "smart-catalogue rules" do
+    setup do
+      smart = fixture_catalogue(%{name: "Services", kind: "smart"})
+      kitchen = fixture_catalogue(%{name: "Kitchen"})
+      hardware = fixture_catalogue(%{name: "Hardware"})
+
+      smart_item =
+        fixture_item(%{
+          name: "Delivery",
+          catalogue_uuid: smart.uuid,
+          default_value: Decimal.new("5"),
+          default_unit: "percent"
+        })
+
+      %{smart: smart, kitchen: kitchen, hardware: hardware, item: smart_item}
+    end
+
+    test "toggle_catalogue_rule adds and removes a rule client-side", %{
+      conn: conn,
+      item: item,
+      kitchen: kitchen
+    } do
+      {:ok, view, _html} = live(conn, edit_item_url(item.uuid))
+
+      # Initial: no working rules
+      render_click(view, "toggle_catalogue_rule", %{"uuid" => kitchen.uuid})
+      # Toggle off again
+      render_click(view, "toggle_catalogue_rule", %{"uuid" => kitchen.uuid})
+
+      # No persistence yet — saving the form persists the working set.
+      assert Catalogue.list_catalogue_rules(item) == []
+    end
+
+    test "set_catalogue_rule_value + save persists the value", %{
+      conn: conn,
+      item: item,
+      kitchen: kitchen
+    } do
+      {:ok, view, _html} = live(conn, edit_item_url(item.uuid))
+
+      render_click(view, "toggle_catalogue_rule", %{"uuid" => kitchen.uuid})
+      render_change(view, "set_catalogue_rule_value", %{"uuid" => kitchen.uuid, "value" => "10"})
+
+      view
+      |> form("form[phx-submit=save]",
+        item: %{
+          "name" => item.name,
+          "base_price" => "0",
+          "unit" => "piece",
+          "status" => "active"
+        }
+      )
+      |> render_submit()
+
+      [rule] = Catalogue.list_catalogue_rules(item)
+      assert rule.referenced_catalogue_uuid == kitchen.uuid
+      assert Decimal.equal?(rule.value, Decimal.new("10"))
+    end
+
+    test "set_catalogue_rule_unit accepts only known units", %{
+      conn: conn,
+      item: item,
+      kitchen: kitchen
+    } do
+      {:ok, view, _html} = live(conn, edit_item_url(item.uuid))
+
+      render_click(view, "toggle_catalogue_rule", %{"uuid" => kitchen.uuid})
+      render_change(view, "set_catalogue_rule_unit", %{"uuid" => kitchen.uuid, "unit" => "flat"})
+
+      view
+      |> form("form[phx-submit=save]",
+        item: %{
+          "name" => item.name,
+          "base_price" => "0",
+          "unit" => "piece",
+          "status" => "active"
+        }
+      )
+      |> render_submit()
+
+      [rule] = Catalogue.list_catalogue_rules(item)
+      assert rule.unit == "flat"
+    end
+
+    test "clear_catalogue_rules wipes the working set client-side", %{
+      conn: conn,
+      item: item,
+      kitchen: kitchen,
+      hardware: hardware
+    } do
+      {:ok, view, _html} = live(conn, edit_item_url(item.uuid))
+
+      render_click(view, "toggle_catalogue_rule", %{"uuid" => kitchen.uuid})
+      render_click(view, "toggle_catalogue_rule", %{"uuid" => hardware.uuid})
+      render_click(view, "clear_catalogue_rules", %{})
+
+      view
+      |> form("form[phx-submit=save]",
+        item: %{
+          "name" => item.name,
+          "base_price" => "0",
+          "unit" => "piece",
+          "status" => "active"
+        }
+      )
+      |> render_submit()
+
+      assert Catalogue.list_catalogue_rules(item) == []
+    end
+  end
 end


### PR DESCRIPTION
## Feature — smart catalogues + discount leg

- Smart catalogues (`kind: "smart"`) hold items whose cost is a rule-driven function of other catalogues. New `CatalogueRule` schema + replace-all `put_catalogue_rules/3` API with duplicate detection, activity logging (`smart_rules.synced` with added/updated/removed counts), and a `CatalogueRule.effective/2` inheritance helper.
- Per-item overrides: `Item.discount_percentage` (nullable, mirrors the V97 markup pattern) + `Item.default_value` / `default_unit` for ruleless smart items. Pricing chain is now `base → markup → discount`.
- `list_items_referencing_catalogue/1` + `catalogue_reference_count/1`
  + force-delete guard so permanently deleting a catalogue referenced by smart items requires `force: true` (warns about cascade first).
- `list_catalogues(kind: :smart)` filter for the move-to-smart-catalogue picker in the item form.

## Refactor — context split

- Extract monolithic `catalogue.ex` into 10 focused submodules: `Rules`, `Search`, `Manufacturers`, `Suppliers`, `Links`, `Counts`, `PubSub`, `Translations`, `Helpers`, `ActivityLog`. Public surface unchanged — every caller still goes through `Catalogue.*` via `defdelegate`.
- Scoped search: `search_items/2` accepts `:catalogue_uuids` / `:category_uuids` filters composed via `where dynamic`; new `scope_selector` component pairs with it.
- All form LVs (catalogue / category / item / manufacturer / supplier) migrated to Phoenix 1.7 component-style `<.input>` / `<.select>` / `<.textarea>` / `<.checkbox>` bindings. Multilang wrapper now scopes *only* translatable fields (name / description) — pricing, classification, and actions render as siblings so a language switch doesn't re-mount them.

## Hardening

- Replace raising `confirm_delete!/1` with safe case-match + `unexpected_confirm_event/2` fallback across all 5 delete handlers (item / category / catalogue / manufacturer / supplier). Malformed push events flash + log instead of crashing the LV.
- Add `rescue` to `Catalogue.ActivityLog.log/1` — activity-logging failures no longer crash the primary mutation, matching the contract documented in AGENTS.md.
- New `log_operation_error/3` helper in both admin LVs: structured logs carrying `actor_uuid`, `entity_type`, `entity_uuid`, and `Ecto.Changeset.traverse_errors`-expanded field/message pairs so production incidents can be debugged from the log alone.
- Search task-exit logs now include query, offset, and catalogue_uuid.
- `phx-disable-with` on 9 destructive-action buttons (trash / restore on catalogue + category + item tables and cards) to prevent double-mutation on slow networks.

## Tests + infrastructure

- Full coverage for smart catalogues: `put_catalogue_rules/3` edge cases (duplicate detection, self-reference, smart-to-smart, force-delete cascade, nil uuid), per-item discount override precedence (`nil` inherits, `0` overrides), smart-item form branching, migration v102 CHECK + UNIQUE constraints.
- New test migration mirroring production V102 so the catalogue's standalone test DB gains `kind`, discount columns, default_value / default_unit, the rules table, and all CHECK constraints — without this the smart-catalogue tests couldn't actually run.
- New coverage for `category_counts_by_catalogue/0`.

## Docs

- AGENTS.md: file tree reflects the `catalogue/` submodule split; "Single context module" convention rewritten for the new reality; added Tailwind CSS Scanning + JavaScript Hooks sections for consistency with sibling plugins.
- README.md: Items feature now mentions `final_price` (post-discount) alongside `sale_price` (post-markup).