### PR TITLE
Add nested categories, attachments, item metadata, and item picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ This is a **PhoenixKit module** that implements the `PhoenixKit.Module` behaviou
 
 ### Core Schemas (all use UUIDv7 primary keys)
 
-- **Catalogue** (`phoenix_kit_cat_catalogues`) — top-level groupings with name, description, `markup_percentage` (default 0, NOT NULL), `discount_percentage` (default 0, NOT NULL, V102), `kind` (`"standard"` | `"smart"`, default `"standard"`, NOT NULL, V102), status (active/archived/deleted). A **smart catalogue** holds items whose cost is a rule-driven function of other catalogues (see "Smart catalogues" section below).
-- **Category** (`phoenix_kit_cat_categories`) — subdivisions within a catalogue with position ordering, status (active/deleted)
+- **Catalogue** (`phoenix_kit_cat_catalogues`) — top-level groupings with name, description, `markup_percentage` (default 0, NOT NULL), `discount_percentage` (default 0, NOT NULL, V102), `kind` (`"standard"` | `"smart"`, default `"standard"`, NOT NULL, V102), status (active/archived/deleted). A **smart catalogue** holds items whose cost is a rule-driven function of other catalogues (see "Smart catalogues" section below). Optional `data["featured_image_uuid"]` + `data["files_folder_uuid"]` wire the `Attachments` module in (see "Attachments" section).
+- **Category** (`phoenix_kit_cat_categories`) — subdivisions within a catalogue with position ordering, status (active/deleted), and a nullable self-FK `parent_uuid` (V103) that turns the flat taxonomy into an arbitrary-depth tree. `NULL` means root. Position is scoped to `(catalogue_uuid, parent_uuid)` — siblings only.
 - **Item** (`phoenix_kit_cat_items`) — individual products with SKU, base_price, unit of measure, manufacturer link, status (active/deleted). **Belongs directly to a catalogue via `catalogue_uuid`** (required), with an optional `category_uuid` for grouping. Items without a category are "uncategorized within a catalogue" — still scoped to that catalogue. Has two nullable percentage overrides (`markup_percentage` added V97, `discount_percentage` added V102) with identical inherit-or-override semantics: `NULL` inherits from the catalogue, any Decimal (including `0`) overrides it. `Item.effective_markup/2` and `Item.effective_discount/2` resolve which value applies
 - **Manufacturer** (`phoenix_kit_cat_manufacturers`) — company directory with name, website, logo, status (active/inactive)
 - **Supplier** (`phoenix_kit_cat_suppliers`) — delivery companies with name, website, status (active/inactive)
@@ -67,10 +67,22 @@ This is a **PhoenixKit module** that implements the `PhoenixKit.Module` behaviou
 
 ### Soft-Delete Cascade System
 
-- **Downward on trash:** catalogue → categories + all items (categorized and uncategorized) in that catalogue
-- **Upward on restore:** item → category → catalogue; category → catalogue + items
-- **Permanent delete** follows same downward cascade but removes from DB; uncategorized items of the catalogue are removed too
-- All cascading operations wrapped in `Repo.transaction/1`
+- **Downward on trash:** catalogue → categories + all items (categorized and uncategorized) in that catalogue. Category → **entire subtree** (V103) including descendant categories + their items.
+- **Upward on restore:** item → category → catalogue; category → **every deleted ancestor category** + catalogue + full deleted subtree + items. Restoring a deep child brings back ancestors so the restored node is reachable in the active tree.
+- **Permanent delete** follows same downward cascade but removes from DB; uncategorized items of the catalogue are removed too. For categories: subtree is walked, items hard-deleted, `parent_uuid` NULL'd across the subtree (V103's FK has no `ON DELETE CASCADE`), then rows deleted.
+- All cascading operations wrapped in `Repo.transaction/1`. Activity metadata on `category.trashed` / `category.restored` / `category.permanently_deleted` / `category.moved` carries `subtree_size` (categories touched, including root) and `items_cascaded` so the audit log tells the full story.
+
+### Nested Categories (V103)
+
+The V103 migration adds `parent_uuid` to `phoenix_kit_cat_categories`. All tree walks run through `PhoenixKitCatalogue.Catalogue.Tree` (internal module, `@moduledoc false`), which exposes `subtree_uuids/1`, `descendant_uuids/1`, `ancestor_uuids/1`, `ancestors_in_order/1`, `build_children_index/1`, `walk_subtree/3`. Recursive CTEs use `UNION` (not `UNION ALL`) so even if DB corruption produced a cycle, the working-set dedupe would break termination — no infinite-loop risk.
+
+- **Public tree API on `Catalogue`:** `list_category_tree/2` returns `[{category, depth}]` in depth-first display order. Options: `:mode` (`:active` default, excludes deleted; `:deleted` includes everything), `:exclude_subtree_of` (pass the category being edited to keep it out of its own parent picker). Orphans (categories whose parent was filtered out) are promoted to roots so they don't vanish. `list_category_ancestors/1` returns the breadcrumb chain (root → direct parent).
+- **Reparent within a catalogue:** `move_category_under(category, new_parent_uuid, opts)`. Returns `{:error, :would_create_cycle}` (self or descendant), `{:error, :cross_catalogue}` (target lives elsewhere — caller should `move_category_to_catalogue/3` first), `{:error, :parent_not_found}`. `nil` promotes to root. Same-parent is a no-op.
+- **Cross-catalogue move:** `move_category_to_catalogue/3` still takes the whole subtree along — internal `parent_uuid` links inside the subtree stay valid because every row moves. The root's `parent_uuid` is cleared (detaches from the former parent, which stays in the source catalogue).
+- **Position:** `next_category_position(catalogue_uuid, parent_uuid \\ nil)` is scoped to sibling groups. `swap_category_positions/3` refuses `:not_siblings` when the two categories don't share a parent or catalogue — the detail view's up/down arrows filter to siblings before calling swap.
+- **Parent-uuid guards:** `create_category/2` and `update_category/3` both run `validate_parent_in_same_catalogue/1` after the changeset. It catches three cases: (a) parent doesn't exist (`{:error, cs}` with `"does not exist"`), (b) parent belongs to another catalogue (`"must belong to the same catalogue"`), (c) on update, the new parent is the category itself or one of its descendants (`"would create a cycle"`). The form LV's parent dropdown only lists same-catalogue, non-descendant candidates, but this context guard covers programmatic / API callers too. `Category.changeset` rejects the self-parent case; the cross-catalogue + cycle cases live in the context because they need DB lookups. `move_category_under/3` runs the same cycle/cross-catalogue checks with richer error atoms (`:would_create_cycle`, `:cross_catalogue`, `:parent_not_found`) for callers that want to react specifically.
+- **Breadcrumbs in `list_all_categories/0`:** now returns `"Catalogue / Ancestor / Child"` format (not just `"Catalogue / Child"`) so move-dropdowns disambiguate same-named leaves under different parents. Runs one catalogues query + one categories query, builds the tree in memory — not N+1 per catalogue.
+- **Search: `:include_descendants`** in `search_items/2` (default `true`): passes each entry in `:category_uuids` through `Tree.subtree_uuids_for/1`, so filtering by a parent category also matches items in descendants. Pass `false` for strict literal-set semantics.
 
 ### Pricing
 
@@ -103,13 +115,39 @@ A smart catalogue (`Catalogue.kind == "smart"`) holds items whose cost is a func
 - **Smart items don't use `base_price` / `markup_percentage` / `discount_percentage`.** Those columns still exist on the row (shared Item schema) but the smart item form doesn't surface them and the convention is to leave them `nil`. A smart item's intrinsic standalone fee lives in `default_value` + `default_unit`. For ruleless smart items, `default_value: 50, default_unit: "flat"` means "this item costs $50 flat". When rules exist, `default_value` still acts as a fallback for any rule row whose `value` is blank (the data-layer inheritance surfaced via the `Inherit: N` placeholder); `default_unit` is *not* a UI fallback for rule rows — each row's unit is explicit.
 - **No math on our side.** `Catalogue.item_pricing/1` and `Item.final_price/3` work purely off `base_price` + markup + discount and do not consult rules or defaults — they're the standard-item pricing helpers. Smart-item consumers read `list_catalogue_rules/1` + the item's `default_value`/`default_unit` and do their own math.
 
+### Attachments (featured image + file grid)
+
+Both catalogue and item forms support a featured image + a folder-scoped file grid via the shared `PhoenixKitCatalogue.Attachments` module. All the form plumbing (mount, upload progress, media-selector integration, file detach with `FolderLink` awareness, folder-rename on create) lives there; the form LVs just delegate.
+
+- **Folder-per-resource:** each item/catalogue owns one folder in `phoenix_kit_media_folders`, named deterministically (`catalogue-item-<uuid>` / `catalogue-<uuid>`). `data["files_folder_uuid"]` on the resource points at it. For `:new` forms the folder is created with a pending random name and `maybe_rename_pending_folder/2` renames it after save — non-fatal if rename fails (logs, returns `:ok`).
+- **Featured image:** `data["featured_image_uuid"]` on the resource points at any `phoenix_kit_files` row (not necessarily in this resource's folder — cross-resource duplicate moves can leave the featured pointer in another folder, and `compute_files_list/1` surfaces it in the grid anyway).
+- **Media picker scope:** catalogue + item forms render `<.live_component module={MediaSelectorModal} scope_folder_id={@files_folder_uuid} ...>`. The modal's `scope_folder_id` attr (added in phoenix_kit core) filters the browse query to files whose `folder_uuid` matches OR who have a `FolderLink` to that folder, and sets the same folder as home/link on post-upload files. This means uploading the same image to two items creates a `FolderLink` on the second — the file keeps its home with the first but appears in both grids.
+- **File detach semantics** (`Attachments.trash_file/2`): if the file's home folder is this resource AND it's only here → `Storage.trash_file`; home here + linked elsewhere → promote a link to home and delete the promoted link (the file stays alive under its new owner); linked here (home elsewhere) → delete the link only. Also clears the featured pointer if the removed file was featured.
+- **Save-path contract:** LVs call `Attachments.inject_attachment_data(params, socket)` before `update_item` / `update_catalogue` so `params["data"]` ends up with `files_folder_uuid` + `featured_image_uuid`. Save button is `disabled` while `@uploads.attachment_files.entries != []` to avoid racing a mid-upload `handle_progress` write against the save.
+- **Query cap:** `list_files_in_folder/1` uses `limit: 200` to keep a mistakenly-huge folder from freezing the form on mount (the dropzone itself caps a single submission at 20 files).
+- **`file_type` allowlist widened** (in phoenix_kit core): `File.changeset` now permits `["image", "video", "audio", "document", "archive", "other"]` so `file_type_from_mime/1` can safely return `"other"` for unknowns.
+
+### Item Metadata (opt-in fields)
+
+`PhoenixKitCatalogue.ItemMetadata` holds a code-defined list of fields an item can opt into. Values live on `item.data["meta"]` as a flat `%{key => string}` map — not on their own columns. Adding a field is a code edit; removing one does **not** wipe stored values (they surface in the form as "Legacy" rows with a remove-only action, so the user cleans them up explicitly).
+
+- `definitions/0` returns `[%{key: "color", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Color")}, ...]`. The `:key` is stable (JSONB key, never translated). The `:label` is gettext-wrapped at call time — callers cannot cache it across locale changes.
+- The item form's metadata tab shows a pick-a-field dropdown (only definitions not yet attached), renders one text input per attached key, and folds them into `item.data["meta"]` on save via `inject_meta_into_data/2`. Blank values drop (don't store empty strings). Legacy keys pass through untouched.
+- There is **no** `Catalogue.set_item_metadata/3` context helper — use `update_item(item, %{data: %{"meta" => new_meta}})`. Merge the new meta with whatever else lives on `data`.
+
+### Item Picker component
+
+`PhoenixKitCatalogue.Web.Components.ItemPicker` is a combobox LiveComponent for picking a single item via server-side search. Exposed through the `<.item_picker id=... category_uuids=... locale=... />` wrapper in `Components`. Emits `{:item_picker_select, id, %Item{}}` / `{:item_picker_clear, id}` up to the parent LV (parent needs matching `handle_info/2` clauses). Keyboard/a11y is driven by a colocated `ItemPicker` hook (no external JS). Scope composes via `:category_uuids`, `:catalogue_uuids`, `:include_descendants` — the latter passes straight through to the `search_items/2` tree expansion.
+
+The dropdown is absolutely positioned with `z-50` — the container's ancestors must not clip overflow.
+
 ### Activity Logging
 
 Every mutating operation in `Catalogue` context is logged via `PhoenixKit.Activity.log/1`:
 
 - **Pattern**: Private `log_activity/1` helper guarded by `Code.ensure_loaded?(PhoenixKit.Activity)` with rescue to `Logger.warning`. Activity logging failures never crash the primary operation.
 - **Actor tracking**: All mutating functions accept `opts \\ []` keyword list. Pass `actor_uuid: user.uuid` to attribute the action.
-- **Actions logged**: `manufacturer.created/updated/deleted`, `supplier.created/updated/deleted`, `catalogue.created/updated/deleted/trashed/restored/permanently_deleted`, `category.created/updated/deleted/trashed/restored/permanently_deleted/moved/positions_swapped`, `item.created/updated/deleted/trashed/restored/permanently_deleted/moved/bulk_trashed`, `manufacturer.suppliers_synced`, `supplier.manufacturers_synced`, `smart_rules.synced` (with `added`/`updated`/`removed`/`total` counts), `import.started`, `import.completed`
+- **Actions logged**: `manufacturer.created/updated/deleted`, `supplier.created/updated/deleted`, `catalogue.created/updated/deleted/trashed/restored/permanently_deleted`, `category.created/updated/deleted/trashed/restored/permanently_deleted/moved/positions_swapped`, `item.created/updated/deleted/trashed/restored/permanently_deleted/moved/bulk_trashed`, `manufacturer.suppliers_synced`, `supplier.manufacturers_synced`, `smart_rules.synced` (with `added`/`updated`/`removed`/`total` counts), `import.started`, `import.completed`. Since V103, `category.trashed` / `category.restored` / `category.permanently_deleted` carry `subtree_size` + `items_cascaded`; `category.moved` includes `from_parent_uuid` / `to_parent_uuid` (in-catalogue reparents via `move_category_under/3`) or `from_catalogue_uuid` / `to_catalogue_uuid` + `subtree_size` + `items_cascaded` (cross-catalogue moves). Attachments (file uploads, featured-image changes) are not individually logged — they're captured as part of the `item.updated` / `catalogue.updated` entry on the containing save.
 - **Mode**: `"manual"` for user actions, `"auto"` for import-created items/categories
 - **LiveViews**: Extract actor UUID via `actor_opts(socket)` private helper reading `socket.assigns[:phoenix_kit_current_user]`
 
@@ -196,7 +234,10 @@ lib/phoenix_kit_catalogue/
 │   ├── rules.ex                               # Smart-catalogue rule CRUD + put_catalogue_rules/3 replace-all
 │   ├── search.ex                              # search_items/2 + scoped wrappers, count_*
 │   ├── suppliers.ex                           # Supplier CRUD with activity logging
-│   └── translations.ex                        # Multilang read/write against schema.data JSONB
+│   ├── translations.ex                        # Multilang read/write against schema.data JSONB
+│   └── tree.ex                                # V103 recursive-CTE helpers (subtree/ancestor/children-index)
+├── attachments.ex                             # Form-level featured-image + inline files dropzone wiring (shared by catalogue_form_live + item_form_live)
+├── item_metadata.ex                           # Global opt-in metadata field definitions (labels are gettext-wrapped)
 ├── paths.ex                                   # Centralized URL path helpers
 ├── schemas/
 │   ├── cat_catalogue.ex                       # Catalogue schema + changeset (kind: standard|smart)
@@ -211,12 +252,14 @@ lib/phoenix_kit_catalogue/
 │   ├── mapper.ex                              # Column mapping + auto-detection
 │   └── executor.ex                            # Import execution with progress reporting
 └── web/
-    ├── components.ex                          # Reusable components (item_table, search_input, etc.)
+    ├── components.ex                          # Reusable components (item_table, search_input, item_picker wrapper, etc.)
+    ├── components/
+    │   └── item_picker.ex                     # Combobox LiveComponent (server-side search + colocated JS hook)
     ├── catalogues_live.ex                     # Index page (catalogues/manufacturers/suppliers)
-    ├── catalogue_detail_live.ex               # Catalogue detail with categories + items
-    ├── catalogue_form_live.ex                 # Create/edit catalogue
-    ├── category_form_live.ex                  # Create/edit/move category
-    ├── item_form_live.ex                      # Create/edit/move item
+    ├── catalogue_detail_live.ex               # Catalogue detail with categories + items (tree depths render indented)
+    ├── catalogue_form_live.ex                 # Create/edit catalogue + featured image + files dropzone
+    ├── category_form_live.ex                  # Create/edit/move category (with parent picker + Move-to-parent)
+    ├── item_form_live.ex                      # Create/edit/move item (with tabs: Details / Metadata / Files)
     ├── manufacturer_form_live.ex              # Create/edit manufacturer + supplier links
     ├── supplier_form_live.ex                  # Create/edit supplier + manufacturer links
     ├── import_live.ex                         # Multi-step import wizard

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Designed for manufacturing companies (e.g. kitchen/furniture producers) that nee
 
 ## Features
 
-- **Catalogues** — top-level groupings with configurable markup and discount percentage for pricing
-- **Categories** — subdivisions within a catalogue with manual position ordering
-- **Items** — individual products with SKU, base price, unit of measure, and computed `sale_price` (post-markup) + `final_price` (post-discount)
+- **Catalogues** — top-level groupings with configurable markup and discount percentage for pricing; featured image + file attachments
+- **Categories** — nested subdivisions within a catalogue (arbitrary-depth tree via V103 `parent_uuid`); sibling-scoped position ordering; trash/restore/delete cascades through the whole subtree
+- **Items** — individual products with SKU, base price, unit of measure, and computed `sale_price` (post-markup) + `final_price` (post-discount). Optional per-item metadata fields (color, weight, dimensions, …) stored on `item.data["meta"]`; featured image + file attachments
 - **Manufacturers** — company directory with many-to-many supplier linking
 - **Suppliers** — delivery companies linked to manufacturers
 - **Pricing chain** — `base → markup → discount`: per-catalogue defaults plus optional per-item override on each leg (`nil` inherits, any value including `0` overrides)
@@ -18,7 +18,7 @@ Designed for manufacturing companies (e.g. kitchen/furniture producers) that nee
 - **Multilingual** — all translatable fields use PhoenixKit's multilang system
 - **Move operations** — move categories between catalogues, items between categories
 - **Card/table views** — all tables support card view toggle, persisted per user in localStorage
-- **Reusable components** — `item_table`, `search_input`, `view_mode_toggle`, `empty_state`, `scope_selector`, `catalogue_rules_picker` with gettext localization
+- **Reusable components** — `item_table`, `search_input`, `view_mode_toggle`, `empty_state`, `scope_selector`, `catalogue_rules_picker`, `item_picker` (server-side search combobox with colocated keyboard hook) with gettext localization
 - **Zero-config discovery** — auto-discovered by PhoenixKit via beam scanning
 
 ## Installation
@@ -55,7 +55,9 @@ Catalogue (1) ──> Category (many) ──> Item (many)
                   │                                  │
                   │                                  └── references another Catalogue
                   │                                       with (value, unit, position)
-                  └── position-ordered, soft-deletable
+                  ├── position-ordered, soft-deletable
+                  └── self-FK parent_uuid (V103) — arbitrary-depth tree;
+                      NULL means root; positions scoped per sibling group
 ```
 
 All tables use UUIDv7 primary keys and are prefixed with `phoenix_kit_cat_*`.
@@ -112,13 +114,28 @@ Catalogue.permanently_delete_catalogue(cat)        # hard-delete (cascades down)
 
 # ── Categories ────────────────────────────────────────
 Catalogue.list_categories_for_catalogue(cat_uuid)  # excludes deleted
-Catalogue.list_all_categories()                    # "Catalogue / Category" format
+Catalogue.list_all_categories()                    # "Catalogue / Ancestor / Child" breadcrumb format
 Catalogue.create_category(%{name: "Frames", catalogue_uuid: cat.uuid})
-Catalogue.trash_category(category)                 # cascades to items
-Catalogue.restore_category(category)               # cascades up + down
-Catalogue.permanently_delete_category(category)    # cascades to items
-Catalogue.move_category_to_catalogue(category, target_uuid)
-Catalogue.next_category_position(cat_uuid)
+Catalogue.create_category(%{name: "Nested", catalogue_uuid: cat.uuid, parent_uuid: parent.uuid})
+Catalogue.trash_category(category)                 # cascades through the whole subtree (V103)
+Catalogue.restore_category(category)               # restores deleted ancestors + subtree + items
+Catalogue.permanently_delete_category(category)    # hard-deletes subtree; cannot be undone
+Catalogue.move_category_to_catalogue(category, target_uuid)   # moves the whole subtree
+Catalogue.next_category_position(cat_uuid)         # root-level (parent_uuid: nil)
+Catalogue.next_category_position(cat_uuid, parent_uuid)  # scoped to a sibling group
+
+# ── Nested categories (V103) ──────────────────────────
+Catalogue.list_category_tree(cat_uuid)
+# => [{%Category{}, 0}, {%Category{}, 1}, ...]  # depth-first with depth
+Catalogue.list_category_tree(cat_uuid, exclude_subtree_of: editing.uuid)
+Catalogue.list_category_ancestors(child_uuid)      # [root, ..., direct_parent]
+
+Catalogue.move_category_under(child, parent.uuid)  # reparent within the catalogue
+Catalogue.move_category_under(child, nil)          # promote to root
+# => {:error, :would_create_cycle | :cross_catalogue | :parent_not_found}
+
+Catalogue.swap_category_positions(a, b)            # siblings only
+# => {:error, :not_siblings} for non-siblings
 
 # ── Items ─────────────────────────────────────────────
 Catalogue.list_items()                             # all non-deleted, preloads all
@@ -206,6 +223,12 @@ Catalogue.search_items("oak", category_uuids: [c1, c2])          # only these ca
 Catalogue.search_items("oak", catalogue_uuids: [a], category_uuids: [c1])  # AND
 Catalogue.search_items_in_catalogue(cat_uuid, "panel")           # convenience wrapper
 Catalogue.search_items_in_category(cat_uuid, "oak")              # convenience wrapper
+
+# Nested categories: scoping by a parent category also matches items
+# in descendant categories (default since V103). Pass false to scope
+# strictly to the given UUIDs.
+Catalogue.search_items("oak", category_uuids: [root_uuid])                            # matches descendants
+Catalogue.search_items("oak", category_uuids: [root_uuid], include_descendants: false) # literal set only
 
 # Unbounded total for paging / summaries (accepts the same scope filters)
 Catalogue.count_search_items("oak")
@@ -311,6 +334,29 @@ Smart-catalogue rule editor — one row per candidate catalogue with a checkbox,
 
 Emits four customizable events: `toggle_catalogue_rule`, `set_catalogue_rule_value`, `set_catalogue_rule_unit`, `clear_catalogue_rules`. The LV owns `working_rules` as a `%{referenced_catalogue_uuid => %{value, unit}}` map and calls `put_catalogue_rules/3` on save. Rows with blank values show `Inherit: N` as placeholder when an item default is set. The per-row unit dropdown is self-contained — toggling a row on defaults its unit to `"percent"` and the item's `default_unit` does not cascade into rule rows.
 
+### `item_picker/1`
+
+Combobox for picking a single item by searching across a scoped set of catalogues/categories. Server-side search, colocated keyboard-handling hook (arrow keys, enter, escape, home/end), debounced input. Pairs with the nested-category search: category scopes expand through descendants by default.
+
+```heex
+<.item_picker
+  id={"row-#{@row.id}-picker"}
+  category_uuids={[@category_uuid]}
+  selected_item={@row.item}
+  excluded_uuids={@used_uuids}
+  locale="en"
+/>
+```
+
+The parent LV handles two messages:
+
+```elixir
+def handle_info({:item_picker_select, id, %Item{} = item}, socket), do: ...
+def handle_info({:item_picker_clear, id}, socket), do: ...
+```
+
+The dropdown is absolutely positioned with `z-50`; ancestor containers must not `overflow: hidden`.
+
 ### `search_results_summary/1` and `empty_state/1`
 
 ```heex
@@ -324,6 +370,20 @@ Emits four customizable events: `toggle_catalogue_rule`, `set_catalogue_rule_val
 ```
 
 All component text (column headers, action labels, toggle tooltips, result counts) is localizable via PhoenixKit's Gettext backend.
+
+## Attachments (featured image + files)
+
+Both catalogue and item forms support a **featured image** plus an **inline files dropzone**, wired via the shared `PhoenixKitCatalogue.Attachments` module. Each resource owns one folder in `phoenix_kit_media_folders` (named `catalogue-<uuid>` / `catalogue-item-<uuid>`); `data["files_folder_uuid"]` on the resource points at it. `data["featured_image_uuid"]` points at a `phoenix_kit_files` row.
+
+The featured-image picker opens phoenix_kit's `MediaSelectorModal` scoped to the resource's folder (via a new `scope_folder_id` attr in phoenix_kit core) — browse and post-upload home folder are both constrained to that scope, so uploading the same file to two items creates a `FolderLink` rather than yanking the file between resources. See `lib/phoenix_kit_catalogue/attachments.ex` for the full behaviour (detach semantics for shared files, pending-folder rename on first save, upload-error messages, etc.).
+
+There's no dedicated `Catalogue.set_featured_image/2` context helper — programmatic callers use `update_item`/`update_catalogue` with `%{data: %{"featured_image_uuid" => uuid, "files_folder_uuid" => folder_uuid}}`.
+
+## Item Metadata (opt-in fields)
+
+Items can opt into a shared, code-defined list of metadata fields (color, weight, dimensions, material, finish, …) defined in `PhoenixKitCatalogue.ItemMetadata`. Values live in `item.data["meta"]` as a flat `%{key => string}` map. The form's Metadata tab lets the user pick which fields to attach per item; legacy keys (defined in older code revisions but no longer listed) surface as "Legacy" rows with a remove-only action so stored data isn't silently lost.
+
+Labels are translated via `PhoenixKitWeb.Gettext`. Adding / removing fields is a code edit to `definitions/0`.
 
 ## Admin UI
 

--- a/lib/phoenix_kit_catalogue/attachments.ex
+++ b/lib/phoenix_kit_catalogue/attachments.ex
@@ -1,0 +1,727 @@
+defmodule PhoenixKitCatalogue.Attachments do
+  @moduledoc """
+  Folder-scoped file attachments + featured image for catalogue
+  resources (items and catalogues share the exact same pattern).
+
+  Each resource owns a `phoenix_kit_media_folders` row keyed by a
+  deterministic name derived from the resource struct and UUID.
+  Files belong to the resource via `phoenix_kit_files.folder_uuid`,
+  queried on mount and refreshed after uploads. An optional featured
+  image is a single UUID pointer on `resource.data["featured_image_uuid"]`.
+
+  ## Usage
+
+  The owning LiveView calls `mount_attachments/2` in `mount/3` and
+  `allow_attachment_upload/1` in the same chain. Its event/info
+  clauses delegate to the matching functions here:
+
+      # Mount
+      socket
+      |> Attachments.mount_attachments(item_or_catalogue)
+      |> Attachments.allow_attachment_upload()
+
+      # Events (one-liner bodies)
+      def handle_event("open_featured_image_picker", _, s),
+        do: Attachments.open_featured_image_picker(s)
+
+      def handle_event("close_media_selector", _, s),
+        do: {:noreply, Attachments.close_media_selector(s)}
+
+      def handle_event("cancel_upload", %{"ref" => ref}, s),
+        do: Attachments.cancel_attachment_upload(s, ref)
+
+      def handle_event("clear_featured_image", _, s),
+        do: Attachments.clear_featured_image(s)
+
+      def handle_event("remove_file", %{"uuid" => uuid}, s),
+        do: Attachments.trash_file(s, uuid)
+
+      def handle_info({:media_selected, uuids}, s),
+        do: Attachments.handle_media_selected(s, uuids)
+
+      def handle_info({:media_selector_closed}, s),
+        do: {:noreply, Attachments.close_media_selector(s)}
+
+  On save, weave attachment state into params:
+
+      params = Attachments.inject_attachment_data(params, socket)
+
+  And after a `:new` save succeeds, rename the pending folder:
+
+      :ok = Attachments.maybe_rename_pending_folder(socket, saved_resource)
+
+  ## Resource shape
+
+  The module pattern-matches on the resource struct to derive the
+  folder name prefix. Add a new clause to `folder_name_for/1` to
+  support additional resource types.
+  """
+
+  require Logger
+
+  import Ecto.Query, warn: false
+  import Phoenix.Component, only: [assign: 2, assign: 3]
+
+  import Phoenix.LiveView,
+    only: [
+      allow_upload: 3,
+      cancel_upload: 3,
+      consume_uploaded_entry: 3,
+      put_flash: 3
+    ]
+
+  alias PhoenixKit.Modules.Storage
+  alias PhoenixKit.Modules.Storage.{File, FolderLink}
+  alias PhoenixKit.Users.Auth, as: UsersAuth
+  alias PhoenixKitCatalogue.Schemas.{Catalogue, Item}
+
+  @upload_name :attachment_files
+  @doc "Returns the upload ref name used for the inline files dropzone."
+  def upload_name, do: @upload_name
+
+  # ── Mount ────────────────────────────────────────────────────────
+
+  @doc """
+  Populates the attachment-related assigns on the socket. Accepts the
+  owning resource (Item or Catalogue). Stashes the resource at
+  `:attachments_resource` so later callbacks (progress, events) can
+  reach it without plumbing.
+  """
+  def mount_attachments(socket, resource) do
+    socket
+    |> assign(:attachments_resource, resource)
+    |> assign_files_folder(resource)
+    # Featured image must be set before files_state so the merge can
+    # surface it even if it's in a different folder (e.g. the file was
+    # moved to another resource's folder after being featured here).
+    |> assign_featured_image_state(resource)
+    |> assign_files_state()
+    |> assign_media_selector_defaults()
+  end
+
+  @doc """
+  Registers the file input `:attachment_files` with a 20-file, 100MB
+  ceiling and auto-upload. Progress is consumed by `handle_progress/3`
+  which this module captures for the caller.
+  """
+  def allow_attachment_upload(socket) do
+    allow_upload(socket, @upload_name,
+      accept: :any,
+      max_entries: 20,
+      max_file_size: 100_000_000,
+      auto_upload: true,
+      progress: &handle_progress/3
+    )
+  end
+
+  defp assign_files_folder(socket, resource) do
+    assign(socket, :files_folder_uuid, read_string(resource_data(resource), "files_folder_uuid"))
+  end
+
+  defp assign_files_state(socket) do
+    assign(socket, :files_state, %{files: compute_files_list(socket)})
+  end
+
+  # Files list = everything in the resource's folder + the featured
+  # image if it lives elsewhere. Cross-resource duplicate-moves can
+  # leave `featured_image_uuid` pointing at a file now in another
+  # resource's folder; we still show it here so the grid reflects
+  # what the form's pointers actually reference.
+  defp compute_files_list(socket) do
+    folder_files =
+      case socket.assigns[:files_folder_uuid] do
+        nil -> []
+        folder_uuid -> list_files_in_folder(folder_uuid)
+      end
+
+    case socket.assigns[:featured_image_file] do
+      nil ->
+        folder_files
+
+      %{uuid: featured_uuid} = featured_file ->
+        if Enum.any?(folder_files, &(&1.uuid == featured_uuid)) do
+          folder_files
+        else
+          [featured_file | folder_files]
+        end
+    end
+  end
+
+  defp assign_featured_image_state(socket, resource) do
+    uuid = read_string(resource_data(resource), "featured_image_uuid")
+    file = if uuid, do: safe_get_file(uuid), else: nil
+
+    assign(socket,
+      featured_image_uuid: if(file, do: uuid, else: nil),
+      featured_image_file: file
+    )
+  end
+
+  defp assign_media_selector_defaults(socket) do
+    assign(socket,
+      show_media_selector: false,
+      media_selector_target: nil,
+      media_selection_mode: :single,
+      media_filter: :image,
+      media_selected_uuids: []
+    )
+  end
+
+  # ── Event bodies ─────────────────────────────────────────────────
+
+  @doc "Opens the media selector modal scoped to the resource's folder."
+  def open_featured_image_picker(socket) do
+    case ensure_folder(socket) do
+      {:ok, _folder_uuid, socket} ->
+        preselected = List.wrap(socket.assigns[:featured_image_uuid])
+
+        {:noreply,
+         socket
+         |> assign(:media_selector_target, :featured_image)
+         |> assign(:media_selection_mode, :single)
+         |> assign(:media_filter, :image)
+         |> assign(:media_selected_uuids, preselected)
+         |> assign(:show_media_selector, true)}
+
+      {:error, reason} ->
+        Logger.warning("Failed to ensure attachments folder: #{inspect(reason)}")
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Could not prepare the files folder.")
+         )}
+    end
+  end
+
+  @doc "Clears the media-selector assigns; returns the plain socket."
+  def close_media_selector(socket) do
+    assign(socket,
+      show_media_selector: false,
+      media_selector_target: nil,
+      media_selected_uuids: []
+    )
+  end
+
+  @doc "Cancels an in-flight upload entry by ref."
+  def cancel_attachment_upload(socket, ref) do
+    {:noreply, cancel_upload(socket, @upload_name, ref)}
+  end
+
+  @doc "Nulls the featured image pointer in socket state (save persists)."
+  def clear_featured_image(socket) do
+    {:noreply,
+     socket
+     |> assign(:featured_image_uuid, nil)
+     |> assign(:featured_image_file, nil)
+     |> refresh_files_from_folder()}
+  end
+
+  @doc """
+  Removes the file from this resource. Three cases:
+
+  1. File's home folder is this resource AND it's only here → trash it
+     (single-owner case; same effect as before folder-links).
+  2. File's home folder is this resource AND it's also linked elsewhere
+     → promote one link to home, delete the promoted link. The file
+     stays alive under its new owner.
+  3. File was here via a `FolderLink` (home is another resource) →
+     delete the link. Other owners keep their reference untouched.
+
+  Also clears the featured pointer if the removed file was featured.
+  """
+  def trash_file(socket, uuid) do
+    folder_uuid = socket.assigns[:files_folder_uuid]
+
+    case do_detach(uuid, folder_uuid) do
+      :ok ->
+        new_files = Enum.reject(socket.assigns.files_state.files, &(&1.uuid == uuid))
+
+        {:noreply,
+         socket
+         |> assign(:files_state, %{files: new_files})
+         |> maybe_clear_featured_if_matches(uuid)}
+
+      {:error, reason} ->
+        Logger.warning("Failed to remove file #{uuid}: #{inspect(reason)}")
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Could not remove file.")
+         )}
+    end
+  end
+
+  defp do_detach(_uuid, nil), do: :ok
+
+  defp do_detach(file_uuid, folder_uuid) do
+    case Storage.get_file(file_uuid) do
+      nil -> :ok
+      %File{folder_uuid: ^folder_uuid} = file -> detach_home(file)
+      %File{} = file -> detach_link(file.uuid, folder_uuid)
+    end
+  end
+
+  # File's home is this folder; check for other `FolderLink`s to
+  # decide between trashing (single-owner) and promoting (shared).
+  defp detach_home(file) do
+    repo = PhoenixKit.RepoHelper.repo()
+
+    case list_links(file.uuid) do
+      [] ->
+        case soft_trash_file(file) do
+          {:ok, _} -> :ok
+          err -> err
+        end
+
+      [%FolderLink{} = link | _rest] ->
+        repo.transaction(fn ->
+          file
+          |> Ecto.Changeset.change(%{folder_uuid: link.folder_uuid})
+          |> repo.update!()
+
+          repo.delete!(link)
+        end)
+        |> case do
+          {:ok, _} -> :ok
+          err -> err
+        end
+    end
+  end
+
+  # Inline soft-trash so we don't depend on `Storage.trash_file/1` being
+  # present in the consumer's vendored `phoenix_kit` version. The
+  # public core helper was introduced after the hex release this plugin
+  # pins against; the write shape is trivial (status + timestamp) so
+  # doing it here keeps the plugin decoupled from the core version
+  # skew.
+  defp soft_trash_file(%File{} = file) do
+    file
+    |> Ecto.Changeset.change(%{
+      status: "trashed",
+      trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> PhoenixKit.RepoHelper.repo().update()
+  end
+
+  # File's home is elsewhere — removing from this resource just means
+  # deleting its folder_link for this folder. Other resources keep it.
+  defp detach_link(file_uuid, folder_uuid) do
+    from(fl in FolderLink,
+      where: fl.file_uuid == ^file_uuid and fl.folder_uuid == ^folder_uuid
+    )
+    |> PhoenixKit.RepoHelper.repo().delete_all()
+
+    :ok
+  end
+
+  defp list_links(file_uuid) do
+    from(fl in FolderLink, where: fl.file_uuid == ^file_uuid)
+    |> PhoenixKit.RepoHelper.repo().all()
+  end
+
+  # ── handle_info bodies ───────────────────────────────────────────
+
+  @doc """
+  Routes the `:media_selected` reply by `:media_selector_target`.
+  Featured-image target promotes the first selected UUID; files
+  target is a no-op (modal already set folder_uuid). Both refresh
+  the grid from the folder.
+  """
+  def handle_media_selected(socket, file_uuids) do
+    socket =
+      case socket.assigns[:media_selector_target] do
+        :featured_image -> apply_featured_image_selection(socket, file_uuids)
+        # Future: :files target for bulk picker. Today only featured_image
+        # opens the modal, but routing stays open for extension.
+        _ -> refresh_files_from_folder(socket)
+      end
+
+    {:noreply, close_media_selector(socket)}
+  end
+
+  # ── Upload progress (captured via &handle_progress/3) ────────────
+
+  @doc false
+  def handle_progress(@upload_name, %{done?: false}, socket), do: {:noreply, socket}
+
+  def handle_progress(@upload_name, entry, socket) do
+    case ensure_folder(socket) do
+      {:ok, folder_uuid, socket} -> consume_and_store(socket, entry, folder_uuid)
+      {:error, reason} -> {:noreply, put_upload_error(socket, entry, reason)}
+    end
+  end
+
+  defp consume_and_store(socket, entry, folder_uuid) do
+    case consume_uploaded_entry(socket, entry, &store_upload(&1, entry, socket, folder_uuid)) do
+      {:ok, _file} -> {:noreply, refresh_files_from_folder(socket)}
+      {:error, reason} -> {:noreply, put_upload_error(socket, entry, reason)}
+    end
+  end
+
+  # ── Save-time helpers ────────────────────────────────────────────
+
+  @doc """
+  Merges `files_folder_uuid` and `featured_image_uuid` into `params["data"]`.
+  Call right before passing params to your context's create/update.
+  """
+  def inject_attachment_data(params, socket) do
+    params
+    |> inject_files_folder(socket.assigns[:files_folder_uuid])
+    |> inject_featured_image(socket.assigns[:featured_image_uuid])
+  end
+
+  @doc """
+  After a `:new` save, renames the pending (random-named) folder to
+  the deterministic name now that the resource has a UUID. Non-fatal:
+  rename failures log and return `:ok` so the save flow isn't blocked.
+  """
+  def maybe_rename_pending_folder(socket, resource) do
+    with folder_uuid when is_binary(folder_uuid) <- socket.assigns[:files_folder_uuid],
+         {:ok, target_name} <- folder_name_for(resource),
+         %{} = folder <- Storage.get_folder(folder_uuid) do
+      case Storage.update_folder(folder, %{name: target_name}) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning(
+            "Pending folder rename failed for #{inspect(resource.__struct__)} #{resource.uuid}: #{inspect(reason)}"
+          )
+
+          :ok
+      end
+    else
+      _ -> :ok
+    end
+  end
+
+  # ── Template helpers ─────────────────────────────────────────────
+
+  @doc "Renders a byte count as a human string. Nil-safe."
+  def format_file_size(nil), do: "—"
+
+  def format_file_size(bytes) when is_integer(bytes) do
+    cond do
+      bytes >= 1_000_000_000 -> "#{Float.round(bytes / 1_000_000_000, 1)} GB"
+      bytes >= 1_000_000 -> "#{Float.round(bytes / 1_000_000, 1)} MB"
+      bytes >= 1_000 -> "#{Float.round(bytes / 1_000, 1)} KB"
+      true -> "#{bytes} B"
+    end
+  end
+
+  def format_file_size(_), do: "—"
+
+  @doc "Picks a heroicon name for a file based on its Storage type."
+  def file_icon(%{file_type: "image"}), do: "hero-photo"
+  def file_icon(%{file_type: "video"}), do: "hero-film"
+  def file_icon(%{file_type: "audio"}), do: "hero-musical-note"
+  def file_icon(%{file_type: "archive"}), do: "hero-archive-box"
+  def file_icon(%{mime_type: "application/pdf"}), do: "hero-document-text"
+  def file_icon(_), do: "hero-document"
+
+  @doc "Translates LiveView upload error atoms to user-facing text."
+  def upload_error_message(:too_large),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "File is too large.")
+
+  def upload_error_message(:not_accepted),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "File type not accepted.")
+
+  def upload_error_message(:too_many_files),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Too many files.")
+
+  def upload_error_message(other),
+    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Upload error: %{reason}", reason: inspect(other))
+
+  # ── Internals ────────────────────────────────────────────────────
+
+  # Naming convention: `catalogue-item-<uuid>` vs `catalogue-<uuid>`.
+  # Different prefixes prevent name collisions at the folder root.
+  defp folder_name_for(%Item{uuid: uuid}) when is_binary(uuid),
+    do: {:ok, "catalogue-item-#{uuid}"}
+
+  defp folder_name_for(%Catalogue{uuid: uuid}) when is_binary(uuid),
+    do: {:ok, "catalogue-#{uuid}"}
+
+  defp folder_name_for(_), do: :pending
+
+  # Lazy-creates (or finds) the owning folder. For persisted resources
+  # the name is deterministic; for `:new` resources we create a pending
+  # random-named folder that `maybe_rename_pending_folder/2` renames
+  # once the resource has a UUID.
+  defp ensure_folder(socket) do
+    case socket.assigns[:files_folder_uuid] do
+      uuid when is_binary(uuid) ->
+        {:ok, uuid, socket}
+
+      _ ->
+        resource = socket.assigns[:attachments_resource]
+
+        case folder_name_for(resource) do
+          {:ok, name} -> find_or_create_folder(socket, name)
+          :pending -> create_pending_folder(socket)
+        end
+    end
+  end
+
+  defp find_or_create_folder(socket, folder_name) do
+    case find_folder_by_name(folder_name) do
+      %{uuid: uuid} ->
+        {:ok, uuid, assign(socket, :files_folder_uuid, uuid)}
+
+      nil ->
+        create_folder(socket, folder_name)
+    end
+  end
+
+  defp create_pending_folder(socket) do
+    create_folder(socket, "catalogue-attachment-pending-#{Ecto.UUID.generate()}")
+  end
+
+  defp create_folder(socket, folder_name) do
+    user_uuid = current_user_uuid(socket)
+
+    case Storage.create_folder(%{name: folder_name, user_uuid: user_uuid}) do
+      {:ok, folder} -> {:ok, folder.uuid, assign(socket, :files_folder_uuid, folder.uuid)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp find_folder_by_name(name) when is_binary(name) do
+    from(f in PhoenixKit.Modules.Storage.Folder,
+      where: f.name == ^name and is_nil(f.parent_uuid),
+      limit: 1
+    )
+    |> PhoenixKit.RepoHelper.repo().one()
+  rescue
+    error ->
+      Logger.warning("find_folder_by_name failed for #{name}: #{inspect(error)}")
+      nil
+  end
+
+  # Upload cap is 20 files per submit; the inline grid is not paginated
+  # and renders every row. Anything over this is almost certainly data
+  # left by an earlier workflow — we hard-cap the query so a folder
+  # with thousands of files doesn't freeze the form on mount.
+  @files_grid_limit 200
+
+  # Files visible in this resource's folder: home-folder files plus
+  # anything linked in via `FolderLink`. The link path lets the same
+  # file be attached to multiple resources without being moved when
+  # uploaded a second time.
+  defp list_files_in_folder(folder_uuid) do
+    linked_subq =
+      from(fl in FolderLink,
+        where: fl.folder_uuid == ^folder_uuid,
+        select: fl.file_uuid
+      )
+
+    from(f in File,
+      where:
+        (f.folder_uuid == ^folder_uuid or f.uuid in subquery(linked_subq)) and
+          f.status != "trashed",
+      order_by: [asc: f.inserted_at],
+      limit: @files_grid_limit
+    )
+    |> PhoenixKit.RepoHelper.repo().all()
+  rescue
+    error ->
+      Logger.warning("list_files_in_folder failed for #{folder_uuid}: #{inspect(error)}")
+      []
+  end
+
+  defp safe_get_file(uuid) when is_binary(uuid) do
+    Storage.get_file(uuid)
+  rescue
+    error ->
+      Logger.warning("Failed to load Storage file #{uuid}: #{inspect(error)}")
+      nil
+  end
+
+  defp safe_get_file(_), do: nil
+
+  defp current_user_uuid(socket) do
+    case socket.assigns[:phoenix_kit_current_user] do
+      %{uuid: uuid} -> uuid
+      _ -> nil
+    end
+  end
+
+  # Re-queries the folder and merges the featured image if needed.
+  # Use this after any state change that can affect the files list —
+  # uploads, featured-image changes, trashing, etc.
+  defp refresh_files_from_folder(socket) do
+    assign(socket, :files_state, %{files: compute_files_list(socket)})
+  end
+
+  defp apply_featured_image_selection(socket, []) do
+    assign(socket, featured_image_uuid: nil, featured_image_file: nil)
+  end
+
+  defp apply_featured_image_selection(socket, [uuid | _]) when is_binary(uuid) do
+    case safe_get_file(uuid) do
+      nil ->
+        put_flash(
+          socket,
+          :error,
+          Gettext.gettext(PhoenixKitWeb.Gettext, "Selected image could not be loaded.")
+        )
+
+      file ->
+        # Assign featured first, then refresh — `compute_files_list/1`
+        # reads `featured_image_file` to surface the featured file in
+        # the grid even when it lives outside the folder.
+        socket
+        |> assign(featured_image_uuid: uuid, featured_image_file: file)
+        |> refresh_files_from_folder()
+    end
+  end
+
+  defp maybe_clear_featured_if_matches(socket, uuid) do
+    if socket.assigns[:featured_image_uuid] == uuid do
+      assign(socket, featured_image_uuid: nil, featured_image_file: nil)
+    else
+      socket
+    end
+  end
+
+  defp store_upload(%{path: path}, entry, socket, folder_uuid) do
+    user_uuid = current_user_uuid(socket)
+
+    if is_nil(user_uuid) do
+      {:ok, {:error, :no_user}}
+    else
+      file_checksum = UsersAuth.calculate_file_hash(path)
+      ext = entry.client_name |> Path.extname() |> String.trim_leading(".") |> String.downcase()
+      file_type = file_type_from_mime(entry.client_type)
+
+      case Storage.store_file_in_buckets(
+             path,
+             file_type,
+             user_uuid,
+             file_checksum,
+             ext,
+             entry.client_name
+           ) do
+        {:ok, file} ->
+          _ = assign_file_to_folder(file, folder_uuid)
+          {:ok, {:ok, file}}
+
+        {:ok, file, :duplicate} ->
+          _ = assign_file_to_folder(file, folder_uuid)
+          {:ok, {:ok, file}}
+
+        {:error, reason} ->
+          {:ok, {:error, reason}}
+      end
+    end
+  end
+
+  # Mirrors the phoenix_kit core `maybe_set_folder/2`: no-op when the
+  # file is already in this folder, adopt as home when it has no
+  # folder, otherwise add a `FolderLink` so the file appears in
+  # multiple resource folders without being yanked from its original
+  # owner. Inline dropzone uploads use this path; modal uploads go
+  # through the core function of the same shape.
+  defp assign_file_to_folder(%{folder_uuid: current}, folder_uuid) when current == folder_uuid,
+    do: :ok
+
+  defp assign_file_to_folder(%File{folder_uuid: nil} = file, folder_uuid) do
+    file
+    |> Ecto.Changeset.change(%{folder_uuid: folder_uuid})
+    |> PhoenixKit.RepoHelper.repo().update()
+  end
+
+  defp assign_file_to_folder(%File{uuid: file_uuid}, folder_uuid) when is_binary(folder_uuid) do
+    %FolderLink{}
+    |> FolderLink.changeset(%{folder_uuid: folder_uuid, file_uuid: file_uuid})
+    |> PhoenixKit.RepoHelper.repo().insert(
+      on_conflict: :nothing,
+      conflict_target: [:folder_uuid, :file_uuid]
+    )
+  end
+
+  defp put_upload_error(socket, entry, reason) do
+    Logger.warning("Attachment upload failed for #{entry.client_name}: #{inspect(reason)}")
+
+    put_flash(
+      socket,
+      :error,
+      Gettext.gettext(PhoenixKitWeb.Gettext, "Upload failed for %{name}.",
+        name: entry.client_name
+      )
+    )
+  end
+
+  @document_mimes ~w(
+    application/pdf
+    application/msword
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    application/vnd.ms-excel
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+  )
+
+  # Matches `Storage.determine_file_type/1` for types the browser
+  # surfaces; anything we can't bucket falls to "other" (allowed since
+  # the phoenix_kit allowlist was widened).
+  defp file_type_from_mime(mime) when mime in [nil, ""], do: "other"
+
+  defp file_type_from_mime(mime) when is_binary(mime) do
+    file_type_from_prefix(mime) ||
+      file_type_from_exact(mime) ||
+      file_type_from_keyword(mime) ||
+      "other"
+  end
+
+  defp file_type_from_prefix("image/" <> _), do: "image"
+  defp file_type_from_prefix("video/" <> _), do: "video"
+  defp file_type_from_prefix("audio/" <> _), do: "audio"
+  defp file_type_from_prefix("text/" <> _), do: "document"
+  defp file_type_from_prefix(_), do: nil
+
+  defp file_type_from_exact(mime) when mime in @document_mimes, do: "document"
+  defp file_type_from_exact(_), do: nil
+
+  defp file_type_from_keyword(mime) do
+    if String.contains?(mime, "zip") or String.contains?(mime, "archive") do
+      "archive"
+    end
+  end
+
+  defp inject_files_folder(params, nil), do: params
+
+  defp inject_files_folder(params, folder_uuid) when is_binary(folder_uuid) do
+    data = ensure_data_map(params)
+    Map.put(params, "data", Map.put(data, "files_folder_uuid", folder_uuid))
+  end
+
+  defp inject_featured_image(params, nil) do
+    data = ensure_data_map(params)
+    Map.put(params, "data", Map.delete(data, "featured_image_uuid"))
+  end
+
+  defp inject_featured_image(params, uuid) when is_binary(uuid) do
+    data = ensure_data_map(params)
+    Map.put(params, "data", Map.put(data, "featured_image_uuid", uuid))
+  end
+
+  defp ensure_data_map(params) do
+    case Map.get(params, "data") do
+      %{} = d -> d
+      _ -> %{}
+    end
+  end
+
+  defp resource_data(%{data: data}) when is_map(data), do: data
+  defp resource_data(_), do: %{}
+
+  defp read_string(data, key) when is_map(data) do
+    case Map.get(data, key) do
+      s when is_binary(s) and s != "" -> s
+      _ -> nil
+    end
+  end
+end

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -50,7 +50,8 @@ defmodule PhoenixKitCatalogue.Catalogue do
     Rules,
     Search,
     Suppliers,
-    Translations
+    Translations,
+    Tree
   }
 
   alias PhoenixKitCatalogue.Schemas.{Catalogue, Category, Item}
@@ -500,6 +501,13 @@ defmodule PhoenixKitCatalogue.Catalogue do
         from(i in Item, where: i.catalogue_uuid == ^catalogue.uuid)
         |> repo().delete_all()
 
+        # Break V103 self-FKs inside the catalogue before deleting —
+        # every category in the catalogue is being removed anyway, so
+        # NULLing parent_uuid first is the simplest way to avoid a
+        # leaf-first traversal.
+        from(c in Category, where: c.catalogue_uuid == ^catalogue.uuid)
+        |> repo().update_all(set: [parent_uuid: nil])
+
         from(c in Category, where: c.catalogue_uuid == ^catalogue.uuid)
         |> repo().delete_all()
 
@@ -731,20 +739,94 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
-  Lists all non-deleted categories across all non-deleted catalogues.
+  Lists all non-deleted categories across all non-deleted catalogues,
+  with breadcrumb-style names prefixed by their catalogue and every
+  ancestor category (e.g. `"Kitchen / Cabinets / Frames"`). Useful for
+  item move dropdowns where the user needs to distinguish
+  same-named leaves under different parents.
 
-  Category names are prefixed with their catalogue name (e.g. `"Kitchen / Frames"`).
-  Useful for item move dropdowns.
+  Entries are grouped by catalogue (catalogues ordered by name) and
+  within each catalogue returned in depth-first display order.
+
+  One query for catalogues + one query for all their categories — the
+  tree walk and breadcrumb rewrite happen in memory. Safe to call on
+  demand from move-dropdowns.
   """
   def list_all_categories do
-    from(c in Category,
-      join: cat in Catalogue,
-      on: c.catalogue_uuid == cat.uuid,
-      where: c.status != "deleted" and cat.status != "deleted",
-      order_by: [asc: cat.name, asc: c.position, asc: c.name],
-      select: %{c | name: fragment("? || ' / ' || ?", cat.name, c.name)}
-    )
-    |> repo().all()
+    catalogues =
+      from(cat in Catalogue,
+        where: cat.status != "deleted",
+        order_by: [asc: cat.name]
+      )
+      |> repo().all()
+
+    case catalogues do
+      [] ->
+        []
+
+      catalogues ->
+        catalogue_uuids = Enum.map(catalogues, & &1.uuid)
+
+        categories_by_catalogue =
+          from(c in Category,
+            where: c.catalogue_uuid in ^catalogue_uuids and c.status != "deleted",
+            order_by: [asc: :position, asc: :name]
+          )
+          |> repo().all()
+          |> Enum.group_by(& &1.catalogue_uuid)
+
+        Enum.flat_map(catalogues, fn %Catalogue{uuid: uuid, name: cat_name} ->
+          categories = Map.get(categories_by_catalogue, uuid, [])
+          breadcrumb_categories_for_catalogue(cat_name, categories)
+        end)
+    end
+  end
+
+  # Builds the depth-first list of `%Category{name: "A / B / C"}` for
+  # one catalogue from a flat, pre-sorted list of its categories.
+  defp breadcrumb_categories_for_catalogue(cat_name, categories) when is_list(categories) do
+    uuid_set = MapSet.new(categories, & &1.uuid)
+
+    # Promote orphans (children whose parent isn't in this list because
+    # it's been deleted or excluded) to roots so they still appear.
+    normalized =
+      Enum.map(categories, fn c ->
+        if c.parent_uuid == nil or MapSet.member?(uuid_set, c.parent_uuid) do
+          c
+        else
+          %{c | parent_uuid: nil}
+        end
+      end)
+
+    index = Tree.build_children_index(normalized)
+
+    {reversed, _} =
+      normalized
+      |> Enum.filter(&is_nil(&1.parent_uuid))
+      |> Enum.reduce({[], %{}}, fn root, {acc, path_by_uuid} ->
+        collect_breadcrumb(root, index, cat_name, path_by_uuid, acc)
+      end)
+
+    Enum.reverse(reversed)
+  end
+
+  defp collect_breadcrumb(%Category{} = cat, index, catalogue_name, path_by_uuid, acc) do
+    parent_label =
+      case cat.parent_uuid do
+        nil -> catalogue_name
+        parent_uuid -> Map.get(path_by_uuid, parent_uuid, catalogue_name)
+      end
+
+    full_label = "#{parent_label} / #{cat.name}"
+    labeled = %{cat | name: full_label}
+    path_by_uuid = Map.put(path_by_uuid, cat.uuid, full_label)
+    acc = [labeled | acc]
+
+    index
+    |> Map.get(cat.uuid, [])
+    |> Enum.reduce({acc, path_by_uuid}, fn child, {acc, path_by_uuid} ->
+      collect_breadcrumb(child, index, catalogue_name, path_by_uuid, acc)
+    end)
   end
 
   @doc "Fetches a category by UUID. Returns `nil` if not found."
@@ -771,7 +853,12 @@ defmodule PhoenixKitCatalogue.Catalogue do
       Catalogue.create_category(%{name: "Frames", catalogue_uuid: catalogue.uuid})
   """
   def create_category(attrs, opts \\ []) do
-    case %Category{} |> Category.changeset(attrs) |> repo().insert() do
+    changeset =
+      %Category{}
+      |> Category.changeset(attrs)
+      |> validate_parent_in_same_catalogue()
+
+    case repo().insert(changeset) do
       {:ok, category} = ok ->
         log_activity(%{
           action: "category.created",
@@ -791,7 +878,12 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
   @doc "Updates a category with the given attributes."
   def update_category(%Category{} = category, attrs, opts \\ []) do
-    case category |> Category.changeset(attrs) |> repo().update() do
+    changeset =
+      category
+      |> Category.changeset(attrs)
+      |> validate_parent_in_same_catalogue()
+
+    case repo().update(changeset) do
       {:ok, updated} = ok ->
         log_activity(%{
           action: "category.updated",
@@ -806,6 +898,59 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
       error ->
         error
+    end
+  end
+
+  # Guards both create_category/2 and update_category/3 against a
+  # `parent_uuid` that names a category in a different catalogue, AND
+  # against cycles on update (a raw
+  # `update_category(cat, %{parent_uuid: descendant.uuid})` would
+  # otherwise sail past the `move_category_under/3` checks). The
+  # self-parent rejection lives on `Category.changeset`; the
+  # cross-catalogue and full-subtree cycle checks need DB lookups, so
+  # they live here.
+  defp validate_parent_in_same_catalogue(%Ecto.Changeset{} = changeset) do
+    catalogue_uuid = Ecto.Changeset.get_field(changeset, :catalogue_uuid)
+    parent_uuid = Ecto.Changeset.get_field(changeset, :parent_uuid)
+    own_uuid = Ecto.Changeset.get_field(changeset, :uuid)
+
+    cond do
+      parent_uuid in [nil, ""] ->
+        changeset
+
+      is_nil(catalogue_uuid) ->
+        Ecto.Changeset.add_error(
+          changeset,
+          :parent_uuid,
+          "cannot be set without a catalogue"
+        )
+
+      own_uuid && parent_uuid in Tree.subtree_uuids(own_uuid) ->
+        Ecto.Changeset.add_error(
+          changeset,
+          :parent_uuid,
+          "would create a cycle"
+        )
+
+      true ->
+        check_parent_catalogue(changeset, parent_uuid, catalogue_uuid)
+    end
+  end
+
+  defp check_parent_catalogue(changeset, parent_uuid, catalogue_uuid) do
+    case repo().get(Category, parent_uuid) do
+      nil ->
+        Ecto.Changeset.add_error(changeset, :parent_uuid, "does not exist")
+
+      %Category{catalogue_uuid: ^catalogue_uuid} ->
+        changeset
+
+      %Category{} ->
+        Ecto.Changeset.add_error(
+          changeset,
+          :parent_uuid,
+          "must belong to the same catalogue"
+        )
     end
   end
 
@@ -830,11 +975,17 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
-  Soft-deletes a category by setting its status to `"deleted"`.
+  Soft-deletes a category and its entire subtree by setting their
+  status to `"deleted"`.
 
-  **Cascades downward** in a transaction:
-  1. All non-deleted items in this category → status `"deleted"`
-  2. The category itself → status `"deleted"`
+  **Cascades downward** in a transaction, following the nested-category
+  tree introduced in V103:
+  1. All non-deleted items in this category and any descendant → status `"deleted"`
+  2. This category and every descendant category → status `"deleted"`
+
+  Logs a single `category.trashed` activity on the root with
+  `subtree_size` (categories touched, including root) and
+  `items_cascaded` (items touched) in the metadata.
 
   ## Examples
 
@@ -843,34 +994,58 @@ defmodule PhoenixKitCatalogue.Catalogue do
   def trash_category(%Category{} = category, opts \\ []) do
     result =
       repo().transaction(fn ->
-        from(i in Item, where: i.category_uuid == ^category.uuid and i.status != "deleted")
-        |> repo().update_all(set: [status: "deleted", updated_at: DateTime.utc_now()])
+        now = DateTime.utc_now()
+        subtree = Tree.subtree_uuids(category.uuid)
 
-        category
-        |> Category.changeset(%{status: "deleted"})
-        |> repo().update!()
+        {items_cascaded, _} =
+          from(i in Item,
+            where: i.category_uuid in ^subtree and i.status != "deleted"
+          )
+          |> repo().update_all(set: [status: "deleted", updated_at: now])
+
+        from(c in Category,
+          where: c.uuid in ^subtree and c.status != "deleted"
+        )
+        |> repo().update_all(set: [status: "deleted", updated_at: now])
+
+        updated = repo().get!(Category, category.uuid)
+        {updated, length(subtree), items_cascaded}
       end)
 
-    with {:ok, updated} <- result do
-      log_activity(%{
-        action: "category.trashed",
-        mode: "manual",
-        actor_uuid: opts[:actor_uuid],
-        resource_type: "category",
-        resource_uuid: category.uuid,
-        metadata: %{"name" => category.name, "catalogue_uuid" => category.catalogue_uuid}
-      })
+    case result do
+      {:ok, {updated, subtree_size, items_cascaded}} ->
+        log_activity(%{
+          action: "category.trashed",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "category",
+          resource_uuid: category.uuid,
+          metadata: %{
+            "name" => category.name,
+            "catalogue_uuid" => category.catalogue_uuid,
+            "subtree_size" => subtree_size,
+            "items_cascaded" => items_cascaded
+          }
+        })
 
-      {:ok, updated}
+        {:ok, updated}
+
+      error ->
+        error
     end
   end
 
   @doc """
-  Restores a soft-deleted category by setting its status to `"active"`.
+  Restores a soft-deleted category (and its deleted subtree) by
+  setting status back to `"active"`.
 
   **Cascades both directions** in a transaction:
-  - **Upward**: if the parent catalogue is deleted, restores it too
-  - **Downward**: restores all deleted items in this category
+  - **Upward**: restores every deleted ancestor category so the restored
+    node is reachable in the active tree, then the parent catalogue if
+    it's deleted too.
+  - **Downward**: restores all deleted categories in this subtree and
+    all deleted items inside them. Restoring a node after a prior
+    trash cascade brings the whole sub-branch back as one action.
 
   ## Examples
 
@@ -879,6 +1054,12 @@ defmodule PhoenixKitCatalogue.Catalogue do
   def restore_category(%Category{} = category, opts \\ []) do
     result =
       repo().transaction(fn ->
+        now = DateTime.utc_now()
+        subtree = Tree.subtree_uuids(category.uuid)
+        ancestors = Tree.ancestor_uuids(category.uuid)
+
+        # Upward: catalogue first, then ancestor categories — both
+        # before the subtree so parents are active before children.
         case repo().get(Catalogue, category.catalogue_uuid) do
           %Catalogue{status: "deleted"} = cat ->
             cat |> Catalogue.changeset(%{status: "active"}) |> repo().update!()
@@ -887,61 +1068,117 @@ defmodule PhoenixKitCatalogue.Catalogue do
             :ok
         end
 
-        from(i in Item, where: i.category_uuid == ^category.uuid and i.status == "deleted")
-        |> repo().update_all(set: [status: "active", updated_at: DateTime.utc_now()])
+        if ancestors != [] do
+          from(c in Category,
+            where: c.uuid in ^ancestors and c.status == "deleted"
+          )
+          |> repo().update_all(set: [status: "active", updated_at: now])
+        end
 
-        category
-        |> Category.changeset(%{status: "active"})
-        |> repo().update!()
+        from(c in Category,
+          where: c.uuid in ^subtree and c.status == "deleted"
+        )
+        |> repo().update_all(set: [status: "active", updated_at: now])
+
+        {items_cascaded, _} =
+          from(i in Item,
+            where: i.category_uuid in ^subtree and i.status == "deleted"
+          )
+          |> repo().update_all(set: [status: "active", updated_at: now])
+
+        updated = repo().get!(Category, category.uuid)
+        {updated, length(subtree), items_cascaded}
       end)
 
-    with {:ok, updated} <- result do
-      log_activity(%{
-        action: "category.restored",
-        mode: "manual",
-        actor_uuid: opts[:actor_uuid],
-        resource_type: "category",
-        resource_uuid: category.uuid,
-        metadata: %{"name" => category.name, "catalogue_uuid" => category.catalogue_uuid}
-      })
+    case result do
+      {:ok, {updated, subtree_size, items_cascaded}} ->
+        log_activity(%{
+          action: "category.restored",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "category",
+          resource_uuid: category.uuid,
+          metadata: %{
+            "name" => category.name,
+            "catalogue_uuid" => category.catalogue_uuid,
+            "subtree_size" => subtree_size,
+            "items_cascaded" => items_cascaded
+          }
+        })
 
-      {:ok, updated}
+        {:ok, updated}
+
+      error ->
+        error
     end
   end
 
   @doc """
-  Permanently deletes a category and all its items from the database.
+  Permanently deletes a category and its entire subtree (all descendant
+  categories + every item in any of them) from the database.
 
-  **Cascades downward** in a transaction: hard-deletes all items, then the category.
-  This cannot be undone.
+  **Cascades downward** in a transaction, following the nested-category
+  tree introduced in V103. Items are hard-deleted first, then the
+  subtree categories from leaves up (ordered so child FKs resolve
+  before their parent is removed). This cannot be undone.
   """
   def permanently_delete_category(%Category{} = category, opts \\ []) do
     result =
       repo().transaction(fn ->
-        from(i in Item, where: i.category_uuid == ^category.uuid)
+        subtree = Tree.subtree_uuids(category.uuid)
+
+        {items_cascaded, _} =
+          from(i in Item, where: i.category_uuid in ^subtree)
+          |> repo().delete_all()
+
+        # V103's self-FK on parent_uuid has no ON DELETE CASCADE — a
+        # straight `delete_all` on the subtree would reject any parent
+        # row while its children still reference it. Since every row in
+        # the subtree is being deleted anyway, NULL out parent_uuid
+        # first to break the intra-subtree FKs, then delete in one shot.
+        from(c in Category, where: c.uuid in ^subtree)
+        |> repo().update_all(set: [parent_uuid: nil])
+
+        from(c in Category, where: c.uuid in ^subtree)
         |> repo().delete_all()
 
-        repo().delete!(category)
+        {length(subtree), items_cascaded}
       end)
 
-    with {:ok, _} <- result do
-      log_activity(%{
-        action: "category.permanently_deleted",
-        mode: "manual",
-        actor_uuid: opts[:actor_uuid],
-        resource_type: "category",
-        resource_uuid: category.uuid,
-        metadata: %{"name" => category.name, "catalogue_uuid" => category.catalogue_uuid}
-      })
+    case result do
+      {:ok, {subtree_size, items_cascaded}} ->
+        log_activity(%{
+          action: "category.permanently_deleted",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "category",
+          resource_uuid: category.uuid,
+          metadata: %{
+            "name" => category.name,
+            "catalogue_uuid" => category.catalogue_uuid,
+            "subtree_size" => subtree_size,
+            "items_cascaded" => items_cascaded
+          }
+        })
 
-      result
+        {:ok, category}
+
+      error ->
+        error
     end
   end
 
   @doc """
-  Moves a category (and all its items) to a different catalogue.
+  Moves a category — along with its entire subtree and every item
+  inside — to a different catalogue.
 
-  Automatically assigns the next available position in the target catalogue.
+  The moved category's `parent_uuid` is cleared (it detaches from its
+  former parent, which stays in the source catalogue) and it takes the
+  next available root-level position in the target. Internal parent
+  links inside the moved subtree are preserved.
+
+  Automatically assigns the next available root position in the target
+  catalogue.
 
   ## Examples
 
@@ -949,7 +1186,6 @@ defmodule PhoenixKitCatalogue.Catalogue do
   """
   def move_category_to_catalogue(%Category{} = category, target_catalogue_uuid, opts \\ []) do
     source_catalogue_uuid = category.catalogue_uuid
-    next_pos = next_category_position(target_catalogue_uuid)
 
     result =
       repo().transaction(fn ->
@@ -962,22 +1198,39 @@ defmodule PhoenixKitCatalogue.Catalogue do
         # `catalogue_uuid` between our items-update and our commit.
         repo().one!(from(c in Category, where: c.uuid == ^category.uuid, lock: "FOR UPDATE"))
 
+        subtree = Tree.subtree_uuids(category.uuid)
+        now = DateTime.utc_now()
+
         {items_updated, _} =
-          from(i in Item, where: i.category_uuid == ^category.uuid)
-          |> repo().update_all(
-            set: [catalogue_uuid: target_catalogue_uuid, updated_at: DateTime.utc_now()]
-          )
+          from(i in Item, where: i.category_uuid in ^subtree)
+          |> repo().update_all(set: [catalogue_uuid: target_catalogue_uuid, updated_at: now])
+
+        # Reparent the whole subtree to the target catalogue in a
+        # single query — internal parent_uuids stay intact because
+        # they still reference rows in the subtree.
+        {categories_updated, _} =
+          from(c in Category, where: c.uuid in ^subtree)
+          |> repo().update_all(set: [catalogue_uuid: target_catalogue_uuid, updated_at: now])
+
+        # Position is computed inside the transaction (after the
+        # subtree has moved) to avoid the same-`max_position` race
+        # called out in prior PR reviews.
+        next_pos = next_category_position(target_catalogue_uuid, nil)
 
         moved =
           category
-          |> Category.changeset(%{catalogue_uuid: target_catalogue_uuid, position: next_pos})
+          |> Category.changeset(%{
+            catalogue_uuid: target_catalogue_uuid,
+            parent_uuid: nil,
+            position: next_pos
+          })
           |> repo().update!()
 
-        {moved, items_updated}
+        {moved, categories_updated, items_updated}
       end)
 
     case result do
-      {:ok, {moved, items_updated}} ->
+      {:ok, {moved, categories_updated, items_updated}} ->
         log_activity(%{
           action: "category.moved",
           mode: "manual",
@@ -988,6 +1241,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
             "name" => moved.name,
             "from_catalogue_uuid" => source_catalogue_uuid,
             "to_catalogue_uuid" => target_catalogue_uuid,
+            "subtree_size" => categories_updated,
             "items_cascaded" => items_updated
           }
         })
@@ -1000,15 +1254,145 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
+  Reparents a category within the same catalogue, placing it under
+  `new_parent_uuid` (or promoting it to a root with `nil`).
+
+  Rejects moves that would:
+    * produce a cycle (`new_parent_uuid` is the category itself or one
+      of its descendants) — returns `{:error, :would_create_cycle}`
+    * cross a catalogue boundary — returns `{:error, :cross_catalogue}`.
+      Callers who want that should run `move_category_to_catalogue/3`
+      first, then reparent.
+    * target a missing parent — returns `{:error, :parent_not_found}`
+
+  The moved category takes the next-available position among its new
+  siblings. Its subtree comes along untouched (parent links inside the
+  subtree stay valid).
+
+  Passing `new_parent_uuid = nil` promotes the category to a root within
+  its current catalogue.
+
+  ## Examples
+
+      {:ok, moved} = Catalogue.move_category_under(child, parent.uuid)
+      {:ok, moved} = Catalogue.move_category_under(child, nil)  # promote to root
+  """
+  @spec move_category_under(Category.t(), Ecto.UUID.t() | nil, keyword()) ::
+          {:ok, Category.t()}
+          | {:error,
+             :would_create_cycle
+             | :cross_catalogue
+             | :parent_not_found
+             | Ecto.Changeset.t(Category.t())}
+  def move_category_under(category, new_parent_uuid, opts \\ [])
+
+  def move_category_under(%Category{parent_uuid: same} = category, same, _opts)
+      when is_binary(same) or is_nil(same),
+      do: {:ok, category}
+
+  def move_category_under(%Category{} = category, nil, opts) do
+    from_parent_uuid = category.parent_uuid
+    next_pos = next_category_position(category.catalogue_uuid, nil)
+
+    with {:ok, moved} <-
+           category
+           |> Category.changeset(%{parent_uuid: nil, position: next_pos})
+           |> repo().update() do
+      log_activity(%{
+        action: "category.moved",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "category",
+        resource_uuid: moved.uuid,
+        metadata: %{
+          "name" => moved.name,
+          "from_parent_uuid" => from_parent_uuid,
+          "to_parent_uuid" => nil,
+          "catalogue_uuid" => moved.catalogue_uuid
+        }
+      })
+
+      {:ok, moved}
+    end
+  end
+
+  def move_category_under(%Category{} = category, new_parent_uuid, opts)
+      when is_binary(new_parent_uuid) do
+    cond do
+      new_parent_uuid == category.uuid ->
+        {:error, :would_create_cycle}
+
+      new_parent_uuid in Tree.subtree_uuids(category.uuid) ->
+        {:error, :would_create_cycle}
+
+      true ->
+        do_move_category_under(category, new_parent_uuid, opts)
+    end
+  end
+
+  defp do_move_category_under(category, new_parent_uuid, opts) do
+    case repo().get(Category, new_parent_uuid) do
+      nil ->
+        {:error, :parent_not_found}
+
+      %Category{catalogue_uuid: other} when other != category.catalogue_uuid ->
+        {:error, :cross_catalogue}
+
+      %Category{} ->
+        from_parent_uuid = category.parent_uuid
+        next_pos = next_category_position(category.catalogue_uuid, new_parent_uuid)
+
+        with {:ok, moved} <-
+               category
+               |> Category.changeset(%{parent_uuid: new_parent_uuid, position: next_pos})
+               |> repo().update() do
+          log_activity(%{
+            action: "category.moved",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "category",
+            resource_uuid: moved.uuid,
+            metadata: %{
+              "name" => moved.name,
+              "from_parent_uuid" => from_parent_uuid,
+              "to_parent_uuid" => new_parent_uuid,
+              "catalogue_uuid" => moved.catalogue_uuid
+            }
+          })
+
+          {:ok, moved}
+        end
+    end
+  end
+
+  @doc """
   Atomically swaps the positions of two categories within a transaction.
+
+  Positions are scoped to `(catalogue_uuid, parent_uuid)` sibling
+  groups (V103). Swapping positions of categories that are not
+  siblings would mix two independent ordering axes, so this function
+  refuses with `{:error, :not_siblings}` when the categories live
+  under different parents or in different catalogues. The detail-view
+  reorder buttons enforce the same constraint at the LV level; this
+  is the context-level guard for any programmatic caller.
 
   ## Examples
 
       {:ok, _} = Catalogue.swap_category_positions(cat_a, cat_b)
+      {:error, :not_siblings} = Catalogue.swap_category_positions(root, child)
   """
   @spec swap_category_positions(Category.t(), Category.t(), keyword()) ::
-          {:ok, term()} | {:error, term()}
+          {:ok, term()} | {:error, :not_siblings | term()}
   def swap_category_positions(%Category{} = cat_a, %Category{} = cat_b, opts \\ []) do
+    if cat_a.catalogue_uuid != cat_b.catalogue_uuid or
+         cat_a.parent_uuid != cat_b.parent_uuid do
+      {:error, :not_siblings}
+    else
+      do_swap_category_positions(cat_a, cat_b, opts)
+    end
+  end
+
+  defp do_swap_category_positions(cat_a, cat_b, opts) do
     result =
       repo().transaction(fn ->
         pos_a = cat_a.position
@@ -1043,16 +1427,114 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
-  Returns the next available position for a new category in a catalogue.
-
-  Returns 0 if no categories exist, otherwise `max_position + 1`.
+  Returns the list of ancestor categories from root down to (but not
+  including) `category_uuid`. Empty when the category is a root.
+  Useful for breadcrumbs.
   """
-  def next_category_position(catalogue_uuid) do
+  @spec list_category_ancestors(Ecto.UUID.t()) :: [Category.t()]
+  defdelegate list_category_ancestors(category_uuid), to: Tree, as: :ancestors_in_order
+
+  @doc """
+  Returns the categories in a catalogue paired with their tree depth,
+  in depth-first display order (position, then name, recursing into
+  children). Each entry is `{category, depth}` where depth `0` means a
+  root. Used to render flat parent-pickers and indented listings.
+
+  ## Options
+
+    * `:mode` — `:active` (default, excludes deleted categories) or
+      `:deleted` (all statuses — the detail view in deleted mode still
+      wants deleted categories that contain trashed items).
+    * `:exclude_subtree_of` — skip a category and all its descendants
+      (e.g. the category being edited — you can't parent it under
+      itself or its descendants).
+  """
+  @spec list_category_tree(Ecto.UUID.t(), keyword()) :: [{Category.t(), non_neg_integer()}]
+  def list_category_tree(catalogue_uuid, opts \\ []) do
+    mode = Keyword.get(opts, :mode, :active)
+
+    # Plain list (not MapSet) because the exclude subtree is typically
+    # a single branch (order of 1–20 uuids) and keeping a list here
+    # lets dialyzer type-check the `in` check without tripping on
+    # MapSet's opaque struct.
+    exclude_uuids =
+      case Keyword.get(opts, :exclude_subtree_of) do
+        nil -> []
+        uuid -> Tree.subtree_uuids(uuid)
+      end
+
+    query =
+      from(c in Category,
+        where: c.catalogue_uuid == ^catalogue_uuid,
+        order_by: [asc: :position, asc: :name]
+      )
+
+    query =
+      case mode do
+        :active -> where(query, [c], c.status != "deleted")
+        :deleted -> query
+      end
+
+    categories =
+      query
+      |> repo().all()
+      |> Enum.reject(&(&1.uuid in exclude_uuids))
+
+    # Some parents may be missing from the filtered list (deleted
+    # ancestors in :active mode, or excluded subtree). Orphans — rows
+    # whose `parent_uuid` no longer has a matching row in this set —
+    # get surfaced as roots so they don't vanish from the UI.
+    uuid_set = MapSet.new(categories, & &1.uuid)
+
+    normalized =
+      Enum.map(categories, fn c ->
+        if c.parent_uuid == nil or MapSet.member?(uuid_set, c.parent_uuid) do
+          c
+        else
+          %{c | parent_uuid: nil}
+        end
+      end)
+
+    index = Tree.build_children_index(normalized)
+
+    {acc, _} =
+      Enum.reduce(Map.get(index, nil, []), {[], index}, fn root, {acc, idx} ->
+        {collect_tree(root, idx, 0, acc), idx}
+      end)
+
+    Enum.reverse(acc)
+  end
+
+  defp collect_tree(%Category{} = cat, index, depth, acc) do
+    acc = [{cat, depth} | acc]
+
+    index
+    |> Map.get(cat.uuid, [])
+    |> Enum.reduce(acc, fn child, acc -> collect_tree(child, index, depth + 1, acc) end)
+  end
+
+  @doc """
+  Returns the next available position for a new category among its
+  siblings. Position is scoped to `(catalogue_uuid, parent_uuid)` — the
+  set of categories sharing the same parent within a catalogue — since
+  V103's nested-category tree makes a single catalogue-wide ordering
+  ambiguous.
+
+  `parent_uuid` defaults to `nil`, i.e. root-level siblings. Returns 0
+  if no siblings exist at that level, otherwise `max_position + 1`.
+  """
+  def next_category_position(catalogue_uuid, parent_uuid \\ nil) do
     query =
       from(c in Category,
         where: c.catalogue_uuid == ^catalogue_uuid,
         select: max(c.position)
       )
+
+    query =
+      case parent_uuid do
+        nil -> where(query, [c], is_nil(c.parent_uuid))
+        uuid -> where(query, [c], c.parent_uuid == ^uuid)
+      end
 
     case repo().one(query) do
       nil -> 0

--- a/lib/phoenix_kit_catalogue/catalogue/search.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/search.ex
@@ -13,7 +13,7 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
 
   import Ecto.Query, warn: false
 
-  alias PhoenixKitCatalogue.Catalogue.Helpers
+  alias PhoenixKitCatalogue.Catalogue.{Helpers, Tree}
   alias PhoenixKitCatalogue.Schemas.{Catalogue, Category, Item}
 
   defp repo, do: PhoenixKit.RepoHelper.repo()
@@ -25,6 +25,10 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
 
     * `:catalogue_uuids` — list of catalogue UUIDs to scope to. `nil` or `[]` = all.
     * `:category_uuids` — list of category UUIDs to scope to. `nil` or `[]` = all + uncategorized.
+    * `:include_descendants` — when `true` (default since V103), each
+      entry in `:category_uuids` is expanded to include every descendant
+      category in the nested-category tree. Pass `false` to scope
+      strictly to the given UUIDs.
     * `:limit` — max results (default 50).
     * `:offset` — paging offset (default 0).
   """
@@ -101,7 +105,7 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
   defp search_items_base(query_str, opts) do
     pattern = "%#{Helpers.sanitize_like(query_str)}%"
     catalogue_uuids = opts[:catalogue_uuids]
-    category_uuids = opts[:category_uuids]
+    category_uuids = expand_category_scope(opts)
 
     from(i in Item,
       join: cat in Catalogue,
@@ -118,6 +122,27 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
     )
     |> maybe_scope_catalogues(catalogue_uuids)
     |> maybe_scope_categories(category_uuids)
+  end
+
+  # Expands `:category_uuids` through the V103 nested-category tree so
+  # filtering by "Kitchen" also matches items in "Kitchen / Frames".
+  # `:include_descendants` defaults to `true`; callers can opt out for
+  # the literal-set semantics by passing `false`.
+  defp expand_category_scope(opts) do
+    case opts[:category_uuids] do
+      nil ->
+        nil
+
+      [] ->
+        []
+
+      uuids when is_list(uuids) ->
+        if Keyword.get(opts, :include_descendants, true) do
+          Tree.subtree_uuids_for(uuids)
+        else
+          uuids
+        end
+    end
   end
 
   defp maybe_scope_catalogues(query, uuids) when uuids in [nil, []], do: query

--- a/lib/phoenix_kit_catalogue/catalogue/tree.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/tree.ex
@@ -1,0 +1,180 @@
+defmodule PhoenixKitCatalogue.Catalogue.Tree do
+  @moduledoc false
+  # Recursive tree helpers for the category adjacency list (V103).
+  # Used by the cascade operations (trash/restore/permanent-delete),
+  # cross-catalogue move, cycle checks, and search expansion.
+  #
+  # All public functions run one recursive CTE. For UIs that already
+  # have every category in the catalogue loaded (e.g. the detail view),
+  # prefer `build_index/1` + `walk_subtree/2` — same shape, no DB trip.
+  #
+  # ## Cycle safety
+  #
+  # The context API guards against cycles (`move_category_under/3`
+  # rejects a descendant parent, `Category.changeset` rejects a
+  # self-parent), so a well-formed DB never contains a cycle. As
+  # defense in depth against corrupted data or direct SQL writes, the
+  # CTEs use `UNION` (not `UNION ALL`) — Postgres drops rows already in
+  # the working table before the next iteration, which breaks any
+  # cycle by emptying the working set. No infinite loop.
+
+  import Ecto.Query, warn: false
+
+  alias PhoenixKitCatalogue.Schemas.Category
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+
+  @doc """
+  Returns `[uuid]` for every descendant of `root_uuid`, not including
+  `root_uuid` itself. Empty list for a leaf.
+  """
+  @spec descendant_uuids(Ecto.UUID.t()) :: [Ecto.UUID.t()]
+  def descendant_uuids(root_uuid) when is_binary(root_uuid) do
+    subtree_uuids_for([root_uuid]) -- [root_uuid]
+  end
+
+  @doc """
+  Returns `[uuid]` for `root_uuid` and every descendant. Order
+  unspecified. Used for subtree updates (trash, move_to_catalogue,
+  permanent delete).
+  """
+  @spec subtree_uuids(Ecto.UUID.t()) :: [Ecto.UUID.t()]
+  def subtree_uuids(root_uuid) when is_binary(root_uuid) do
+    subtree_uuids_for([root_uuid])
+  end
+
+  @doc """
+  Returns every UUID in the union of subtrees seeded by `roots`.
+  Duplicates (when one seed is an ancestor of another) are collapsed.
+  Used to expand a search scope from selected categories down into
+  their descendants.
+  """
+  @spec subtree_uuids_for([Ecto.UUID.t()]) :: [Ecto.UUID.t()]
+  def subtree_uuids_for([]), do: []
+
+  def subtree_uuids_for(roots) when is_list(roots) do
+    initial =
+      from(c in Category,
+        where: c.uuid in ^roots,
+        select: %{uuid: c.uuid}
+      )
+
+    recursion =
+      from(c in Category,
+        join: t in "category_tree",
+        on: c.parent_uuid == t.uuid,
+        select: %{uuid: c.uuid}
+      )
+
+    cte = initial |> union(^recursion)
+
+    from(t in "category_tree", select: t.uuid)
+    |> recursive_ctes(true)
+    |> with_cte("category_tree", as: ^cte)
+    |> repo().all()
+  end
+
+  @doc """
+  Returns `[uuid]` for every ancestor of `uuid`, walking up to the root.
+  Excludes `uuid` itself. Order unspecified.
+  """
+  @spec ancestor_uuids(Ecto.UUID.t()) :: [Ecto.UUID.t()]
+  def ancestor_uuids(uuid) when is_binary(uuid) do
+    initial =
+      from(c in Category,
+        where: c.uuid == ^uuid,
+        select: %{uuid: c.uuid, parent_uuid: c.parent_uuid}
+      )
+
+    recursion =
+      from(c in Category,
+        join: t in "category_tree",
+        on: c.uuid == t.parent_uuid,
+        select: %{uuid: c.uuid, parent_uuid: c.parent_uuid}
+      )
+
+    cte = initial |> union(^recursion)
+
+    from(t in "category_tree",
+      where: t.uuid != ^uuid,
+      select: t.uuid
+    )
+    |> recursive_ctes(true)
+    |> with_cte("category_tree", as: ^cte)
+    |> repo().all()
+  end
+
+  @doc """
+  Returns the list of ancestor categories ordered from root → direct
+  parent. Excludes the category itself. Used for breadcrumbs.
+  """
+  @spec ancestors_in_order(Ecto.UUID.t()) :: [Category.t()]
+  def ancestors_in_order(uuid) when is_binary(uuid) do
+    case ancestor_uuids(uuid) do
+      [] ->
+        []
+
+      uuids ->
+        by_uuid =
+          from(c in Category, where: c.uuid in ^uuids)
+          |> repo().all()
+          |> Map.new(&{&1.uuid, &1})
+
+        # Walk from the category's direct parent up; then reverse so
+        # the caller gets root-first order. Using the loaded map means
+        # no extra round trips per hop.
+        uuid
+        |> walk_up(by_uuid, [])
+        |> Enum.reverse()
+    end
+  end
+
+  defp walk_up(uuid, by_uuid, acc) do
+    case Map.get(by_uuid, uuid) do
+      %Category{parent_uuid: nil} = cat -> [cat | acc]
+      %Category{parent_uuid: parent_uuid} = cat -> walk_up(parent_uuid, by_uuid, [cat | acc])
+      nil -> acc
+    end
+  end
+
+  @doc """
+  Builds a `%{parent_uuid => [child_category, ...]}` index from a flat
+  list of categories. Children are kept in the list's incoming order
+  (callers are expected to pass them pre-sorted by position/name).
+  Root categories land under the `nil` key.
+  """
+  @spec build_children_index([Category.t()]) :: %{
+          (Ecto.UUID.t() | nil) => [Category.t()]
+        }
+  def build_children_index(categories) when is_list(categories) do
+    categories
+    |> Enum.group_by(& &1.parent_uuid)
+    |> Map.new(fn {k, children} -> {k, children} end)
+  end
+
+  @doc """
+  Walks a preloaded tree depth-first starting at `root_uuid` (or at
+  every root if `nil` is passed), invoking `fun.(category, depth)` for
+  each node. Depth starts at `0` for the seed.
+  """
+  @spec walk_subtree(
+          %{(Ecto.UUID.t() | nil) => [Category.t()]},
+          Ecto.UUID.t() | nil,
+          (Category.t(), non_neg_integer() -> any())
+        ) :: :ok
+  def walk_subtree(index, root_uuid, fun) when is_function(fun, 2) do
+    index
+    |> Map.get(root_uuid, [])
+    |> Enum.each(&do_walk(&1, index, 0, fun))
+
+    :ok
+  end
+
+  defp do_walk(%Category{} = cat, index, depth, fun) do
+    fun.(cat, depth)
+
+    index
+    |> Map.get(cat.uuid, [])
+    |> Enum.each(&do_walk(&1, index, depth + 1, fun))
+  end
+end

--- a/lib/phoenix_kit_catalogue/item_metadata.ex
+++ b/lib/phoenix_kit_catalogue/item_metadata.ex
@@ -1,0 +1,71 @@
+defmodule PhoenixKitCatalogue.ItemMetadata do
+  @moduledoc """
+  Global, code-defined list of metadata fields that items can opt into.
+
+  Items store their chosen values in `item.data["meta"]` as a flat map
+  keyed by the definition's `:key` — e.g. `%{"color" => "red", "weight_kg" => "5.2"}`.
+  Only fields the user has explicitly added to a given item appear in
+  that map. The per-item form lets the user pick which fields to attach
+  from `definitions/0`.
+
+  The multilang layer owns the top-level `item.data` map (keys like
+  `_name`, `_primary_language`, per-language entries) — metadata lives
+  strictly under the `"meta"` sub-key so the two don't collide.
+
+  All fields are text inputs for now — typed inputs (decimal / enum /
+  etc.) can be reintroduced later by adding a `:type` field to the
+  definition shape and dispatching at render + cast time.
+
+  Edit `definitions/0` to add/remove fields. Removing a field from the
+  list does **not** wipe stored values — items that already hold a
+  value for the removed key will surface it as "Legacy" in the form so
+  the data isn't lost; the user can clear it manually.
+  """
+
+  @type definition :: %{
+          required(:key) => String.t(),
+          required(:label) => String.t()
+        }
+
+  @doc """
+  The global list of metadata definitions. Order here is the order
+  used for the "Add metadata" dropdown.
+
+  The `:label` values are translated at call time via
+  `PhoenixKitWeb.Gettext` — do not cache the result across locale
+  changes. The `:key` is stable (it's the JSONB key) and never
+  translated.
+  """
+  @spec definitions() :: [definition()]
+  def definitions do
+    [
+      %{key: "color", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Color")},
+      %{key: "weight", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Weight")},
+      %{key: "width", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Width")},
+      %{key: "height", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Height")},
+      %{key: "depth", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Depth")},
+      %{key: "material", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Material")},
+      %{key: "finish", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Finish")}
+    ]
+  end
+
+  @doc "Fetches a single definition by key. Returns `nil` if the key isn't in `definitions/0`."
+  @spec definition(String.t()) :: definition() | nil
+  def definition(key) when is_binary(key) do
+    Enum.find(definitions(), &(&1.key == key))
+  end
+
+  @doc """
+  Normalizes a raw form value for storage: trims whitespace, collapses
+  blanks to `nil` so callers can drop empty entries from the JSONB map.
+  """
+  @spec cast_value(definition(), term()) :: String.t() | nil
+  def cast_value(_def, value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  def cast_value(_def, _value), do: nil
+end

--- a/lib/phoenix_kit_catalogue/schemas/category.ex
+++ b/lib/phoenix_kit_catalogue/schemas/category.ex
@@ -24,6 +24,20 @@ defmodule PhoenixKitCatalogue.Schemas.Category do
       type: UUIDv7
     )
 
+    # Nullable self-FK — NULL = root category. Cycle detection and
+    # same-catalogue enforcement happen in the Catalogue context because
+    # they require DB lookups; the changeset only catches self-parent.
+    belongs_to(:parent, __MODULE__,
+      foreign_key: :parent_uuid,
+      references: :uuid,
+      type: UUIDv7
+    )
+
+    has_many(:children, __MODULE__,
+      foreign_key: :parent_uuid,
+      references: :uuid
+    )
+
     has_many(:items, PhoenixKitCatalogue.Schemas.Item,
       foreign_key: :category_uuid,
       references: :uuid
@@ -33,7 +47,7 @@ defmodule PhoenixKitCatalogue.Schemas.Category do
   end
 
   @required_fields [:name, :catalogue_uuid]
-  @optional_fields [:description, :position, :status, :data]
+  @optional_fields [:description, :position, :status, :data, :parent_uuid]
 
   def changeset(category, attrs) do
     category
@@ -41,5 +55,18 @@ defmodule PhoenixKitCatalogue.Schemas.Category do
     |> validate_required(@required_fields)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_inclusion(:status, @statuses)
+    |> validate_not_self_parent()
+    |> foreign_key_constraint(:parent_uuid)
+  end
+
+  defp validate_not_self_parent(changeset) do
+    uuid = get_field(changeset, :uuid)
+    parent = get_field(changeset, :parent_uuid)
+
+    if uuid != nil and parent != nil and uuid == parent do
+      add_error(changeset, :parent_uuid, "category cannot be its own parent")
+    else
+      changeset
+    end
   end
 end

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -24,6 +24,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Catalogue.PubSub
   alias PhoenixKitCatalogue.Paths
+  alias PhoenixKitCatalogue.Schemas.Category
 
   @per_page 100
 
@@ -35,6 +36,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         catalogue_uuid: uuid,
         catalogue: nil,
         category_list: [],
+        category_depths: %{},
         category_counts: %{},
         uncategorized_total: 0,
         loaded_cards: [],
@@ -463,7 +465,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
     mode = view_mode_to_atom(view_mode)
     catalogue = Catalogue.fetch_catalogue!(uuid)
-    category_list = Catalogue.list_categories_metadata_for_catalogue(uuid, mode: mode)
+    tree = Catalogue.list_category_tree(uuid, mode: mode)
+    category_list = Enum.map(tree, fn {cat, _depth} -> cat end)
+    category_depths = Map.new(tree, fn {cat, depth} -> {cat.uuid, depth} end)
     category_counts = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode)
     uncategorized_total = Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
 
@@ -474,6 +478,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       page_title: catalogue.name,
       catalogue: catalogue,
       category_list: category_list,
+      category_depths: category_depths,
       category_counts: category_counts,
       uncategorized_total: uncategorized_total,
       loaded_cards: [],
@@ -804,33 +809,47 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp view_mode_to_atom("deleted"), do: :deleted
 
   defp reorder_category(socket, uuid, direction) do
+    # V103 nested categories: reorder operates strictly among siblings
+    # (same parent_uuid). Swapping across parents would shuffle rows into
+    # different sub-trees and leave position values meaningless for the
+    # flat ordering that the detail view relies on.
     categories = socket.assigns.category_list
-    index = Enum.find_index(categories, &(&1.uuid == uuid))
 
-    swap_index =
-      case direction do
-        :up -> max(index - 1, 0)
-        :down -> min(index + 1, length(categories) - 1)
-      end
+    case Enum.find(categories, &(&1.uuid == uuid)) do
+      %Category{parent_uuid: parent_uuid} = cat_a ->
+        siblings = Enum.filter(categories, &(&1.parent_uuid == parent_uuid))
+        sibling_index = Enum.find_index(siblings, &(&1.uuid == uuid))
 
-    if index != swap_index do
-      cat_a = Enum.at(categories, index)
-      cat_b = Enum.at(categories, swap_index)
+        swap_index =
+          case direction do
+            :up -> sibling_index - 1
+            :down -> sibling_index + 1
+          end
 
-      case Catalogue.swap_category_positions(cat_a, cat_b, actor_opts(socket)) do
-        {:ok, _} ->
-          {:noreply, reset_and_load(socket)}
+        if swap_index >= 0 and swap_index < length(siblings) do
+          cat_b = Enum.at(siblings, swap_index)
+          swap_categories(socket, cat_a, cat_b)
+        else
+          {:noreply, socket}
+        end
 
-        {:error, _} ->
-          {:noreply,
-           put_flash(
-             socket,
-             :error,
-             Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to reorder categories.")
-           )}
-      end
-    else
-      {:noreply, socket}
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  defp swap_categories(socket, cat_a, cat_b) do
+    case Catalogue.swap_category_positions(cat_a, cat_b, actor_opts(socket)) do
+      {:ok, _} ->
+        {:noreply, reset_and_load(socket)}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to reorder categories.")
+         )}
     end
   end
 
@@ -975,6 +994,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             view_mode={@view_mode}
             category_total={length(@category_list)}
             category_counts={@category_counts}
+            category_depths={@category_depths}
+            category_list={@category_list}
             uncategorized_total={@uncategorized_total}
             catalogue={@catalogue}
           />
@@ -1060,24 +1081,37 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   attr(:view_mode, :string, required: true)
   attr(:category_total, :integer, required: true)
   attr(:category_counts, :map, required: true)
+  attr(:category_depths, :map, default: %{})
+  attr(:category_list, :list, default: [])
   attr(:uncategorized_total, :integer, required: true)
   attr(:catalogue, :any, required: true)
 
   defp detail_card(%{card: %{kind: :category}} = assigns) do
+    %{uuid: uuid, parent_uuid: parent_uuid} = assigns.card.category
+    siblings = Enum.filter(assigns.category_list, &(&1.parent_uuid == parent_uuid))
+    sibling_count = length(siblings)
+
     assigns =
-      assign(assigns, :total, Map.get(assigns.category_counts, assigns.card.category.uuid, 0))
+      assigns
+      |> assign(:total, Map.get(assigns.category_counts, uuid, 0))
+      |> assign(:depth, Map.get(assigns.category_depths, uuid, 0))
+      |> assign(:sibling_count, sibling_count)
 
     ~H"""
-    <div :if={@view_mode == "active" or @card.category.status == "deleted" or @total > 0} class="card bg-base-100 shadow">
+    <div
+      :if={@view_mode == "active" or @card.category.status == "deleted" or @total > 0}
+      class="card bg-base-100 shadow"
+      style={"margin-left: #{@depth * 1.5}rem"}
+    >
       <div class="card-body">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <div :if={@category_total > 1 && @view_mode == "active"} class="flex flex-col">
+            <div :if={@sibling_count > 1 && @view_mode == "active"} class="flex flex-col">
               <button
                 phx-click="move_category_up"
                 phx-value-uuid={@card.category.uuid}
                 class="btn btn-ghost btn-xs btn-square"
-                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Move up")}
+                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Move up (among siblings)")}
               >
                 <.icon name="hero-chevron-up" class="w-3 h-3" />
               </button>
@@ -1085,7 +1119,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 phx-click="move_category_down"
                 phx-value-uuid={@card.category.uuid}
                 class="btn btn-ghost btn-xs btn-square"
-                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Move down")}
+                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Move down (among siblings)")}
               >
                 <.icon name="hero-chevron-down" class="w-3 h-3" />
               </button>

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -7,10 +7,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
 
   import PhoenixKitWeb.Components.MultilangForm
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
 
+  alias PhoenixKit.Modules.Storage.URLSigner
+  alias PhoenixKitCatalogue.Attachments
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Catalogue, as: CatalogueSchema
@@ -62,6 +65,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
          catalogue: catalogue,
          confirm_delete: false
        )
+       |> Attachments.mount_attachments(catalogue)
+       |> Attachments.allow_attachment_upload()
        |> assign_changeset(changeset)
        |> mount_multilang()}
     end
@@ -99,13 +104,32 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
 
   def handle_event("save", %{"catalogue" => params}, socket) do
     params =
-      merge_translatable_params(params, socket, @translatable_fields,
+      params
+      |> merge_translatable_params(socket, @translatable_fields,
         changeset: socket.assigns.changeset,
         preserve_fields: @preserve_fields
       )
+      |> Attachments.inject_attachment_data(socket)
 
     save_catalogue(socket, socket.assigns.action, params)
   end
+
+  # ── Attachments (featured image modal + inline files dropzone) ──
+
+  def handle_event("open_featured_image_picker", _params, socket),
+    do: Attachments.open_featured_image_picker(socket)
+
+  def handle_event("close_media_selector", _params, socket),
+    do: {:noreply, Attachments.close_media_selector(socket)}
+
+  def handle_event("cancel_upload", %{"ref" => ref}, socket),
+    do: Attachments.cancel_attachment_upload(socket, ref)
+
+  def handle_event("remove_file", %{"uuid" => uuid}, socket),
+    do: Attachments.trash_file(socket, uuid)
+
+  def handle_event("clear_featured_image", _params, socket),
+    do: Attachments.clear_featured_image(socket)
 
   def handle_event("show_delete_confirm", _params, socket) do
     {:noreply, assign(socket, :confirm_delete, true)}
@@ -140,6 +164,17 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     {:noreply, assign(socket, :confirm_delete, false)}
   end
 
+  @impl true
+  def handle_info({:media_selected, file_uuids}, socket),
+    do: Attachments.handle_media_selected(socket, file_uuids)
+
+  def handle_info({:media_selector_closed}, socket),
+    do: {:noreply, Attachments.close_media_selector(socket)}
+
+  # Catch-all so stray monitor signals or unrelated PubSub traffic
+  # can't crash the form mid-edit.
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
   defp actor_opts(socket) do
     case socket.assigns[:phoenix_kit_current_user] do
       %{uuid: uuid} -> [actor_uuid: uuid]
@@ -150,6 +185,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
   defp save_catalogue(socket, :new, params) do
     case Catalogue.create_catalogue(params, actor_opts(socket)) do
       {:ok, catalogue} ->
+        _ = Attachments.maybe_rename_pending_folder(socket, catalogue)
+
         {:noreply,
          socket
          |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue created."))
@@ -184,8 +221,98 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
 
     ~H"""
     <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
+      <%!-- Media selector — folder-scoped featured-image picker.
+           Reconfigured per open; the Files card below is inline so
+           no files-mode routing is needed. --%>
+      <.live_component
+        module={PhoenixKitWeb.Live.Components.MediaSelectorModal}
+        id="catalogue-form-media-selector"
+        show={@show_media_selector}
+        mode={@media_selection_mode}
+        file_type_filter={@media_filter}
+        selected_uuids={@media_selected_uuids}
+        scope_folder_id={@files_folder_uuid}
+        phoenix_kit_current_user={assigns[:phoenix_kit_current_user]}
+      />
+
       <%!-- Header --%>
       <.admin_page_header back={Paths.index()} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update catalogue details and settings.")} />
+
+      <%!-- Featured image card. Opens the scoped picker (images only,
+           single). Upload a new image or pick an attached one; the
+           uuid is stored on `catalogue.data["featured_image_uuid"]`. --%>
+      <div class="card bg-base-100 shadow-lg">
+        <div class="card-body flex flex-col gap-3">
+          <div class="flex items-center justify-between">
+            <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+              <.icon name="hero-photo" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Featured Image")}
+            </h2>
+            <span class="text-xs text-base-content/50">
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Shown on catalogue listings and detail views.")}
+            </span>
+          </div>
+
+          <%= if @featured_image_file do %>
+            <div class="flex items-center gap-4">
+              <a
+                href={URLSigner.signed_url(@featured_image_uuid, "original")}
+                target="_blank"
+                rel="noopener"
+                class="shrink-0"
+                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Open original")}
+              >
+                <img
+                  src={URLSigner.signed_url(@featured_image_uuid, "thumbnail")}
+                  alt={@featured_image_file.original_file_name}
+                  class="w-24 h-24 rounded-md object-cover bg-base-200 border border-base-300"
+                />
+              </a>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-medium truncate">
+                  {@featured_image_file.original_file_name}
+                </p>
+                <p class="text-xs text-base-content/50">
+                  {Attachments.format_file_size(@featured_image_file.size)}
+                </p>
+              </div>
+              <div class="flex flex-col gap-2">
+                <button
+                  type="button"
+                  phx-click="open_featured_image_picker"
+                  class="btn btn-sm btn-outline"
+                >
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Change")}
+                </button>
+                <button
+                  type="button"
+                  phx-click="clear_featured_image"
+                  class="btn btn-sm btn-ghost"
+                >
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Remove")}
+                </button>
+              </div>
+            </div>
+          <% else %>
+            <div class="flex items-center justify-between py-4 border border-dashed border-base-300 rounded-md px-4">
+              <div class="flex items-center gap-3 text-base-content/60">
+                <.icon name="hero-photo" class="w-6 h-6" />
+                <span class="text-sm">
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No featured image set.")}
+                </span>
+              </div>
+              <button
+                type="button"
+                phx-click="open_featured_image_picker"
+                class="btn btn-sm btn-primary"
+              >
+                <.icon name="hero-plus" class="w-4 h-4 mr-1" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Set featured image")}
+              </button>
+            </div>
+          <% end %>
+        </div>
+      </div>
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <%!-- Main content card --%>
@@ -316,22 +443,164 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                 {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived catalogues are hidden from active views.")}
               </span>
             </div>
+          </div>
+        </div>
 
-            <%!-- Actions --%>
-            <div class="divider my-0"></div>
+        <%!-- Files card lives inside the form so the file input's
+             phx-change hooks into the form's `validate` event (which
+             is what kicks off auto_upload). Rendering it outside the
+             form kept the server from ever seeing new entries. --%>
+        <div class="card bg-base-100 shadow-lg mt-6">
+        <div class="card-body flex flex-col gap-4">
+          <div class="flex flex-col gap-0.5">
+            <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+              <.icon name="hero-paper-clip" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Attached Files")}
+              <span :if={@files_state.files != []} class="badge badge-sm badge-ghost ml-1">
+                {length(@files_state.files)}
+              </span>
+            </h2>
+            <p class="text-xs text-base-content/50">
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Brochures, spec sheets, datasheets. Any file type is accepted.")}
+            </p>
+          </div>
 
-            <div class="flex justify-end gap-3">
-              <.link navigate={Paths.index()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
+          <label
+            for={@uploads.attachment_files.ref}
+            class="flex flex-col items-center justify-center gap-2 py-6 border-2 border-dashed border-base-300 rounded-md bg-base-200/20 hover:bg-base-200/40 transition-colors cursor-pointer"
+            phx-drop-target={@uploads.attachment_files.ref}
+          >
+            <.icon name="hero-cloud-arrow-up" class="w-8 h-8 text-base-content/40" />
+            <div class="text-sm text-base-content/60">
+              <span class="font-medium text-primary">{Gettext.gettext(PhoenixKitWeb.Gettext, "Click to upload")}</span>
+              <span>{Gettext.gettext(PhoenixKitWeb.Gettext, " or drag & drop")}</span>
+            </div>
+            <.live_file_input upload={@uploads.attachment_files} class="hidden" />
+          </label>
+
+          <div :if={@uploads.attachment_files.entries != []} class="flex flex-col gap-2">
+            <div
+              :for={entry <- @uploads.attachment_files.entries}
+              class="flex items-center gap-3 rounded-md border border-base-300 bg-base-100 p-2"
+            >
+              <.icon name="hero-cloud-arrow-up" class="w-4 h-4 text-base-content/60 shrink-0" />
+              <div class="flex-1 min-w-0">
+                <p class="text-sm truncate">{entry.client_name}</p>
+                <progress
+                  class="progress progress-primary w-full h-1 mt-1"
+                  value={entry.progress}
+                  max="100"
+                >
+                </progress>
+              </div>
+              <span class="text-xs text-base-content/50 tabular-nums">{entry.progress}%</span>
               <button
-                type="submit"
-                class="btn btn-primary phx-submit-loading:opacity-75"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+                type="button"
+                phx-click="cancel_upload"
+                phx-value-ref={entry.ref}
+                class="btn btn-ghost btn-xs btn-square"
+                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
               >
-                {if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Catalogue"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}
+                <.icon name="hero-x-mark" class="w-4 h-4" />
               </button>
             </div>
           </div>
+
+          <p
+            :for={err <- upload_errors(@uploads.attachment_files)}
+            class="text-xs text-error"
+          >
+            {Attachments.upload_error_message(err)}
+          </p>
+
+          <%= if @files_state.files == [] do %>
+            <div class="flex flex-col items-center gap-2 py-10 text-center border border-dashed border-base-300 rounded-md">
+              <.icon name="hero-paper-clip" class="w-8 h-8 text-base-content/30" />
+              <p class="text-sm text-base-content/50">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "No files attached yet.")}
+              </p>
+            </div>
+          <% else %>
+            <ul class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <li
+                :for={file <- @files_state.files}
+                class="flex items-center gap-3 rounded-md border border-base-300 bg-base-200/30 p-3"
+              >
+                <%= if file.file_type == "image" do %>
+                  <a
+                    href={URLSigner.signed_url(file.uuid, "original")}
+                    target="_blank"
+                    rel="noopener"
+                    class="shrink-0"
+                  >
+                    <img
+                      src={URLSigner.signed_url(file.uuid, "thumbnail")}
+                      alt={file.original_file_name}
+                      class="w-14 h-14 rounded object-cover bg-base-200 border border-base-300"
+                    />
+                  </a>
+                <% else %>
+                  <a
+                    href={URLSigner.signed_url(file.uuid, "original")}
+                    target="_blank"
+                    rel="noopener"
+                    class="shrink-0 flex items-center justify-center w-14 h-14 rounded bg-base-200 border border-base-300 text-base-content/60"
+                    title={Gettext.gettext(PhoenixKitWeb.Gettext, "Download")}
+                  >
+                    <.icon name={Attachments.file_icon(file)} class="w-6 h-6" />
+                  </a>
+                <% end %>
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm font-medium truncate" title={file.original_file_name}>
+                    {file.original_file_name}
+                  </p>
+                  <p class="text-xs text-base-content/50">
+                    {Attachments.format_file_size(file.size)} · {file.file_type}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  phx-click="remove_file"
+                  phx-value-uuid={file.uuid}
+                  data-confirm={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove this file from the catalogue? If it's not attached to any other resource, it will be moved to trash (admins can restore).")}
+                  class="btn btn-ghost btn-xs btn-square"
+                  title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove from catalogue")}
+                >
+                  <.icon name="hero-x-mark" class="w-4 h-4" />
+                </button>
+              </li>
+            </ul>
+          <% end %>
         </div>
+      </div>
+
+      <%!-- Save/Cancel — at the bottom of the form so it covers
+           every card inside (main details + files).
+           Save is disabled while uploads are mid-flight so we don't
+           race the post-upload `handle_progress` write against the
+           save path. --%>
+      <div class="flex justify-end gap-3 pt-2">
+        <.link navigate={Paths.index()} class="btn btn-ghost">
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
+        </.link>
+        <button
+          type="submit"
+          class="btn btn-primary phx-submit-loading:opacity-75"
+          disabled={@uploads.attachment_files.entries != []}
+          phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+        >
+          {cond do
+            @uploads.attachment_files.entries != [] ->
+              Gettext.gettext(PhoenixKitWeb.Gettext, "Waiting for uploads...")
+
+            @action == :new ->
+              Gettext.gettext(PhoenixKitWeb.Gettext, "Create Catalogue")
+
+            true ->
+              Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")
+          end}
+        </button>
+      </div>
       </.form>
 
       <%!-- Danger zone — only in edit mode --%>

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -25,8 +25,15 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       case action do
         :new ->
           catalogue_uuid = params["catalogue_uuid"]
-          next_pos = Catalogue.next_category_position(catalogue_uuid)
-          cat = %Category{catalogue_uuid: catalogue_uuid, position: next_pos}
+          parent_uuid = blank_to_nil(params["parent_uuid"])
+          next_pos = Catalogue.next_category_position(catalogue_uuid, parent_uuid)
+
+          cat = %Category{
+            catalogue_uuid: catalogue_uuid,
+            parent_uuid: parent_uuid,
+            position: next_pos
+          }
+
           {cat, Catalogue.change_category(cat), catalogue_uuid}
 
         :edit ->
@@ -59,6 +66,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         []
       end
 
+    parent_options = parent_options_for(action, category, catalogue_uuid)
+
     {:ok,
      socket
      |> assign(
@@ -72,11 +81,40 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
        catalogue_uuid: catalogue_uuid,
        confirm_delete_all: false,
        other_catalogues: other_catalogues,
+       parent_options: parent_options,
+       parent_move_target: category && category.parent_uuid,
        move_target: nil
      )
      |> assign_changeset(changeset)
      |> mount_multilang()}
   end
+
+  # Tree-flattened options for the parent picker. Root entry first,
+  # then each category prefixed with indentation that matches its
+  # depth. For edit mode, the category's own subtree is excluded so
+  # the user can't pick itself or one of its descendants.
+  defp parent_options_for(:new, _category, catalogue_uuid) do
+    Catalogue.list_category_tree(catalogue_uuid)
+    |> format_parent_options()
+  end
+
+  defp parent_options_for(:edit, %Category{uuid: uuid}, catalogue_uuid) do
+    catalogue_uuid
+    |> Catalogue.list_category_tree(exclude_subtree_of: uuid)
+    |> format_parent_options()
+  end
+
+  defp parent_options_for(_, _, _), do: []
+
+  defp format_parent_options(entries) do
+    Enum.map(entries, fn {category, depth} ->
+      {String.duplicate("— ", depth) <> category.name, category.uuid}
+    end)
+  end
+
+  defp blank_to_nil(nil), do: nil
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
 
   defp assign_changeset(socket, changeset) do
     socket
@@ -93,6 +131,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
     params =
       params
       |> Map.put_new("catalogue_uuid", socket.assigns.catalogue_uuid)
+      |> normalize_parent_uuid()
       |> merge_translatable_params(socket, @translatable_fields,
         changeset: socket.assigns.changeset
       )
@@ -109,6 +148,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
     params =
       params
       |> Map.put_new("catalogue_uuid", socket.assigns.catalogue_uuid)
+      |> normalize_parent_uuid()
       |> merge_translatable_params(socket, @translatable_fields,
         changeset: socket.assigns.changeset
       )
@@ -181,9 +221,67 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
     end
   end
 
+  def handle_event("select_parent_move_target", %{"parent_uuid" => uuid}, socket) do
+    target = blank_to_nil(uuid)
+    {:noreply, assign(socket, :parent_move_target, target)}
+  end
+
+  def handle_event("move_under_parent", _params, socket) do
+    target = socket.assigns.parent_move_target
+
+    case Catalogue.move_category_under(socket.assigns.category, target, actor_opts(socket)) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> assign(:category, updated)
+         |> assign(:parent_options, parent_options_for(:edit, updated, updated.catalogue_uuid))
+         |> put_flash(
+           :info,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Category moved.")
+         )}
+
+      {:error, :would_create_cycle} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Cannot move a category under itself or one of its descendants."
+           )
+         )}
+
+      {:error, :cross_catalogue} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Parent must live in the same catalogue."
+           )
+         )}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move category.")
+         )}
+    end
+  end
+
   def handle_event("cancel_delete", _params, socket) do
     {:noreply, assign(socket, :confirm_delete_all, false)}
   end
+
+  # Form-submitted empty string means "no parent" — normalize so the
+  # changeset treats it as NULL rather than attempting a malformed FK.
+  defp normalize_parent_uuid(%{"parent_uuid" => ""} = params),
+    do: Map.put(params, "parent_uuid", nil)
+
+  defp normalize_parent_uuid(params), do: params
 
   defp actor_opts(socket) do
     case socket.assigns[:phoenix_kit_current_user] do
@@ -275,6 +373,17 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
           <div class="card-body flex flex-col gap-5 pt-0">
             <div class="divider my-0"></div>
 
+            <div :if={@action == :new} class="form-control">
+              <.select
+                field={@form[:parent_uuid]}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Parent category")}
+                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Top level (no parent) —")}
+                options={@parent_options}
+                class="transition-colors focus-within:select-primary"
+              />
+              <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Pick a parent to nest this category inside, or leave blank to keep it at the top level. You can move it later.")}</span>
+            </div>
+
             <div class="form-control">
               <.input
                 field={@form[:position]}
@@ -301,6 +410,36 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         </div>
       </.form>
 
+      <%!-- Move to a different parent — only in edit mode, within the same catalogue --%>
+      <div :if={@action == :edit} class="card bg-base-100 shadow-lg">
+        <div class="card-body flex flex-col gap-3">
+          <h3 class="text-sm font-semibold text-base-content/80">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Parent")}</h3>
+          <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Reparent this category within its catalogue. Its subtree comes along.")}</p>
+          <div class="flex items-end gap-3">
+            <div class="form-control flex-1">
+              <.select
+                name="parent_uuid"
+                id="category-parent-move-target"
+                value={@parent_move_target}
+                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Top level (no parent) —")}
+                options={@parent_options}
+                class="select-sm transition-colors focus-within:select-primary"
+                phx-change="select_parent_move_target"
+              />
+            </div>
+            <button
+              type="button"
+              phx-click="move_under_parent"
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+              disabled={@parent_move_target == @category.parent_uuid}
+              class="btn btn-sm btn-outline"
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+            </button>
+          </div>
+        </div>
+      </div>
+
       <%!-- Move to another catalogue — only in edit mode with other catalogues available --%>
       <div :if={@action == :edit && @other_catalogues != []} class="card bg-base-100 shadow-lg">
         <div class="card-body flex flex-col gap-3">
@@ -321,6 +460,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
             <button
               type="button"
               phx-click="move_category"
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
               disabled={is_nil(@move_target)}
               class="btn btn-sm btn-outline"
             >

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -17,6 +17,9 @@ defmodule PhoenixKitCatalogue.Web.Components do
       value + unit per catalogue; pairs with `Catalogue.put_catalogue_rules/3`)
     * `view_mode_toggle/1` — table/card view toggle synced via localStorage
     * `item_table/1` — configurable item table with selectable columns
+    * `item_picker/1` — combobox for picking a single item via server-side
+      search; backed by `Components.ItemPicker` LiveComponent, fires
+      `{:item_picker_select, id, item}` / `{:item_picker_clear, id}` upward
     * `empty_state/1` — centered empty state card with message and optional action
 
   Several of these (`search_input`, `search_results_summary`,
@@ -1015,6 +1018,73 @@ defmodule PhoenixKitCatalogue.Web.Components do
         <.table_row_menu_button :if={@on_permanent_delete} phx-click={@on_permanent_delete} phx-value-uuid={@item.uuid} phx-value-type={@permanent_delete_type} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")} variant="error" />
       </.table_row_menu>
     </.table_default_cell>
+    """
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Item Picker
+  # ═══════════════════════════════════════════════════════════════════
+
+  @doc """
+  Combobox for picking a single catalogue item via server-side search.
+
+  Thin wrapper around the `ItemPicker` LiveComponent — it's the
+  LiveComponent that owns search state, events, and the colocated JS
+  hook. This wrapper exists so consumers have an attr-declared call
+  site and don't have to remember `<.live_component module={...}>`.
+
+  The parent LiveView reacts to two messages in its `handle_info/2`:
+
+      {:item_picker_select, id, %Item{}}   # user chose an item
+      {:item_picker_clear,  id}            # user cleared the selection
+
+  where `id` is the `:id` you passed in — handy for multiple pickers on
+  one page.
+
+  ## Examples
+
+      <.item_picker
+        id={"row-\#{@row.id}-picker"}
+        category_uuids={[@category_uuid]}
+        selected_item={@row.item}
+        excluded_uuids={@used_uuids}
+        locale="en"
+      />
+
+  See `PhoenixKitCatalogue.Web.Components.ItemPicker` for the full attr
+  reference and the keyboard / a11y contract.
+  """
+
+  attr(:id, :string, required: true)
+  attr(:category_uuids, :list, default: nil)
+  attr(:catalogue_uuids, :list, default: nil)
+  attr(:include_descendants, :boolean, default: true)
+  attr(:selected_item, :any, default: nil)
+  attr(:excluded_uuids, :list, default: [])
+  attr(:locale, :string, required: true)
+  attr(:placeholder, :string, default: nil)
+  attr(:empty_query_limit, :integer, default: 10)
+  attr(:page_size, :integer, default: 20)
+  attr(:disabled, :boolean, default: false)
+  attr(:format_price, :any, default: nil)
+
+  def item_picker(assigns) do
+    ~H"""
+    <.live_component
+      module={PhoenixKitCatalogue.Web.Components.ItemPicker}
+      id={@id}
+      category_uuids={@category_uuids}
+      catalogue_uuids={@catalogue_uuids}
+      include_descendants={@include_descendants}
+      selected_item={@selected_item}
+      excluded_uuids={@excluded_uuids}
+      locale={@locale}
+      placeholder={@placeholder}
+      empty_query_limit={@empty_query_limit}
+      page_size={@page_size}
+      disabled={@disabled}
+      format_price={@format_price}
+    />
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/components/item_picker.ex
+++ b/lib/phoenix_kit_catalogue/web/components/item_picker.ex
@@ -1,0 +1,512 @@
+defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
+  @moduledoc """
+  Combobox LiveComponent for picking a single item from the catalogue
+  via server-side search.
+
+  Drop one into any LiveView — typically many, one per row in a picker
+  table. Each instance owns its own search state; the parent LV only
+  reacts to two messages:
+
+      {:item_picker_select, id, %Item{}}  # user chose an item
+      {:item_picker_clear,  id}           # user cleared the selection
+
+  ### API
+
+      <.item_picker
+        id="row-42-picker"
+        category_uuids={[category.uuid]}
+        selected_item={@chosen_item}
+        excluded_uuids={@already_used_uuids}
+        locale="en"
+      />
+
+  Attrs:
+
+    * `:id` (required) — unique DOM/component id. The `:item_picker_*`
+      messages echo this back so a parent with N pickers knows which
+      fired.
+    * `:category_uuids` — scope search to these categories. `nil` or
+      `[]` means "all categories + uncategorized" (matches
+      `Catalogue.search_items/2`).
+    * `:catalogue_uuids` — scope search to these catalogues. Composes
+      with `:category_uuids` (AND).
+    * `:include_descendants` — when `true` (default), `:category_uuids`
+      is expanded through the V103 tree; pass `false` for literal
+      set semantics.
+    * `:selected_item` — the `%Item{}` currently chosen (or `nil`).
+      Drives the input text and the `aria-selected` / primary-border
+      styling in the dropdown.
+    * `:excluded_uuids` — items in this list are rendered dim +
+      `aria-disabled` and cannot be clicked. Use for "already picked in
+      another row" state.
+    * `:locale` (required) — locale string for translated display
+      names (`"en"`, `"es"`, etc.). Resolved via
+      `Catalogue.get_translation/2`.
+    * `:placeholder` — input placeholder. Defaults to "Search items…".
+    * `:empty_query_limit` — how many items to show when the query is
+      empty (the "just focused" state). Defaults to `10`.
+    * `:page_size` — max results fetched per query. Defaults to `20`.
+      When the unbounded count exceeds this the dropdown shows a
+      "Type to refine…" sentinel row so the user knows there's more.
+    * `:disabled` — disables the input and hides the clear button.
+    * `:format_price` — 1-arity function taking an `%Item{}` (with
+      `:catalogue` preloaded — the search always does this) and
+      returning a display string or `nil`. Defaults to a Decimal
+      stringifier of `item_pricing(item).final_price`. Return `nil` to
+      omit the price column entirely.
+
+  ### Keyboard / a11y
+
+  Handled client-side by the colocated `ItemPicker` hook:
+
+    * ArrowDown / ArrowUp cycle through enabled options (announced via
+      `aria-activedescendant`; DOM focus stays on the input).
+    * Home / End jump to first / last enabled option.
+    * Enter activates the focused option (simulates a click so the
+      normal `select` event fires).
+    * Escape closes the dropdown and keeps focus on the input.
+    * Clicking outside the picker closes it (`phx-click-away`).
+
+  The dropdown is absolutely positioned and elevated with `z-50`; the
+  parent container must allow overflow (`overflow: visible` or just
+  don't set `overflow: hidden` on an ancestor that clips it).
+  """
+
+  use Phoenix.LiveComponent
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  alias Phoenix.LiveView.JS
+  alias PhoenixKitCatalogue.Catalogue
+  alias PhoenixKitCatalogue.Schemas.Item
+
+  @default_empty_query_limit 10
+  @default_page_size 20
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     assign(socket,
+       query: "",
+       options: [],
+       has_more: false,
+       open: false,
+       selected_item: nil,
+       last_selected_uuid: nil,
+       excluded_uuids: [],
+       category_uuids: nil,
+       catalogue_uuids: nil,
+       include_descendants: true,
+       placeholder: nil,
+       empty_query_limit: @default_empty_query_limit,
+       page_size: @default_page_size,
+       disabled: false,
+       format_price: nil,
+       locale: "en"
+     )}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    # If the selected_item UUID *changes* between updates, mirror the
+    # new item's name into the input. No change (including first mount
+    # with no selection) leaves `:query` alone so a mid-typing user
+    # isn't clobbered by unrelated parent re-renders.
+    incoming_uuid = uuid_of(assigns[:selected_item])
+    prior_uuid = socket.assigns.last_selected_uuid
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:last_selected_uuid, incoming_uuid)
+
+    socket =
+      if prior_uuid == incoming_uuid do
+        socket
+      else
+        locale = socket.assigns.locale
+        assign(socket, :query, item_display_name(assigns[:selected_item], locale) || "")
+      end
+
+    {:ok, socket}
+  end
+
+  defp uuid_of(%Item{uuid: u}), do: u
+  defp uuid_of(_), do: nil
+
+  # ─────────────────────────────────────────────────────────────────
+  # Events
+  # ─────────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("query_change", %{"value" => value}, socket) do
+    {:noreply, socket |> assign(:query, value) |> assign(:open, true) |> run_search()}
+  end
+
+  def handle_event("open", _params, socket) do
+    socket =
+      if socket.assigns.options == [] and socket.assigns.query == "" do
+        run_search(assign(socket, :open, true))
+      else
+        assign(socket, :open, true)
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("close", _params, socket) do
+    {:noreply, assign(socket, :open, false)}
+  end
+
+  def handle_event("select", %{"uuid" => uuid}, socket) do
+    case Enum.find(socket.assigns.options, &(&1.uuid == uuid)) do
+      nil ->
+        {:noreply, socket}
+
+      %Item{} = item ->
+        send(self(), {:item_picker_select, socket.assigns.id, item})
+
+        {:noreply,
+         socket
+         |> assign(:query, item_display_name(item, socket.assigns.locale) || "")
+         |> assign(:open, false)}
+    end
+  end
+
+  def handle_event("clear", _params, socket) do
+    send(self(), {:item_picker_clear, socket.assigns.id})
+
+    {:noreply,
+     socket
+     |> assign(:query, "")
+     |> assign(:options, [])
+     |> assign(:has_more, false)
+     |> assign(:open, false)}
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Search
+  # ─────────────────────────────────────────────────────────────────
+
+  defp run_search(socket) do
+    %{
+      query: query,
+      category_uuids: category_uuids,
+      catalogue_uuids: catalogue_uuids,
+      include_descendants: include_descendants,
+      page_size: page_size,
+      empty_query_limit: empty_query_limit
+    } = socket.assigns
+
+    limit =
+      case String.trim(query || "") do
+        "" -> empty_query_limit
+        _ -> page_size
+      end
+
+    opts =
+      [limit: limit, include_descendants: include_descendants]
+      |> maybe_put(:category_uuids, category_uuids)
+      |> maybe_put(:catalogue_uuids, catalogue_uuids)
+
+    options = Catalogue.search_items(query || "", opts)
+
+    has_more =
+      if length(options) >= limit do
+        total = Catalogue.count_search_items(query || "", Keyword.delete(opts, :limit))
+        total > length(options)
+      else
+        false
+      end
+
+    assign(socket, options: options, has_more: has_more)
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, _key, []), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+
+  # ─────────────────────────────────────────────────────────────────
+  # Display helpers
+  # ─────────────────────────────────────────────────────────────────
+
+  defp item_display_name(nil, _locale), do: nil
+
+  defp item_display_name(%Item{} = item, locale) do
+    translation = safe_get_translation(item, locale)
+
+    Map.get(translation, "_name") ||
+      Map.get(translation, "name") ||
+      item.name
+  end
+
+  defp item_breadcrumb(%Item{} = item, locale) do
+    catalogue_name =
+      case item.catalogue do
+        %{__struct__: Ecto.Association.NotLoaded} ->
+          nil
+
+        nil ->
+          nil
+
+        catalogue ->
+          translated_name(catalogue, locale)
+      end
+
+    category_name =
+      case item.category do
+        %{__struct__: Ecto.Association.NotLoaded} ->
+          nil
+
+        nil ->
+          nil
+
+        category ->
+          translated_name(category, locale)
+      end
+
+    [catalogue_name, category_name]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" / ")
+  end
+
+  defp translated_name(record, locale) do
+    translation = safe_get_translation(record, locale)
+
+    Map.get(translation, "_name") ||
+      Map.get(translation, "name") ||
+      Map.get(record, :name)
+  end
+
+  defp safe_get_translation(record, locale) do
+    Catalogue.get_translation(record, locale)
+  rescue
+    _ -> %{}
+  end
+
+  defp format_price_display(_item, nil), do: nil
+
+  defp format_price_display(%Item{} = item, fun) when is_function(fun, 1) do
+    fun.(item)
+  end
+
+  defp default_format_price(%Item{} = item) do
+    pricing = Catalogue.item_pricing(item)
+
+    case pricing.final_price do
+      nil -> nil
+      %Decimal{} = price -> Decimal.to_string(price, :normal)
+    end
+  rescue
+    _ -> nil
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Render
+  # ─────────────────────────────────────────────────────────────────
+
+  @impl true
+  def render(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        :placeholder_text,
+        assigns[:placeholder] || Gettext.gettext(PhoenixKitWeb.Gettext, "Search items…")
+      )
+      |> assign(
+        :price_fun,
+        assigns[:format_price] || (&default_format_price/1)
+      )
+
+    ~H"""
+    <div
+      id={@id}
+      class="relative w-full"
+      phx-hook=".ItemPicker"
+      phx-click-away={JS.push("close", target: @myself)}
+    >
+      <input
+        id={"#{@id}-input"}
+        type="text"
+        role="combobox"
+        aria-expanded={to_string(@open)}
+        aria-controls={"#{@id}-listbox"}
+        aria-autocomplete="list"
+        autocomplete="off"
+        value={@query}
+        placeholder={@placeholder_text}
+        disabled={@disabled}
+        phx-target={@myself}
+        phx-change="query_change"
+        phx-debounce="300"
+        phx-focus="open"
+        class={[
+          "input input-sm w-full pr-8",
+          @selected_item && "input-primary"
+        ]}
+      />
+
+      <button
+        :if={@selected_item && !@disabled}
+        type="button"
+        phx-click="clear"
+        phx-target={@myself}
+        class="btn btn-xs btn-ghost absolute right-1 top-1/2 -translate-y-1/2"
+        aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+      >
+        <.icon name="hero-x-mark" class="w-3 h-3" />
+      </button>
+
+      <ul
+        :if={@open and @options != []}
+        id={"#{@id}-listbox"}
+        role="listbox"
+        class="absolute z-50 mt-1 w-full max-h-64 overflow-y-auto bg-base-100 border border-base-300 rounded-box shadow-lg"
+      >
+        <li
+          :for={{item, idx} <- Enum.with_index(@options)}
+          id={"#{@id}-option-#{idx}"}
+          role="option"
+          aria-selected={to_string(@selected_item && @selected_item.uuid == item.uuid)}
+          aria-disabled={to_string(item.uuid in @excluded_uuids)}
+          data-excluded={to_string(item.uuid in @excluded_uuids)}
+          class={[
+            "flex items-center justify-between px-3 py-2 cursor-pointer select-none",
+            "data-[focused=true]:bg-base-200 hover:bg-base-200",
+            "data-[excluded=true]:opacity-40 data-[excluded=true]:cursor-not-allowed",
+            "data-[excluded=true]:hover:bg-transparent"
+          ]}
+          phx-click={if item.uuid in @excluded_uuids, do: nil, else: "select"}
+          phx-value-uuid={item.uuid}
+          phx-target={@myself}
+        >
+          <div class="min-w-0 flex-1">
+            <div class="font-medium text-sm truncate">
+              {item_display_name(item, @locale)}
+            </div>
+            <div :if={item_breadcrumb(item, @locale) != ""} class="text-xs text-base-content/50 truncate">
+              {item_breadcrumb(item, @locale)}
+            </div>
+          </div>
+          <div
+            :if={(price = format_price_display(item, @price_fun)) && price != ""}
+            class="text-sm font-medium ml-4 shrink-0"
+          >
+            {price}
+          </div>
+        </li>
+        <li
+          :if={@has_more}
+          role="option"
+          aria-disabled="true"
+          class="px-3 py-2 text-xs text-base-content/40 italic cursor-default select-none"
+        >
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Type to refine search…")}
+        </li>
+      </ul>
+
+      <div
+        :if={@open and @options == [] and @query != ""}
+        class="absolute z-50 mt-1 w-full bg-base-100 border border-base-300 rounded-box shadow-lg px-3 py-2 text-sm text-base-content/50"
+      >
+        {Gettext.gettext(PhoenixKitWeb.Gettext, "No items found")}
+      </div>
+
+      <script :type={Phoenix.LiveView.ColocatedHook} name=".ItemPicker">
+        export default {
+          mounted() {
+            this.input = this.el.querySelector('input[role="combobox"]')
+            this.focusedIdx = -1
+            this._onKey = (e) => this.handleKey(e)
+            this.input.addEventListener("keydown", this._onKey)
+          },
+
+          updated() {
+            // Options re-rendered — clamp the highlight.
+            const opts = this.enabledOptions()
+            if (this.focusedIdx >= opts.length) {
+              this.focusedIdx = opts.length - 1
+            }
+            this.syncActiveDescendant()
+          },
+
+          destroyed() {
+            if (this.input && this._onKey) {
+              this.input.removeEventListener("keydown", this._onKey)
+            }
+          },
+
+          enabledOptions() {
+            return Array.from(
+              this.el.querySelectorAll('li[role="option"]:not([aria-disabled="true"])')
+            )
+          },
+
+          handleKey(e) {
+            const opts = this.enabledOptions()
+
+            switch (e.key) {
+              case "ArrowDown":
+                if (opts.length === 0) return
+                e.preventDefault()
+                this.focusedIdx = Math.min(this.focusedIdx + 1, opts.length - 1)
+                if (this.focusedIdx < 0) this.focusedIdx = 0
+                this.syncActiveDescendant()
+                break
+
+              case "ArrowUp":
+                if (opts.length === 0) return
+                e.preventDefault()
+                this.focusedIdx = Math.max(this.focusedIdx - 1, 0)
+                this.syncActiveDescendant()
+                break
+
+              case "Home":
+                if (opts.length === 0) return
+                e.preventDefault()
+                this.focusedIdx = 0
+                this.syncActiveDescendant()
+                break
+
+              case "End":
+                if (opts.length === 0) return
+                e.preventDefault()
+                this.focusedIdx = opts.length - 1
+                this.syncActiveDescendant()
+                break
+
+              case "Enter":
+                if (this.focusedIdx >= 0 && this.focusedIdx < opts.length) {
+                  e.preventDefault()
+                  opts[this.focusedIdx].click()
+                }
+                break
+
+              case "Escape":
+                e.preventDefault()
+                this.pushEventTo(this.el, "close", {})
+                break
+            }
+          },
+
+          syncActiveDescendant() {
+            this.el
+              .querySelectorAll('li[data-focused="true"]')
+              .forEach((el) => el.removeAttribute("data-focused"))
+
+            const opts = this.enabledOptions()
+            if (this.focusedIdx >= 0 && this.focusedIdx < opts.length) {
+              const el = opts[this.focusedIdx]
+              el.setAttribute("data-focused", "true")
+              el.scrollIntoView({block: "nearest"})
+              this.input.setAttribute("aria-activedescendant", el.id)
+            } else {
+              this.input.removeAttribute("aria-activedescendant")
+            }
+          }
+        }
+      </script>
+    </div>
+    """
+  end
+end

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -12,8 +12,11 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
   import PhoenixKitCatalogue.Web.Components, only: [catalogue_rules_picker: 1]
 
+  alias PhoenixKit.Modules.Storage.URLSigner
   alias PhoenixKit.Utils.Multilang
+  alias PhoenixKitCatalogue.Attachments
   alias PhoenixKitCatalogue.Catalogue
+  alias PhoenixKitCatalogue.ItemMetadata
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Item
 
@@ -117,12 +120,43 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       manufacturers: Catalogue.list_manufacturers(status: "active"),
       all_categories: all_categories,
       smart_move_targets: smart_move_targets,
-      move_target: nil
+      move_target: nil,
+      current_tab: :details,
+      meta_state: build_meta_state(item)
     )
+    |> Attachments.mount_attachments(item)
+    |> Attachments.allow_attachment_upload()
     |> assign_changeset(changeset)
     |> assign_rule_state(item, kind, catalogue_uuid)
     |> mount_multilang()
     |> adjust_multilang_for_item(item)
+  end
+
+  # Metadata values live at `item.data["meta"]` (a flat %{key => string}
+  # map). Known keys are ordered by their position in
+  # `ItemMetadata.definitions/0`; legacy keys (stored but no longer
+  # defined in code) come after, alphabetized, so the UI can tag them
+  # and offer a remove-only action without losing data.
+  defp build_meta_state(%Item{data: data}) do
+    raw =
+      case data do
+        %{"meta" => %{} = m} -> m
+        _ -> %{}
+      end
+
+    defined_keys = Enum.map(ItemMetadata.definitions(), & &1.key)
+    present_defined = Enum.filter(defined_keys, &Map.has_key?(raw, &1))
+    legacy = raw |> Map.keys() |> Enum.reject(&(&1 in defined_keys)) |> Enum.sort()
+
+    %{attached: present_defined ++ legacy, values: stringify_values(raw)}
+  end
+
+  defp stringify_values(values) when is_map(values) do
+    Map.new(values, fn
+      {k, nil} -> {k, ""}
+      {k, v} when is_binary(v) -> {k, v}
+      {k, v} -> {k, to_string(v)}
+    end)
   end
 
   # Keeps both :changeset (for <.translatable_field>) and :form (for
@@ -221,29 +255,96 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     {:noreply, handle_switch_language(socket, lang_code)}
   end
 
-  def handle_event("validate", %{"item" => params}, socket) do
-    params =
-      merge_translatable_params(params, socket, @translatable_fields,
+  def handle_event("switch_tab", %{"tab" => tab}, socket) do
+    {:noreply, assign(socket, :current_tab, parse_tab(tab))}
+  end
+
+  def handle_event("add_meta_field", %{"key" => key}, socket) do
+    case ItemMetadata.definition(key) do
+      nil ->
+        # Unknown key arriving from a stale client — ignore rather than
+        # inserting data the save path can't round-trip.
+        {:noreply, socket}
+
+      _def ->
+        state = socket.assigns.meta_state
+
+        new_state =
+          if key in state.attached do
+            state
+          else
+            %{
+              attached: state.attached ++ [key],
+              values: Map.put_new(state.values, key, "")
+            }
+          end
+
+        {:noreply, assign(socket, :meta_state, new_state)}
+    end
+  end
+
+  def handle_event("remove_meta_field", %{"key" => key}, socket) do
+    state = socket.assigns.meta_state
+
+    new_state = %{
+      attached: Enum.reject(state.attached, &(&1 == key)),
+      values: Map.delete(state.values, key)
+    }
+
+    {:noreply, assign(socket, :meta_state, new_state)}
+  end
+
+  # ── Attachments (featured image modal + inline files dropzone) ──
+  # Delegated to `PhoenixKitCatalogue.Attachments`; shared with
+  # `CatalogueFormLive` so both forms behave identically.
+
+  def handle_event("open_featured_image_picker", _params, socket),
+    do: Attachments.open_featured_image_picker(socket)
+
+  def handle_event("close_media_selector", _params, socket),
+    do: {:noreply, Attachments.close_media_selector(socket)}
+
+  def handle_event("cancel_upload", %{"ref" => ref}, socket),
+    do: Attachments.cancel_attachment_upload(socket, ref)
+
+  def handle_event("remove_file", %{"uuid" => uuid}, socket),
+    do: Attachments.trash_file(socket, uuid)
+
+  def handle_event("clear_featured_image", _params, socket),
+    do: Attachments.clear_featured_image(socket)
+
+  def handle_event("validate", params, socket) do
+    socket = absorb_meta_params(socket, params)
+    item_params = Map.get(params, "item", %{})
+
+    item_params =
+      merge_translatable_params(item_params, socket, @translatable_fields,
         changeset: socket.assigns.changeset,
         preserve_fields: @preserve_fields
       )
 
     changeset =
       socket.assigns.item
-      |> Catalogue.change_item(params)
+      |> Catalogue.change_item(item_params)
       |> Map.put(:action, :validate)
 
     {:noreply, assign_changeset(socket, changeset)}
   end
 
-  def handle_event("save", %{"item" => params}, socket) do
-    params =
-      merge_translatable_params(params, socket, @translatable_fields,
+  def handle_event("save", params, socket) do
+    socket = absorb_meta_params(socket, params)
+    item_params = Map.get(params, "item", %{})
+
+    item_params =
+      item_params
+      |> merge_translatable_params(socket, @translatable_fields,
         changeset: socket.assigns.changeset,
         preserve_fields: @preserve_fields
       )
+      |> inject_meta_into_data(socket.assigns.meta_state)
+      |> Attachments.inject_attachment_data(socket)
 
-    save_item(socket, socket.assigns.action, params)
+    save_item(socket, socket.assigns.action, item_params)
   end
 
   # ── Smart-catalogue rule picker events ──────────────────────────
@@ -316,6 +417,84 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     end
   end
 
+  defp parse_tab("metadata"), do: :metadata
+  defp parse_tab("files"), do: :files
+  defp parse_tab(_), do: :details
+
+  # ── Attachments handle_info (delegated to Attachments module) ────
+
+  @impl true
+  def handle_info({:media_selected, file_uuids}, socket),
+    do: Attachments.handle_media_selected(socket, file_uuids)
+
+  def handle_info({:media_selector_closed}, socket),
+    do: {:noreply, Attachments.close_media_selector(socket)}
+
+  # Catch-all so stray monitor signals or unrelated PubSub traffic
+  # can't crash the form mid-edit.
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  # Inbound form params carry whatever is currently typed into the
+  # metadata inputs under `"meta"` (name="meta[color]"). We fold them
+  # into `meta_state.values` on every validate/save so the assign stays
+  # in sync with what the user sees — unattached keys are ignored to
+  # avoid resurrecting a row they just removed.
+  defp absorb_meta_params(socket, params) do
+    meta_params = Map.get(params, "meta", %{})
+    state = socket.assigns.meta_state
+
+    if is_map(meta_params) and meta_params != %{} do
+      values = Enum.reduce(state.attached, state.values, &absorb_one(meta_params, &1, &2))
+      assign(socket, :meta_state, %{state | values: values})
+    else
+      socket
+    end
+  end
+
+  defp absorb_one(meta_params, key, acc) do
+    case Map.get(meta_params, key) do
+      nil -> acc
+      value -> Map.put(acc, key, value)
+    end
+  end
+
+  # Casts the meta_state into its storage shape and wedges it into
+  # `params["data"]["meta"]`. Known-key values go through
+  # `ItemMetadata.cast_value/2` (blanks become nil → key dropped). Legacy
+  # keys (no current definition) pass through untouched so their data
+  # isn't silently nuked by a save — the user clears them explicitly
+  # via the × button.
+  defp inject_meta_into_data(params, %{attached: attached, values: values}) do
+    meta = Enum.reduce(attached, %{}, &cast_meta_entry(&1, values, &2))
+
+    data =
+      case Map.get(params, "data") do
+        %{} = d -> d
+        _ -> %{}
+      end
+
+    Map.put(params, "data", Map.put(data, "meta", meta))
+  end
+
+  defp cast_meta_entry(key, values, acc) do
+    raw = Map.get(values, key, "")
+
+    case ItemMetadata.definition(key) do
+      nil -> put_legacy_meta(acc, key, raw)
+      def_ -> put_defined_meta(acc, key, def_, raw)
+    end
+  end
+
+  defp put_legacy_meta(acc, _key, raw) when raw in [nil, ""], do: acc
+  defp put_legacy_meta(acc, key, raw), do: Map.put(acc, key, raw)
+
+  defp put_defined_meta(acc, key, def_, raw) do
+    case ItemMetadata.cast_value(def_, raw) do
+      nil -> acc
+      cast -> Map.put(acc, key, cast)
+    end
+  end
+
   # Routes on the parent catalogue's kind: smart items move across
   # catalogues (categories don't apply), standard items move between
   # categories (the catalogue is derived from the target category).
@@ -357,7 +536,8 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     params = Map.put_new(params, "catalogue_uuid", socket.assigns.catalogue_uuid)
 
     with {:ok, item} <- Catalogue.create_item(params, actor_opts(socket)),
-         {:ok, _rules} <- maybe_put_rules(socket, item) do
+         {:ok, _rules} <- maybe_put_rules(socket, item),
+         :ok <- Attachments.maybe_rename_pending_folder(socket, item) do
       {:noreply,
        socket
        |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item created."))
@@ -477,7 +657,19 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       <.admin_page_header
         back={if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index()}
         title={@page_title}
-        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Add a new product or material to the catalogue."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update item details, pricing, and classification.")}
+        subtitle={
+          if @action == :new,
+            do:
+              Gettext.gettext(
+                PhoenixKitWeb.Gettext,
+                "Add a new product or material to the catalogue."
+              ),
+            else:
+              Gettext.gettext(
+                PhoenixKitWeb.Gettext,
+                "Update item details, pricing, and classification."
+              )
+        }
       />
 
       <%!-- Primary language warning --%>
@@ -485,21 +677,161 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
         <div>
           <p class="text-sm font-medium">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "This item was imported in %{lang}. Please fill in the %{primary} translation and save to set it as the primary language.", lang: lang_name(@language_tabs, @item_primary_language), primary: lang_name(@language_tabs, @primary_language))}
+            {Gettext.gettext(
+              PhoenixKitWeb.Gettext,
+              "This item was imported in %{lang}. Please fill in the %{primary} translation and save to set it as the primary language.",
+              lang: lang_name(@language_tabs, @item_primary_language),
+              primary: lang_name(@language_tabs, @primary_language)
+            )}
           </p>
         </div>
       </div>
 
+      <%!-- Tab strip — persists across tab switches; each panel stays in
+           the DOM (toggled by `hidden`) so the multilang wrapper and
+           any user input don't lose state when flipping tabs. --%>
+      <div role="tablist" class="tabs tabs-bordered">
+        <button
+          type="button"
+          phx-click="switch_tab"
+          phx-value-tab="details"
+          class={"tab #{if @current_tab == :details, do: "tab-active"}"}
+        >
+          <.icon name="hero-document-text" class="w-4 h-4 mr-1" />
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Details")}
+        </button>
+        <button
+          type="button"
+          phx-click="switch_tab"
+          phx-value-tab="metadata"
+          class={"tab #{if @current_tab == :metadata, do: "tab-active"}"}
+        >
+          <.icon name="hero-tag" class="w-4 h-4 mr-1" />
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Metadata")}
+          <span :if={@meta_state.attached != []} class="badge badge-sm badge-ghost ml-2">
+            {length(@meta_state.attached)}
+          </span>
+        </button>
+        <button
+          type="button"
+          phx-click="switch_tab"
+          phx-value-tab="files"
+          class={"tab #{if @current_tab == :files, do: "tab-active"}"}
+        >
+          <.icon name="hero-paper-clip" class="w-4 h-4 mr-1" />
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Files")}
+        </button>
+      </div>
+
+      <%!-- Media selector — single instance, reconfigured per click
+           via @media_selector_target. Scoped to this item's folder
+           so browse and new uploads never spill into other items. --%>
+      <.live_component
+        module={PhoenixKitWeb.Live.Components.MediaSelectorModal}
+        id="item-form-media-selector"
+        show={@show_media_selector}
+        mode={@media_selection_mode}
+        file_type_filter={@media_filter}
+        selected_uuids={@media_selected_uuids}
+        scope_folder_id={@files_folder_uuid}
+        phoenix_kit_current_user={assigns[:phoenix_kit_current_user]}
+      />
+
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
-        <div class="card bg-base-100 shadow-lg">
-          <.multilang_tabs multilang_enabled={@multilang_enabled} language_tabs={@language_tabs} current_lang={@current_lang} />
+        <%!-- Featured image: opens the scoped picker in single+image
+             mode. The picker both browses this item's images and
+             accepts new uploads (which get dropped into the item's
+             folder automatically). --%>
+        <div class={"card bg-base-100 shadow-lg mb-4 #{if @current_tab != :details, do: "hidden"}"}>
+          <div class="card-body flex flex-col gap-3">
+            <div class="flex items-center justify-between">
+              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                <.icon name="hero-photo" class="w-4 h-4" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Featured Image")}
+              </h2>
+              <span class="text-xs text-base-content/50">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Shown in lists and detail views.")}
+              </span>
+            </div>
+
+            <%= if @featured_image_file do %>
+              <div class="flex items-center gap-4">
+                <a
+                  href={URLSigner.signed_url(@featured_image_uuid, "original")}
+                  target="_blank"
+                  rel="noopener"
+                  class="shrink-0"
+                  title={Gettext.gettext(PhoenixKitWeb.Gettext, "Open original")}
+                >
+                  <img
+                    src={URLSigner.signed_url(@featured_image_uuid, "thumbnail")}
+                    alt={@featured_image_file.original_file_name}
+                    class="w-24 h-24 rounded-md object-cover bg-base-200 border border-base-300"
+                  />
+                </a>
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm font-medium truncate">
+                    {@featured_image_file.original_file_name}
+                  </p>
+                  <p class="text-xs text-base-content/50">
+                    {Attachments.format_file_size(@featured_image_file.size)}
+                  </p>
+                </div>
+                <div class="flex flex-col gap-2">
+                  <button
+                    type="button"
+                    phx-click="open_featured_image_picker"
+                    class="btn btn-sm btn-outline"
+                  >
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Change")}
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="clear_featured_image"
+                    class="btn btn-sm btn-ghost"
+                  >
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Remove")}
+                  </button>
+                </div>
+              </div>
+            <% else %>
+              <div class="flex items-center justify-between py-4 border border-dashed border-base-300 rounded-md px-4">
+                <div class="flex items-center gap-3 text-base-content/60">
+                  <.icon name="hero-photo" class="w-6 h-6" />
+                  <span class="text-sm">
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "No featured image set.")}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  phx-click="open_featured_image_picker"
+                  class="btn btn-sm btn-primary"
+                >
+                  <.icon name="hero-plus" class="w-4 h-4 mr-1" />
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Set featured image")}
+                </button>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <div class={"card bg-base-100 shadow-lg #{if @current_tab != :details, do: "hidden"}"}>
+          <.multilang_tabs
+            multilang_enabled={@multilang_enabled}
+            language_tabs={@language_tabs}
+            current_lang={@current_lang}
+          />
 
           <%!-- Only translatable fields live inside the wrapper. When the
                user switches languages, the wrapper's ID changes and
                morphdom remounts its children — so we keep the scope as
                small as possible (name + description), not the whole
                form. Everything else renders as a sibling below. --%>
-          <.multilang_fields_wrapper multilang_enabled={@multilang_enabled} current_lang={@current_lang} skeleton_class="card-body flex flex-col gap-5 pb-0">
+          <.multilang_fields_wrapper
+            multilang_enabled={@multilang_enabled}
+            current_lang={@current_lang}
+            skeleton_class="card-body flex flex-col gap-5 pb-0"
+          >
             <:skeleton>
               <%!-- Name --%>
               <div class="space-y-2">
@@ -514,208 +846,495 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
             </:skeleton>
             <div class="card-body flex flex-col gap-5 pb-0">
               <.translatable_field
-                field_name="name" form_prefix="item" changeset={@changeset}
-                schema_field={:name} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Oak Panel 18mm")} required
+                field_name="name"
+                form_prefix="item"
+                changeset={@changeset}
+                schema_field={:name}
+                multilang_enabled={@multilang_enabled}
+                current_lang={@current_lang}
+                primary_language={@primary_language}
+                lang_data={@lang_data}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}
+                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Oak Panel 18mm")}
+                required
                 class="w-full"
               />
 
               <.translatable_field
-                field_name="description" form_prefix="item" changeset={@changeset}
-                schema_field={:description} multilang_enabled={@multilang_enabled}
-                current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")} type="textarea"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Product specifications, dimensions, materials...")}
+                field_name="description"
+                form_prefix="item"
+                changeset={@changeset}
+                schema_field={:description}
+                multilang_enabled={@multilang_enabled}
+                current_lang={@current_lang}
+                primary_language={@primary_language}
+                lang_data={@lang_data}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+                type="textarea"
+                placeholder={
+                  Gettext.gettext(
+                    PhoenixKitWeb.Gettext,
+                    "Product specifications, dimensions, materials..."
+                  )
+                }
                 class="w-full"
               />
             </div>
           </.multilang_fields_wrapper>
 
           <div class="card-body flex flex-col gap-5 pt-0">
-              <%!-- Pricing & identification — hidden for smart catalogues,
+            <%!-- Pricing & identification — hidden for smart catalogues,
                    whose items are priced entirely by the rules picker below. --%>
-              <div :if={@catalogue_kind != "smart"} class="flex flex-col gap-5">
-                <div class="divider my-0"></div>
-
-                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-                  </svg>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Pricing & Identification")}
-                </h2>
-
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <.input
-                    field={@form[:sku]}
-                    type="text"
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")}
-                    class="font-mono"
-                    placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., KF-001")}
-                  />
-                  <div class="form-control">
-                    <.input
-                      field={@form[:base_price]}
-                      type="number"
-                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")}
-                      step="0.01"
-                      min="0"
-                      placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "0.00")}
-                    />
-                    <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cost/purchase price before catalogue markup.")}</span>
-                  </div>
-                  <.select
-                    field={@form[:unit]}
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}
-                    class="transition-colors focus-within:select-primary"
-                    options={[
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Piece"), "piece"},
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "m² (square meter)"), "m2"},
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Running meter"), "running_meter"}
-                    ]}
-                  />
-                  <div class="form-control">
-                    <.input
-                      field={@form[:markup_percentage]}
-                      type="number"
-                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Override (%)")}
-                      step="0.01"
-                      min="0"
-                      placeholder={
-                        if @catalogue_markup,
-                          do: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{markup}%", markup: Decimal.to_string(@catalogue_markup, :normal)),
-                          else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue markup")
-                      }
-                    />
-                    <span class="label-text-alt text-base-content/50 mt-1">
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Leave blank to inherit the catalogue's markup. Set (including 0) to override just this item.")}
-                    </span>
-                  </div>
-                  <div class="form-control">
-                    <.input
-                      field={@form[:discount_percentage]}
-                      type="number"
-                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Discount Override (%)")}
-                      step="0.01"
-                      min="0"
-                      max="100"
-                      placeholder={
-                        if @catalogue_discount,
-                          do: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{discount}%", discount: Decimal.to_string(@catalogue_discount, :normal)),
-                          else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue discount")
-                      }
-                    />
-                    <span class="label-text-alt text-base-content/50 mt-1">
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Leave blank to inherit the catalogue's discount. Set (including 0) to override just this item.")}
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              <%!-- Smart-catalogue rules (only for kind: "smart") --%>
-              <div :if={@catalogue_kind == "smart"} class="flex flex-col gap-4">
-                <div class="divider my-0"></div>
-                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                  <.icon name="hero-link" class="w-4 h-4" />
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue Rules")}
-                </h2>
-                <p class="text-sm text-base-content/60 -mt-2">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Pick which catalogues this item applies to and set a value + unit per catalogue. Rows left blank inherit the defaults below.")}
-                </p>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div class="form-control">
-                    <.input
-                      field={@form[:default_value]}
-                      type="number"
-                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Value")}
-                      step="0.0001"
-                      min="0"
-                      placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 5")}
-                    />
-                    <span class="label-text-alt text-base-content/50 mt-1">
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Used for any selected catalogue that doesn't have its own value. If no catalogues are selected, this is the item's standalone fee (e.g. $50 flat).")}
-                    </span>
-                  </div>
-                  <div class="form-control">
-                    <.select
-                      field={@form[:default_unit]}
-                      label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Unit")}
-                      class="transition-colors focus-within:select-primary"
-                      options={[
-                        {Gettext.gettext(PhoenixKitWeb.Gettext, "Percent (%)"), "percent"},
-                        {Gettext.gettext(PhoenixKitWeb.Gettext, "Flat amount"), "flat"}
-                      ]}
-                    />
-                    <span class="label-text-alt text-base-content/50 mt-1">
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Used for any selected catalogue that doesn't have its own unit.")}
-                    </span>
-                  </div>
-                </div>
-
-                <.catalogue_rules_picker
-                  catalogues={@rule_candidates}
-                  rules={@working_rules}
-                  item_default_value={Ecto.Changeset.get_field(@changeset, :default_value)}
-                />
-              </div>
-
-              <%!-- Classification — hidden for smart catalogues, whose items
-                   don't belong to a category/manufacturer in the usual sense. --%>
-              <div :if={@catalogue_kind != "smart"} class="flex flex-col gap-5">
-                <div class="divider my-0"></div>
-
-                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                  </svg>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Classification")}
-                </h2>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <.select
-                    field={@form[:category_uuid]}
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}
-                    class="transition-colors focus-within:select-primary"
-                    prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No category --")}
-                    options={Enum.map(@categories, &{&1.name, &1.uuid})}
-                  />
-                  <.select
-                    field={@form[:manufacturer_uuid]}
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")}
-                    class="transition-colors focus-within:select-primary"
-                    prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No manufacturer --")}
-                    options={Enum.map(@manufacturers, &{&1.name, &1.uuid})}
-                  />
-                </div>
-              </div>
-
-              <div class="form-control">
-                <.select
-                  field={@form[:status]}
-                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
-                  class="transition-colors focus-within:select-primary"
-                  options={[
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"},
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued"), "discontinued"}
-                  ]}
-                />
-                <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued items are kept for reference but hidden from active listings.")}</span>
-              </div>
-
-              <%!-- Actions --%>
+            <div :if={@catalogue_kind != "smart"} class="flex flex-col gap-5">
               <div class="divider my-0"></div>
 
-              <div class="flex justify-end gap-3">
-                <.link navigate={if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
-                <button
-                  type="submit"
-                  class="btn btn-primary phx-submit-loading:opacity-75"
-                  phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
-                >{if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Item"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}</button>
+              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
+                  />
+                </svg>
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Pricing & Identification")}
+              </h2>
+
+              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <.input
+                  field={@form[:sku]}
+                  type="text"
+                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")}
+                  class="font-mono"
+                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., KF-001")}
+                />
+                <div class="form-control">
+                  <.input
+                    field={@form[:base_price]}
+                    type="number"
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")}
+                    step="0.01"
+                    min="0"
+                    placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "0.00")}
+                  />
+                  <span class="label-text-alt text-base-content/50 mt-1">
+                    {Gettext.gettext(
+                      PhoenixKitWeb.Gettext,
+                      "Cost/purchase price before catalogue markup."
+                    )}
+                  </span>
+                </div>
+                <.select
+                  field={@form[:unit]}
+                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}
+                  class="transition-colors focus-within:select-primary"
+                  options={[
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Piece"), "piece"},
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "m² (square meter)"), "m2"},
+                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Running meter"), "running_meter"}
+                  ]}
+                />
+                <div class="form-control">
+                  <.input
+                    field={@form[:markup_percentage]}
+                    type="number"
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Override (%)")}
+                    step="0.01"
+                    min="0"
+                    placeholder={
+                      if @catalogue_markup,
+                        do:
+                          Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{markup}%",
+                            markup: Decimal.to_string(@catalogue_markup, :normal)
+                          ),
+                        else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue markup")
+                    }
+                  />
+                  <span class="label-text-alt text-base-content/50 mt-1">
+                    {Gettext.gettext(
+                      PhoenixKitWeb.Gettext,
+                      "Leave blank to inherit the catalogue's markup. Set (including 0) to override just this item."
+                    )}
+                  </span>
+                </div>
+                <div class="form-control">
+                  <.input
+                    field={@form[:discount_percentage]}
+                    type="number"
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Discount Override (%)")}
+                    step="0.01"
+                    min="0"
+                    max="100"
+                    placeholder={
+                      if @catalogue_discount,
+                        do:
+                          Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{discount}%",
+                            discount: Decimal.to_string(@catalogue_discount, :normal)
+                          ),
+                        else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue discount")
+                    }
+                  />
+                  <span class="label-text-alt text-base-content/50 mt-1">
+                    {Gettext.gettext(
+                      PhoenixKitWeb.Gettext,
+                      "Leave blank to inherit the catalogue's discount. Set (including 0) to override just this item."
+                    )}
+                  </span>
+                </div>
               </div>
+            </div>
+
+            <%!-- Smart-catalogue rules (only for kind: "smart") --%>
+            <div :if={@catalogue_kind == "smart"} class="flex flex-col gap-4">
+              <div class="divider my-0"></div>
+              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                <.icon name="hero-link" class="w-4 h-4" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue Rules")}
+              </h2>
+              <p class="text-sm text-base-content/60 -mt-2">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "Pick which catalogues this item applies to and set a value + unit per catalogue. Rows left blank inherit the defaults below."
+                )}
+              </p>
+
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div class="form-control">
+                  <.input
+                    field={@form[:default_value]}
+                    type="number"
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Value")}
+                    step="0.0001"
+                    min="0"
+                    placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 5")}
+                  />
+                  <span class="label-text-alt text-base-content/50 mt-1">
+                    {Gettext.gettext(
+                      PhoenixKitWeb.Gettext,
+                      "Used for any selected catalogue that doesn't have its own value. If no catalogues are selected, this is the item's standalone fee (e.g. $50 flat)."
+                    )}
+                  </span>
+                </div>
+                <div class="form-control">
+                  <.select
+                    field={@form[:default_unit]}
+                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Unit")}
+                    class="transition-colors focus-within:select-primary"
+                    options={[
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Percent (%)"), "percent"},
+                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Flat amount"), "flat"}
+                    ]}
+                  />
+                  <span class="label-text-alt text-base-content/50 mt-1">
+                    {Gettext.gettext(
+                      PhoenixKitWeb.Gettext,
+                      "Used for any selected catalogue that doesn't have its own unit."
+                    )}
+                  </span>
+                </div>
+              </div>
+
+              <.catalogue_rules_picker
+                catalogues={@rule_candidates}
+                rules={@working_rules}
+                item_default_value={Ecto.Changeset.get_field(@changeset, :default_value)}
+              />
+            </div>
+
+            <%!-- Classification — hidden for smart catalogues, whose items
+                   don't belong to a category/manufacturer in the usual sense. --%>
+            <div :if={@catalogue_kind != "smart"} class="flex flex-col gap-5">
+              <div class="divider my-0"></div>
+
+              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                  />
+                </svg>
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Classification")}
+              </h2>
+
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <.select
+                  field={@form[:category_uuid]}
+                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}
+                  class="transition-colors focus-within:select-primary"
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No category --")}
+                  options={Enum.map(@categories, &{&1.name, &1.uuid})}
+                />
+                <.select
+                  field={@form[:manufacturer_uuid]}
+                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")}
+                  class="transition-colors focus-within:select-primary"
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No manufacturer --")}
+                  options={Enum.map(@manufacturers, &{&1.name, &1.uuid})}
+                />
+              </div>
+            </div>
+
+            <div class="form-control">
+              <.select
+                field={@form[:status]}
+                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                class="transition-colors focus-within:select-primary"
+                options={[
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"},
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued"), "discontinued"}
+                ]}
+              />
+              <span class="label-text-alt text-base-content/50 mt-1">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "Discontinued items are kept for reference but hidden from active listings."
+                )}
+              </span>
+            </div>
           </div>
+        </div>
+
+        <%!-- Metadata tab — global field list, user opts in per item.
+             Values live in `item.data["meta"]`; legacy keys (stored
+             but no longer in ItemMetadata.definitions/0) render with a
+             "Legacy" pill and a remove-only action so data isn't lost
+             silently. --%>
+        <div class={"card bg-base-100 shadow-lg #{if @current_tab != :metadata, do: "hidden"}"}>
+          <div class="card-body flex flex-col gap-5">
+            <div>
+              <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                <.icon name="hero-tag" class="w-4 h-4" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Metadata")}
+              </h2>
+              <p class="text-sm text-base-content/60 mt-1">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "Attach any metadata fields that apply to this item. Blank values are dropped on save."
+                )}
+              </p>
+            </div>
+
+            <div :if={@meta_state.attached == []} class="alert">
+              <.icon name="hero-information-circle" class="w-5 h-5 shrink-0" />
+              <span class="text-sm">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "No metadata attached yet. Pick a field below to add one."
+                )}
+              </span>
+            </div>
+
+            <div :if={@meta_state.attached != []} class="flex flex-col gap-3">
+              <div :for={key <- @meta_state.attached} class="flex items-end gap-3">
+                {render_meta_row(assigns, key)}
+              </div>
+            </div>
+
+            <%!-- Add-metadata picker: only surfaces definitions not yet
+                 attached. Uses phx-change on the <.select>; the ID
+                 cycles with the attached-count so morphdom replaces the
+                 element on each add — this collapses the "stuck
+                 selection" quirk that otherwise leaves the picker
+                 showing the just-added label. --%>
+            <div class="divider my-0"></div>
+            <div class="flex items-end gap-3">
+              <div class="flex-1">
+                <.select
+                  id={"item-metadata-add-#{length(@meta_state.attached)}"}
+                  name="key"
+                  value={nil}
+                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Add metadata")}
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Pick a field —")}
+                  options={add_meta_options(@meta_state)}
+                  class="select-sm transition-colors focus-within:select-primary"
+                  phx-change="add_meta_field"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <%!-- Files tab — direct upload, per-item scope. Files are
+             discoverable via the item's folder
+             (`item.data["files_folder_uuid"]`); the grid is refreshed
+             from that folder after each upload. No list to track
+             on the item — the folder is the single source of truth. --%>
+        <div class={"card bg-base-100 shadow-lg #{if @current_tab != :files, do: "hidden"}"}>
+          <div class="card-body flex flex-col gap-4">
+            <div class="flex items-center justify-between gap-4">
+              <div class="flex flex-col gap-0.5 min-w-0">
+                <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
+                  <.icon name="hero-paper-clip" class="w-4 h-4" />
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Attached Files")}
+                  <span
+                    :if={@files_state.files != []}
+                    class="badge badge-sm badge-ghost ml-1"
+                  >
+                    {length(@files_state.files)}
+                  </span>
+                </h2>
+                <p class="text-xs text-base-content/50">
+                  {Gettext.gettext(
+                    PhoenixKitWeb.Gettext,
+                    "Spec sheets, drawings, photos. Any file type is accepted."
+                  )}
+                </p>
+              </div>
+            </div>
+
+            <%!-- Inline dropzone — uploads land in this item's folder
+                 and appear in the grid below. No popup, no selection
+                 ceremony. --%>
+            <label
+              for={@uploads.attachment_files.ref}
+              class="flex flex-col items-center justify-center gap-2 py-6 border-2 border-dashed border-base-300 rounded-md bg-base-200/20 hover:bg-base-200/40 transition-colors cursor-pointer"
+              phx-drop-target={@uploads.attachment_files.ref}
+            >
+              <.icon name="hero-cloud-arrow-up" class="w-8 h-8 text-base-content/40" />
+              <div class="text-sm text-base-content/60">
+                <span class="font-medium text-primary">{Gettext.gettext(PhoenixKitWeb.Gettext, "Click to upload")}</span>
+                <span>{Gettext.gettext(PhoenixKitWeb.Gettext, " or drag & drop")}</span>
+              </div>
+              <.live_file_input upload={@uploads.attachment_files} class="hidden" />
+            </label>
+
+            <%!-- In-flight uploads: one row per active entry. --%>
+            <div :if={@uploads.attachment_files.entries != []} class="flex flex-col gap-2">
+              <div
+                :for={entry <- @uploads.attachment_files.entries}
+                class="flex items-center gap-3 rounded-md border border-base-300 bg-base-100 p-2"
+              >
+                <.icon name="hero-cloud-arrow-up" class="w-4 h-4 text-base-content/60 shrink-0" />
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm truncate">{entry.client_name}</p>
+                  <progress class="progress progress-primary w-full h-1 mt-1" value={entry.progress} max="100"></progress>
+                </div>
+                <span class="text-xs text-base-content/50 tabular-nums">{entry.progress}%</span>
+                <button
+                  type="button"
+                  phx-click="cancel_upload"
+                  phx-value-ref={entry.ref}
+                  class="btn btn-ghost btn-xs btn-square"
+                  title={Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
+                >
+                  <.icon name="hero-x-mark" class="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+
+            <%!-- Phoenix.LiveView upload errors (too_large, not_accepted, too_many_files). --%>
+            <p :for={err <- upload_errors(@uploads.attachment_files)} class="text-xs text-error">
+              {Attachments.upload_error_message(err)}
+            </p>
+
+            <%= if @files_state.files == [] do %>
+              <div class="flex flex-col items-center gap-2 py-10 text-center border border-dashed border-base-300 rounded-md">
+                <.icon name="hero-paper-clip" class="w-8 h-8 text-base-content/30" />
+                <p class="text-sm text-base-content/50">
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No files attached yet.")}
+                </p>
+              </div>
+            <% else %>
+              <ul class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <li
+                  :for={file <- @files_state.files}
+                  class="flex items-center gap-3 rounded-md border border-base-300 bg-base-200/30 p-3"
+                >
+                  <%= if file.file_type == "image" do %>
+                    <a
+                      href={URLSigner.signed_url(file.uuid, "original")}
+                      target="_blank"
+                      rel="noopener"
+                      class="shrink-0"
+                    >
+                      <img
+                        src={URLSigner.signed_url(file.uuid, "thumbnail")}
+                        alt={file.original_file_name}
+                        class="w-14 h-14 rounded object-cover bg-base-200 border border-base-300"
+                      />
+                    </a>
+                  <% else %>
+                    <a
+                      href={URLSigner.signed_url(file.uuid, "original")}
+                      target="_blank"
+                      rel="noopener"
+                      class="shrink-0 flex items-center justify-center w-14 h-14 rounded bg-base-200 border border-base-300 text-base-content/60"
+                      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Download")}
+                    >
+                      <.icon name={Attachments.file_icon(file)} class="w-6 h-6" />
+                    </a>
+                  <% end %>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-medium truncate" title={file.original_file_name}>
+                      {file.original_file_name}
+                    </p>
+                    <p class="text-xs text-base-content/50">
+                      {Attachments.format_file_size(file.size)} · {file.file_type}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    phx-click="remove_file"
+                    phx-value-uuid={file.uuid}
+                    data-confirm={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove this file from the item? If it's not attached to any other item, it will be moved to trash (admins can restore).")}
+                    class="btn btn-ghost btn-xs btn-square"
+                    title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove from item")}
+                  >
+                    <.icon name="hero-x-mark" class="w-4 h-4" />
+                  </button>
+                </li>
+              </ul>
+            <% end %>
+          </div>
+        </div>
+
+        <%!-- Actions — sit outside the tab panels so Save works from
+             any tab; the form element wraps them all. Save is
+             disabled while uploads are mid-flight so we don't race
+             the post-upload `handle_progress` write against the save
+             path (would drop the just-uploaded file from the
+             resource). --%>
+        <div class="flex justify-end gap-3 pt-2">
+          <.link
+            navigate={
+              if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index()
+            }
+            class="btn btn-ghost"
+          >
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
+          </.link>
+          <button
+            type="submit"
+            class="btn btn-primary phx-submit-loading:opacity-75"
+            disabled={@uploads.attachment_files.entries != []}
+            phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+          >
+            {cond do
+              @uploads.attachment_files.entries != [] ->
+                Gettext.gettext(PhoenixKitWeb.Gettext, "Waiting for uploads...")
+
+              @action == :new ->
+                Gettext.gettext(PhoenixKitWeb.Gettext, "Create Item")
+
+              true ->
+                Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")
+            end}
+          </button>
         </div>
       </.form>
 
@@ -723,10 +1342,17 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
            items move across smart catalogues (no category). Each card
            only renders when its own target list is non-empty so we
            never show an empty-dropdown dead end. --%>
-      <div :if={@action == :edit && @catalogue_kind != "smart" && @all_categories != []} class="card bg-base-100 shadow-lg">
+      <div
+        :if={@action == :edit && @catalogue_kind != "smart" && @all_categories != []}
+        class="card bg-base-100 shadow-lg"
+      >
         <div class="card-body flex flex-col gap-3">
-          <h3 class="text-sm font-semibold text-base-content/80">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Category")}</h3>
-          <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item to a category in any catalogue.")}</p>
+          <h3 class="text-sm font-semibold text-base-content/80">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Category")}
+          </h3>
+          <p class="text-xs text-base-content/50">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item to a category in any catalogue.")}
+          </p>
           <div class="flex items-end gap-3">
             <div class="form-control flex-1">
               <.select
@@ -742,6 +1368,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
             <button
               type="button"
               phx-click="move_item"
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
               disabled={is_nil(@move_target)}
               class="btn btn-sm btn-outline"
             >
@@ -751,10 +1378,20 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         </div>
       </div>
 
-      <div :if={@action == :edit && @catalogue_kind == "smart" && @smart_move_targets != []} class="card bg-base-100 shadow-lg">
+      <div
+        :if={@action == :edit && @catalogue_kind == "smart" && @smart_move_targets != []}
+        class="card bg-base-100 shadow-lg"
+      >
         <div class="card-body flex flex-col gap-3">
-          <h3 class="text-sm font-semibold text-base-content/80">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Smart Catalogue")}</h3>
-          <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item into a different smart catalogue. Its catalogue rules stay attached.")}</p>
+          <h3 class="text-sm font-semibold text-base-content/80">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Smart Catalogue")}
+          </h3>
+          <p class="text-xs text-base-content/50">
+            {Gettext.gettext(
+              PhoenixKitWeb.Gettext,
+              "Move this item into a different smart catalogue. Its catalogue rules stay attached."
+            )}
+          </p>
           <div class="flex items-end gap-3">
             <div class="form-control flex-1">
               <.select
@@ -770,6 +1407,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
             <button
               type="button"
               phx-click="move_item"
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
               disabled={is_nil(@move_target)}
               class="btn btn-sm btn-outline"
             >
@@ -787,5 +1425,87 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       %{name: name} -> name
       _ -> code
     end
+  end
+
+  # `[{label, key}, ...]` options list for the core `<.select>` — only
+  # definitions the user hasn't already attached.
+  defp add_meta_options(%{attached: attached}) do
+    ItemMetadata.definitions()
+    |> Enum.reject(fn def_ -> def_.key in attached end)
+    |> Enum.map(fn def_ -> {def_.label, def_.key} end)
+  end
+
+  # Renders one attached-metadata row. All fields are currently text;
+  # legacy keys (stored but no longer in code) fall into a separate
+  # read-only renderer that surfaces a "Legacy" pill so data isn't
+  # lost silently when a definition is dropped.
+  defp render_meta_row(assigns, key) do
+    value = Map.get(assigns.meta_state.values, key, "")
+
+    case ItemMetadata.definition(key) do
+      nil -> render_legacy_meta_row(assigns, key, value)
+      def_ -> render_text_meta_row(assigns, def_, value)
+    end
+  end
+
+  defp render_text_meta_row(assigns, def_, value) do
+    assigns = assign(assigns, def_: def_, value: value)
+
+    ~H"""
+    <div class="flex-1">
+      <.input
+        type="text"
+        name={"meta[#{@def_.key}]"}
+        id={"meta-#{@def_.key}"}
+        value={@value}
+        label={@def_.label}
+        class="input-sm transition-colors focus:input-primary"
+      />
+    </div>
+    <button
+      type="button"
+      phx-click="remove_meta_field"
+      phx-value-key={@def_.key}
+      class="btn btn-ghost btn-sm btn-square text-error"
+      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove")}
+    >
+      <.icon name="hero-x-mark" class="w-4 h-4" />
+    </button>
+    """
+  end
+
+  # Legacy rows render the "Legacy" pill outside the Input component's
+  # own label slot because that slot only takes a plain string. The
+  # `<.input>` itself stays the single source of input styling.
+  defp render_legacy_meta_row(assigns, key, value) do
+    assigns = assign(assigns, key: key, value: value)
+
+    ~H"""
+    <div class="flex-1">
+      <div class="mb-2 flex items-center gap-2 text-sm">
+        <span class="font-mono">{@key}</span>
+        <span class="badge badge-warning badge-sm">
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Legacy")}
+        </span>
+      </div>
+      <.input
+        type="text"
+        name={"meta_legacy[#{@key}]"}
+        id={"meta-legacy-#{@key}"}
+        value={@value}
+        disabled
+        class="input-sm"
+      />
+    </div>
+    <button
+      type="button"
+      phx-click="remove_meta_field"
+      phx-value-key={@key}
+      class="btn btn-ghost btn-sm btn-square text-error"
+      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove")}
+    >
+      <.icon name="hero-x-mark" class="w-4 h-4" />
+    </button>
+    """
   end
 end

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -391,6 +391,315 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Catalogue.get_category(c1.uuid).position == 1
       assert Catalogue.get_category(c2.uuid).position == 0
     end
+
+    test "swap_category_positions/2 refuses non-siblings" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root", position: 0})
+      child = create_category(cat, %{name: "Child", position: 0, parent_uuid: root.uuid})
+
+      assert {:error, :not_siblings} = Catalogue.swap_category_positions(root, child)
+    end
+
+    test "swap_category_positions/2 refuses cross-catalogue" do
+      cat_a = create_catalogue(%{name: "A"})
+      cat_b = create_catalogue(%{name: "B"})
+      c1 = create_category(cat_a, %{name: "One", position: 0})
+      c2 = create_category(cat_b, %{name: "Two", position: 0})
+
+      assert {:error, :not_siblings} = Catalogue.swap_category_positions(c1, c2)
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # V103: Nested categories
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "nested categories" do
+    test "create_category/2 accepts parent_uuid within same catalogue" do
+      cat = create_catalogue()
+      parent = create_category(cat, %{name: "Parent"})
+
+      assert {:ok, child} =
+               Catalogue.create_category(%{
+                 name: "Child",
+                 catalogue_uuid: cat.uuid,
+                 parent_uuid: parent.uuid
+               })
+
+      assert child.parent_uuid == parent.uuid
+    end
+
+    test "create_category/2 rejects parent from a different catalogue" do
+      cat_a = create_catalogue(%{name: "A"})
+      cat_b = create_catalogue(%{name: "B"})
+      parent_a = create_category(cat_a, %{name: "In A"})
+
+      assert {:error, changeset} =
+               Catalogue.create_category(%{
+                 name: "Orphan",
+                 catalogue_uuid: cat_b.uuid,
+                 parent_uuid: parent_a.uuid
+               })
+
+      assert "must belong to the same catalogue" in errors_on(changeset).parent_uuid
+    end
+
+    test "update_category/2 rejects reparent to a different catalogue's category" do
+      cat_a = create_catalogue(%{name: "A"})
+      cat_b = create_catalogue(%{name: "B"})
+      child = create_category(cat_a, %{name: "Child"})
+      foreign_parent = create_category(cat_b, %{name: "Foreign"})
+
+      assert {:error, changeset} =
+               Catalogue.update_category(child, %{parent_uuid: foreign_parent.uuid})
+
+      assert "must belong to the same catalogue" in errors_on(changeset).parent_uuid
+    end
+
+    test "Category.changeset/2 rejects self-parent on update" do
+      cat = create_catalogue()
+      c = create_category(cat)
+
+      assert {:error, changeset} = Catalogue.update_category(c, %{parent_uuid: c.uuid})
+      assert "category cannot be its own parent" in errors_on(changeset).parent_uuid
+    end
+
+    test "update_category/3 rejects a parent that is a descendant (cycle)" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root"})
+      child = create_category(cat, %{name: "Child", parent_uuid: root.uuid})
+
+      # Try to parent the root under its own descendant via the raw
+      # update path — must be rejected even though `move_category_under`
+      # wasn't used.
+      assert {:error, changeset} = Catalogue.update_category(root, %{parent_uuid: child.uuid})
+      assert "would create a cycle" in errors_on(changeset).parent_uuid
+    end
+
+    test "next_category_position/2 scopes by (catalogue, parent)" do
+      cat = create_catalogue()
+      parent = create_category(cat, %{name: "Parent", position: 0})
+      _other = create_category(cat, %{name: "Other", position: 1})
+
+      # Root-level has two siblings now
+      assert Catalogue.next_category_position(cat.uuid, nil) == 2
+
+      # Under `parent` there are no siblings yet
+      assert Catalogue.next_category_position(cat.uuid, parent.uuid) == 0
+
+      create_category(cat, %{name: "Child1", parent_uuid: parent.uuid, position: 0})
+      create_category(cat, %{name: "Child2", parent_uuid: parent.uuid, position: 5})
+
+      assert Catalogue.next_category_position(cat.uuid, parent.uuid) == 6
+      # Root level is unaffected
+      assert Catalogue.next_category_position(cat.uuid, nil) == 2
+    end
+
+    test "list_category_tree/2 returns depth-first with depths" do
+      cat = create_catalogue()
+      root_a = create_category(cat, %{name: "A", position: 0})
+      root_b = create_category(cat, %{name: "B", position: 1})
+      a1 = create_category(cat, %{name: "A1", parent_uuid: root_a.uuid, position: 0})
+      _a1a = create_category(cat, %{name: "A1a", parent_uuid: a1.uuid, position: 0})
+
+      tree = Catalogue.list_category_tree(cat.uuid)
+      names_and_depths = Enum.map(tree, fn {c, d} -> {c.name, d} end)
+
+      assert names_and_depths == [
+               {"A", 0},
+               {"A1", 1},
+               {"A1a", 2},
+               {"B", 0}
+             ]
+    end
+
+    test "list_category_tree/2 with exclude_subtree_of skips the subtree" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root", position: 0})
+      _mid = create_category(cat, %{name: "Mid", parent_uuid: root.uuid, position: 0})
+      other = create_category(cat, %{name: "Other", position: 1})
+
+      tree = Catalogue.list_category_tree(cat.uuid, exclude_subtree_of: root.uuid)
+
+      assert Enum.map(tree, fn {c, _d} -> c.name end) == [other.name]
+    end
+
+    test "list_category_tree/2 in :active mode promotes orphans to roots when parent is deleted" do
+      cat = create_catalogue()
+      parent = create_category(cat, %{name: "Parent", position: 0})
+      child = create_category(cat, %{name: "Child", parent_uuid: parent.uuid, position: 0})
+
+      # Manually soft-delete the parent without cascading to simulate
+      # a stale state (trash_category cascades; we test the orphan path).
+      SQL.query!(
+        PhoenixKitCatalogue.Test.Repo,
+        "UPDATE phoenix_kit_cat_categories SET status = 'deleted' WHERE uuid = $1",
+        [Ecto.UUID.dump!(parent.uuid)]
+      )
+
+      tree = Catalogue.list_category_tree(cat.uuid)
+
+      assert Enum.any?(tree, fn {c, depth} -> c.uuid == child.uuid and depth == 0 end)
+    end
+  end
+
+  describe "move_category_under/3" do
+    test "reparents within the same catalogue" do
+      cat = create_catalogue()
+      a = create_category(cat, %{name: "A", position: 0})
+      b = create_category(cat, %{name: "B", position: 1})
+
+      assert {:ok, moved} = Catalogue.move_category_under(b, a.uuid)
+      assert moved.parent_uuid == a.uuid
+      # Position updated to next-available under A
+      assert moved.position == 0
+    end
+
+    test "promotes to root when new_parent_uuid is nil" do
+      cat = create_catalogue()
+      parent = create_category(cat, %{name: "Parent", position: 0})
+      child = create_category(cat, %{name: "Child", parent_uuid: parent.uuid, position: 0})
+
+      assert {:ok, moved} = Catalogue.move_category_under(child, nil)
+      assert is_nil(moved.parent_uuid)
+    end
+
+    test "no-op when parent_uuid matches current" do
+      cat = create_catalogue()
+      c = create_category(cat, %{name: "C"})
+
+      assert {:ok, returned} = Catalogue.move_category_under(c, nil)
+      assert returned.uuid == c.uuid
+    end
+
+    test "refuses to set self as parent" do
+      cat = create_catalogue()
+      c = create_category(cat)
+
+      assert {:error, :would_create_cycle} = Catalogue.move_category_under(c, c.uuid)
+    end
+
+    test "refuses to set a descendant as parent" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root"})
+      child = create_category(cat, %{name: "Child", parent_uuid: root.uuid})
+
+      assert {:error, :would_create_cycle} = Catalogue.move_category_under(root, child.uuid)
+    end
+
+    test "refuses cross-catalogue parent" do
+      cat_a = create_catalogue(%{name: "A"})
+      cat_b = create_catalogue(%{name: "B"})
+      in_a = create_category(cat_a, %{name: "In A"})
+      in_b = create_category(cat_b, %{name: "In B"})
+
+      assert {:error, :cross_catalogue} = Catalogue.move_category_under(in_a, in_b.uuid)
+    end
+
+    test "returns :parent_not_found for a missing parent UUID" do
+      cat = create_catalogue()
+      c = create_category(cat)
+      bogus = Ecto.UUID.generate()
+
+      assert {:error, :parent_not_found} = Catalogue.move_category_under(c, bogus)
+    end
+  end
+
+  describe "nested-category cascades" do
+    test "trash_category walks the whole subtree" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root"})
+      mid = create_category(cat, %{name: "Mid", parent_uuid: root.uuid})
+      leaf = create_category(cat, %{name: "Leaf", parent_uuid: mid.uuid})
+      item = create_item(%{name: "Thing", category_uuid: leaf.uuid})
+
+      assert {:ok, _} = Catalogue.trash_category(root)
+
+      assert Catalogue.get_category(mid.uuid).status == "deleted"
+      assert Catalogue.get_category(leaf.uuid).status == "deleted"
+      assert Catalogue.get_item(item.uuid).status == "deleted"
+    end
+
+    test "restore_category restores ancestors upward and subtree downward" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root"})
+      mid = create_category(cat, %{name: "Mid", parent_uuid: root.uuid})
+      leaf = create_category(cat, %{name: "Leaf", parent_uuid: mid.uuid})
+      item = create_item(%{name: "Thing", category_uuid: leaf.uuid})
+
+      {:ok, _} = Catalogue.trash_category(root)
+
+      # Restore from the deepest node; ancestors + subtree should come back.
+      assert {:ok, _} = Catalogue.restore_category(Catalogue.get_category(leaf.uuid))
+
+      assert Catalogue.get_category(root.uuid).status == "active"
+      assert Catalogue.get_category(mid.uuid).status == "active"
+      assert Catalogue.get_category(leaf.uuid).status == "active"
+      assert Catalogue.get_item(item.uuid).status == "active"
+    end
+
+    test "permanently_delete_category hard-deletes the subtree" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root"})
+      mid = create_category(cat, %{name: "Mid", parent_uuid: root.uuid})
+      item = create_item(%{name: "Thing", category_uuid: mid.uuid})
+
+      assert {:ok, _} = Catalogue.permanently_delete_category(root)
+
+      assert is_nil(Catalogue.get_category(root.uuid))
+      assert is_nil(Catalogue.get_category(mid.uuid))
+      assert is_nil(Catalogue.get_item(item.uuid))
+    end
+
+    test "move_category_to_catalogue moves the whole subtree" do
+      cat_src = create_catalogue(%{name: "Source"})
+      cat_dst = create_catalogue(%{name: "Target"})
+      root = create_category(cat_src, %{name: "Root"})
+      child = create_category(cat_src, %{name: "Child", parent_uuid: root.uuid})
+      item = create_item(%{name: "Thing", category_uuid: child.uuid})
+
+      assert {:ok, moved} = Catalogue.move_category_to_catalogue(root, cat_dst.uuid)
+      assert moved.catalogue_uuid == cat_dst.uuid
+      # Root detaches from its (nonexistent) former parent
+      assert is_nil(moved.parent_uuid)
+      # Internal link preserved
+      assert Catalogue.get_category(child.uuid).parent_uuid == root.uuid
+      assert Catalogue.get_category(child.uuid).catalogue_uuid == cat_dst.uuid
+      assert Catalogue.get_item(item.uuid).catalogue_uuid == cat_dst.uuid
+    end
+  end
+
+  describe "search_items/2 with include_descendants" do
+    test "expands a category scope through its subtree by default" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Outdoor"})
+      child = create_category(cat, %{name: "Chairs", parent_uuid: root.uuid})
+      item = create_item(%{name: "Teak Chair", category_uuid: child.uuid})
+
+      # Scoping to the ROOT should still match an item whose category
+      # is a descendant.
+      results = Catalogue.search_items("Teak", category_uuids: [root.uuid])
+      assert Enum.any?(results, &(&1.uuid == item.uuid))
+    end
+
+    test "include_descendants: false restricts to the literal set" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Outdoor"})
+      child = create_category(cat, %{name: "Chairs", parent_uuid: root.uuid})
+      item = create_item(%{name: "Teak Chair", category_uuid: child.uuid})
+
+      results =
+        Catalogue.search_items("Teak",
+          category_uuids: [root.uuid],
+          include_descendants: false
+        )
+
+      refute Enum.any?(results, &(&1.uuid == item.uuid))
+
+      # Direct scope to child still matches
+      direct = Catalogue.search_items("Teak", category_uuids: [child.uuid])
+      assert Enum.any?(direct, &(&1.uuid == item.uuid))
+    end
   end
 
   # ═══════════════════════════════════════════════════════════════════

--- a/test/web/item_picker_test.exs
+++ b/test/web/item_picker_test.exs
@@ -1,0 +1,239 @@
+defmodule PhoenixKitCatalogue.Web.Components.ItemPickerTest do
+  @moduledoc """
+  Render-shape tests for the `ItemPicker` LiveComponent.
+
+  These don't drive the event lifecycle — they just verify the
+  template produces the HTML the hook and the parent LV expect
+  (ARIA attrs, disabled/excluded styling, sentinel rows, wrapper
+  classes). Search behaviour (server-side DB queries) belongs in
+  integration tests.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias PhoenixKitCatalogue.Schemas.{Catalogue, Item}
+  alias PhoenixKitCatalogue.Web.Components.ItemPicker
+
+  defp fake_catalogue do
+    %Catalogue{
+      uuid: "cat-uuid-1",
+      name: "Kitchen",
+      markup_percentage: Decimal.new("0"),
+      discount_percentage: Decimal.new("0"),
+      kind: "standard",
+      data: %{}
+    }
+  end
+
+  defp fake_item(uuid, name) do
+    %Item{
+      uuid: uuid,
+      name: name,
+      base_price: Decimal.new("100.00"),
+      markup_percentage: nil,
+      discount_percentage: nil,
+      catalogue: fake_catalogue(),
+      category: nil,
+      data: %{}
+    }
+  end
+
+  # Short-circuits item_pricing/1 in tests so we don't exercise the
+  # DB or Decimal math — we're verifying the picker's render shape,
+  # not pricing.
+  defp constant_price(_item), do: "€123"
+
+  defp base_assigns(overrides \\ %{}) do
+    Map.merge(
+      %{
+        id: "test-picker",
+        locale: "en",
+        selected_item: nil,
+        excluded_uuids: [],
+        category_uuids: nil,
+        catalogue_uuids: nil,
+        format_price: &constant_price/1
+      },
+      overrides
+    )
+  end
+
+  describe "render shape (closed state)" do
+    test "renders combobox input with required ARIA attrs" do
+      html = render_component(ItemPicker, base_assigns())
+
+      assert html =~ ~s(role="combobox")
+      assert html =~ ~s(aria-expanded="false")
+      assert html =~ ~s(aria-autocomplete="list")
+      assert html =~ ~s(aria-controls="test-picker-listbox")
+    end
+
+    test "renders with phx-hook set to the colocated ItemPicker hook" do
+      html = render_component(ItemPicker, base_assigns())
+
+      assert html =~ ~s(phx-hook=".ItemPicker") or
+               html =~ ~s(phx-hook="PhoenixKitCatalogue.Web.Components.ItemPicker.ItemPicker")
+    end
+
+    test "does not render the listbox when closed" do
+      html = render_component(ItemPicker, base_assigns())
+
+      refute html =~ ~s(id="test-picker-listbox")
+    end
+
+    test "disabled=true disables the input and hides clear button" do
+      html = render_component(ItemPicker, base_assigns(%{disabled: true}))
+
+      assert html =~ "disabled"
+      refute html =~ ~s(phx-click="clear")
+    end
+
+    test "placeholder defaults to gettext 'Search items…'" do
+      html = render_component(ItemPicker, base_assigns())
+      assert html =~ "Search items"
+    end
+
+    test "custom placeholder overrides the default" do
+      html = render_component(ItemPicker, base_assigns(%{placeholder: "Pick a part"}))
+      assert html =~ ~s(placeholder="Pick a part")
+    end
+  end
+
+  describe "render shape (open with options)" do
+    test "renders listbox and options when :open and :options are set" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            options: [fake_item("item-1", "Oak Plank"), fake_item("item-2", "Pine Plank")],
+            has_more: false
+          })
+        )
+
+      assert html =~ ~s(id="test-picker-listbox")
+      assert html =~ ~s(role="listbox")
+      assert html =~ "Oak Plank"
+      assert html =~ "Pine Plank"
+      assert html =~ "€123"
+    end
+
+    test "excluded items get aria-disabled=true and are not clickable" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            options: [
+              fake_item("item-1", "Oak Plank"),
+              fake_item("item-excluded", "Pine Plank")
+            ],
+            excluded_uuids: ["item-excluded"],
+            has_more: false
+          })
+        )
+
+      # The excluded option carries aria-disabled="true"
+      assert html =~ ~s(aria-disabled="true")
+      assert html =~ "Pine Plank"
+    end
+
+    test "selected item gets aria-selected=true" do
+      item = fake_item("item-1", "Oak Plank")
+
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            options: [item],
+            selected_item: item,
+            has_more: false
+          })
+        )
+
+      assert html =~ ~s(aria-selected="true")
+    end
+
+    test "has_more=true shows 'Type to refine search…' sentinel" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            options: [fake_item("item-1", "Oak Plank")],
+            has_more: true
+          })
+        )
+
+      assert html =~ "Type to refine search"
+    end
+
+    test "has_more=false omits the sentinel" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            options: [fake_item("item-1", "Oak Plank")],
+            has_more: false
+          })
+        )
+
+      refute html =~ "Type to refine search"
+    end
+
+    test "empty-options + non-empty query shows 'No items found'" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            query: "xyzzy",
+            options: [],
+            has_more: false
+          })
+        )
+
+      assert html =~ "No items found"
+    end
+  end
+
+  describe "breadcrumb" do
+    test "renders catalogue name when category is nil (uncategorized item)" do
+      item = fake_item("item-1", "Top-level item")
+
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{open: true, options: [item], has_more: false})
+        )
+
+      assert html =~ "Kitchen"
+    end
+  end
+
+  describe "selected_item styling" do
+    test "selected_item non-nil adds input-primary class" do
+      item = fake_item("item-1", "Oak Plank")
+
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{selected_item: item})
+        )
+
+      assert html =~ "input-primary"
+      # Clear button renders
+      assert html =~ ~s(phx-click="clear")
+    end
+
+    test "selected_item nil omits the primary class and clear button" do
+      html = render_component(ItemPicker, base_assigns())
+
+      refute html =~ "input-primary"
+      refute html =~ ~s(phx-click="clear")
+    end
+  end
+end


### PR DESCRIPTION
Consumes phoenix_kit V103 (self-FK `parent_uuid` on categories) and ships three adjacent features on top of it.

Nested categories (V103)
- `Catalogue.Tree` — recursive-CTE helpers (subtree/descendant/ ancestor/breadcrumb) plus pure in-memory walkers for preloaded trees. `UNION` (not `UNION ALL`) makes the CTEs cycle-safe even against corrupted data — the working-set dedupe breaks any cycle.
- `Catalogue.move_category_under/3` — same-catalogue reparent with `:would_create_cycle` / `:cross_catalogue` / `:parent_not_found` rejection; `nil` promotes to root.
- `trash_category` / `restore_category` / `permanently_delete_category` walk the whole subtree in one transaction. `restore_category` also restores deleted ancestors so the restored node is reachable in the active tree. Activity metadata carries `subtree_size` + `items_cascaded`.
- `move_category_to_catalogue` carries the subtree along; `swap_category_positions/3` refuses `:not_siblings`; `next_category_position/2` is scoped to `(catalogue_uuid, parent_uuid)`.
- `list_category_tree/2` returns `[{category, depth}]` with orphan promotion and an `:exclude_subtree_of` option for parent pickers.
- `list_all_categories/0` now renders full breadcrumbs (`"Catalogue / Parent / Child"`) and loads in two queries instead of N+1 per catalogue.
- `search_items/2` gains `:include_descendants` (default `true`) so a category-scoped search also matches items in descendant categories.
- `Category.changeset` rejects self-parent; `create_category/2` and `update_category/3` additionally guard against cross-catalogue and descendant-as-parent (cycle) cases at the context level — so raw API / form callers can't bypass `move_category_under/3`.

Attachments (shared by catalogue + item forms)
- `PhoenixKitCatalogue.Attachments` — folder-per-resource, featured image pointer, inline files dropzone, smart detach (home vs `FolderLink`), pending-folder rename on first save, widened `file_type` bucketing. LVs delegate the whole flow to this module.
- Save button is disabled while uploads are in flight so we don't race `handle_progress` against the save path.

Item metadata
- `PhoenixKitCatalogue.ItemMetadata` — global opt-in fields stored on `item.data["meta"]`. Labels are gettext-wrapped; legacy keys surface as "Legacy" rows with a remove-only action so dropping a definition from code never nukes stored data.

Item picker
- `PhoenixKitCatalogue.Web.Components.ItemPicker` — combobox LiveComponent with server-side search, colocated keyboard hook, `:include_descendants` scoping, and render-shape tests.

Quality fixes
- Catch-all `handle_info/2` on `CatalogueFormLive` and `ItemFormLive` (stray monitor signals used to crash these forms).
- `phx-disable-with` on every Move button (category-under-parent, category-to-catalogue, item-to-category, item-to-smart-catalogue).
- `Attachments.list_files_in_folder/1` capped at 200 rows.
- `Attachments.soft_trash_file/1` is inlined to avoid depending on the unreleased `PhoenixKit.Modules.Storage.trash_file/1`.
- Credo-clean, dialyzer-clean (refactors: nested-too-deep in meta handlers, cyclomatic-10 `file_type_from_mime`, opaque MapSet in `list_category_tree`, unreachable `read_string/2` fallback).

Docs + tests
- `AGENTS.md` and `README.md` document every new surface: tree helpers, `move_category_under`, swap-siblings-only, breadcrumb `list_all_categories`, `include_descendants` search, attachments, item metadata, item picker.
- `catalogue_test.exs` gets ~20 new tests covering cross-catalogue parent rejection on create + update, cycle-on-update guard, `move_category_under/3` (7 scenarios), subtree trash/restore/ permanent-delete, `list_category_tree/2` ordering + orphan promotion + subtree exclusion, `next_category_position/2` parent scoping, and `include_descendants` search.