### PR TITLE
Close #19/#20/#21 + #16/#17 housekeeping — preload opt, evaluate_smart_rules, category_summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,7 @@ This repo contains **no database migrations**. All database tables and migration
 
 ### Setup
 
-The test database is created and migrated by the parent `phoenix_kit` project. This repo assumes the DB already exists with the correct schema.
+The test database is created locally; schema setup runs core's versioned migrations directly via `PhoenixKit.Migration.ensure_current/2` in `test/test_helper.exs`. The helper re-applies any newly-shipped Vxxx migrations on every boot — do **not** swap in `Ecto.Migrator.run([{0, PhoenixKit.Migration}])` (silently goes stale once `0` lands in `schema_migrations`; see `PhoenixKit.Migration.ensure_current/2` moduledoc for the bug story).
 
 The critical config wiring is in `config/test.exs`:
 
@@ -382,7 +382,7 @@ Without this, all DB calls through `PhoenixKit.RepoHelper` crash with "No reposi
 
 ```
 test/
-├── test_helper.exs                  # DB detection, sandbox setup, Ecto.Migrator.run, Phoenix.PubSub start, pgcrypto
+├── test_helper.exs                  # DB detection, sandbox setup, PhoenixKit.Migration.ensure_current/2, Phoenix.PubSub start, pgcrypto
 ├── support/
 │   ├── activity_log_assertions.ex   # `assert_activity_logged/2` + `refute_activity_logged/2` — query phoenix_kit_activities directly with action / actor / resource / metadata-subset matching
 │   ├── data_case.ex                 # DataCase (sandbox + :integration tag, imports ActivityLogAssertions)

--- a/guides/smart_catalogues.md
+++ b/guides/smart_catalogues.md
@@ -113,81 +113,85 @@ delivery would:
 3. For the delivery item, sum each rule: `15% × 100 = 15`.
 4. Set the delivery line's price to `15`.
 
-## 4. Reference implementation
+## 4. Computing prices
+
+Use `Catalogue.evaluate_smart_rules/2` — the canonical implementation
+of the algorithm. It pairs with `Catalogue.item_pricing/1` for the
+smart-catalogue case: standard entries pass through unchanged, smart
+items get a computed price written to a configurable key.
 
 ```elixir
-defmodule MyApp.SmartRules do
-  @moduledoc "Reference: applies CatalogueRule rows to a snapshot."
+alias PhoenixKitCatalogue.Catalogue
 
-  alias PhoenixKitCatalogue.Schemas.{CatalogueRule, Item}
+# Items must have :catalogue (and, for smart items, :catalogue_rules
+# with :referenced_catalogue) preloaded. The bulk fetchers accept a
+# :preload opt for exactly this:
+items =
+  Catalogue.list_items_for_catalogue(catalogue_uuid,
+    preload: [catalogue_rules: :referenced_catalogue]
+  )
 
-  @doc """
-  `entries` is a list of `%{item: %Item{}, qty: integer}`. Items in a
-  smart catalogue must have `:catalogue_rules` and the rules' nested
-  `:referenced_catalogue` preloaded — see "Pitfalls" below.
-  """
-  def apply_rules(entries) do
-    ref_sums = build_ref_sums(entries)
-    Enum.map(entries, &compute_price(&1, ref_sums))
-  end
+entries = Enum.map(items, &%{item: &1, qty: qty_for(&1)})
 
-  # Sum each standard catalogue's contribution to the order. Smart
-  # items deliberately don't contribute — their prices are themselves
-  # rule-computed and would yield 0 anyway.
-  defp build_ref_sums(entries) do
-    entries
-    |> Enum.filter(&(&1.item.catalogue.kind == "standard"))
-    |> Enum.group_by(& &1.item.catalogue_uuid)
-    |> Map.new(fn {catalogue_uuid, group} ->
-      {catalogue_uuid, Enum.reduce(group, Decimal.new(0), &Decimal.add(line_total(&1), &2))}
-    end)
-  end
+priced = Catalogue.evaluate_smart_rules(entries)
+# => standard entries unchanged; smart entries get :smart_price
+```
 
-  defp line_total(%{item: %Item{base_price: nil}}), do: Decimal.new(0)
-  defp line_total(%{item: %Item{base_price: price}, qty: qty}),
-    do: Decimal.mult(price, Decimal.new(qty))
+Default behaviour:
 
-  defp compute_price(%{item: %Item{catalogue: %{kind: "smart"}} = item} = entry, ref_sums) do
-    price =
-      Enum.reduce(item.catalogue_rules, Decimal.new(0), fn rule, acc ->
-        Decimal.add(acc, rule_amount(rule, item, ref_sums))
-      end)
+  * `:line_total` — `entry.item.base_price * entry.qty` (returns 0
+    when `base_price` is `nil`).
+  * `:write_to` — `:smart_price`.
+  * Smart items with no rules get `Decimal.new("0.00")`.
+  * A rule referencing a catalogue not present in `entries` contributes 0.
 
-    Map.put(entry, :computed_price, price)
-  end
+### Customizing line_total
 
-  defp compute_price(entry, _ref_sums), do: entry
+The one piece of consumer policy is what an entry contributes to its
+catalogue's ref-sum. Override `:line_total` to apply discounts before
+smart-pricing, exclude tax, or compose your own snapshot rules:
 
-  defp rule_amount(rule, item, ref_sums) do
-    {value, unit} = CatalogueRule.effective(rule, item)
-    ref_sum = Map.get(ref_sums, rule.referenced_catalogue_uuid, Decimal.new(0))
-
-    case {value, unit} do
-      {nil, _}        -> Decimal.new(0)
-      {v, "percent"}  -> Decimal.div(Decimal.mult(v, ref_sum), Decimal.new(100))
-      {v, "flat"}     -> v
-      {_, _}          -> Decimal.new(0)
-    end
-  end
+```elixir
+discounted_line_total = fn %{item: i, qty: q} ->
+  base = i.base_price |> Decimal.mult(Decimal.new(q))
+  markup = Decimal.add(Decimal.new(1), Decimal.div(i.markup_percentage || 0, 100))
+  discount = Decimal.sub(Decimal.new(1), Decimal.div(i.discount_percentage || 0, 100))
+  base |> Decimal.mult(markup) |> Decimal.mult(discount)
 end
+
+Catalogue.evaluate_smart_rules(entries, line_total: discounted_line_total)
+```
+
+### Customizing the output key
+
+For consumers that want a different field on each entry (e.g. to align
+with their snapshot's column naming):
+
+```elixir
+Catalogue.evaluate_smart_rules(entries, write_to: :computed_price)
 ```
 
 ## 5. Pitfalls
 
 ### Smart items must be loaded with rules preloaded
 
-Neither `Catalogue.list_items_for_category/1` nor
-`Catalogue.search_items/2` preloads `:catalogue_rules`. Hosts that
-render smart prices must do this themselves:
+`Catalogue.list_items_for_category/2`, `list_items_for_catalogue/2`,
+`list_uncategorized_items/2`, `search_items/2`, `get_item/2`,
+`get_item!/2`, and `list_items_by_uuids/2` all accept a `:preload` opt
+that merges into their default preloads. For smart-pricing, pass:
 
 ```elixir
-items
-|> MyApp.Repo.preload(catalogue_rules: :referenced_catalogue)
+Catalogue.list_items_for_catalogue(uuid,
+  preload: [catalogue_rules: :referenced_catalogue]
+)
 ```
 
-`Catalogue.list_catalogue_rules/1` and `Catalogue.catalogue_rule_map/1`
-*do* preload the referenced catalogue, so if you fetch rules separately
-you don't need to chain another preload.
+`evaluate_smart_rules/2` raises `ArgumentError` if `:catalogue` or
+`:catalogue_rules` is `%Ecto.Association.NotLoaded{}` on any entry —
+no silent zero-pricing. `Catalogue.list_catalogue_rules/1` and
+`Catalogue.catalogue_rule_map/1` *do* preload the referenced catalogue
+already, so if you fetch rules separately you don't need to chain
+another preload.
 
 ### `unit` does not inherit at the UI layer (only `value` does)
 

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -55,6 +55,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
     PubSub,
     Rules,
     Search,
+    SmartPricing,
     Suppliers,
     Translations,
     Tree
@@ -774,12 +775,15 @@ defmodule PhoenixKitCatalogue.Catalogue do
       (only deleted items)
     * `:offset` — default `0`
     * `:limit` — default `50`
+    * `:preload` — extra associations appended to the default
+      `[:catalogue, :manufacturer]`.
   """
   @spec list_items_for_category_paged(Ecto.UUID.t(), keyword()) :: [Item.t()]
   def list_items_for_category_paged(category_uuid, opts \\ []) do
     mode = Keyword.get(opts, :mode, :active)
     offset = Keyword.get(opts, :offset, 0)
     limit = Keyword.get(opts, :limit, 50)
+    preloads = Helpers.merge_preloads([:catalogue, :manufacturer], opts)
 
     query =
       from(i in Item,
@@ -787,7 +791,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
         order_by: [asc: i.position, asc: i.name],
         offset: ^offset,
         limit: ^limit,
-        preload: [:catalogue, :manufacturer]
+        preload: ^preloads
       )
 
     query =
@@ -811,12 +815,15 @@ defmodule PhoenixKitCatalogue.Catalogue do
     * `:mode` — `:active` (default) or `:deleted`
     * `:offset` — default `0`
     * `:limit` — default `50`
+    * `:preload` — extra associations appended to the default
+      `[:catalogue, :manufacturer]`.
   """
   @spec list_uncategorized_items_paged(Ecto.UUID.t(), keyword()) :: [Item.t()]
   def list_uncategorized_items_paged(catalogue_uuid, opts \\ []) do
     mode = Keyword.get(opts, :mode, :active)
     offset = Keyword.get(opts, :offset, 0)
     limit = Keyword.get(opts, :limit, 50)
+    preloads = Helpers.merge_preloads([:catalogue, :manufacturer], opts)
 
     query =
       from(i in Item,
@@ -824,7 +831,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
         order_by: [asc: i.position, asc: i.name],
         offset: ^offset,
         limit: ^limit,
-        preload: [:catalogue, :manufacturer]
+        preload: ^preloads
       )
 
     query =
@@ -921,6 +928,65 @@ defmodule PhoenixKitCatalogue.Catalogue do
     |> repo().all()
     |> Map.new()
   end
+
+  @doc """
+  One-shot helper for lazy-loading a catalogue's category tree. Returns
+  category metadata plus per-category and uncategorized item counts in
+  two queries instead of three.
+
+  Combines the work of:
+
+    * `list_categories_metadata_for_catalogue/2`
+    * `item_counts_by_category_for_catalogue/2`
+    * `uncategorized_count_for_catalogue/2`
+
+  Categories are ordered the same way `list_categories_metadata_for_catalogue/2`
+  orders them. Empty categories don't appear in `:item_counts` (treat
+  missing keys as `0`).
+
+  ## Options
+
+    * `:mode` — `:active` (default, excludes deleted) or `:deleted`.
+      Mode is applied uniformly to both the categories query and the
+      item-count query.
+  """
+  @spec category_summary_for_catalogue(Ecto.UUID.t(), keyword()) :: %{
+          categories: [Category.t()],
+          item_counts: %{Ecto.UUID.t() => non_neg_integer()},
+          uncategorized_count: non_neg_integer()
+        }
+  def category_summary_for_catalogue(catalogue_uuid, opts \\ []) do
+    mode = Keyword.get(opts, :mode, :active)
+
+    categories = list_categories_metadata_for_catalogue(catalogue_uuid, mode: mode)
+
+    rows =
+      from(i in Item,
+        where: i.catalogue_uuid == ^catalogue_uuid,
+        group_by: i.category_uuid,
+        select: {i.category_uuid, count(i.uuid)}
+      )
+      |> apply_summary_mode(mode)
+      |> repo().all()
+
+    {item_counts, uncategorized_count} =
+      Enum.reduce(rows, {%{}, 0}, fn
+        {nil, count}, {map, _} -> {map, count}
+        {uuid, count}, {map, uncat} -> {Map.put(map, uuid, count), uncat}
+      end)
+
+    %{
+      categories: categories,
+      item_counts: item_counts,
+      uncategorized_count: uncategorized_count
+    }
+  end
+
+  defp apply_summary_mode(query, :active),
+    do: where(query, [i], i.status != "deleted")
+
+  defp apply_summary_mode(query, :deleted),
+    do: where(query, [i], i.status == "deleted")
 
   @doc """
   Lists all non-deleted categories across all non-deleted catalogues,
@@ -2336,16 +2402,19 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
-  Lists non-deleted items for a category, ordered by name.
+  Lists non-deleted items for a category, ordered by position then name.
 
-  Preloads category (with catalogue) and manufacturer.
+  Default preloads `[:catalogue, category: :catalogue, manufacturer: []]`.
+  Pass `:preload` in `opts` to add more (e.g.
+  `preload: [catalogue_rules: :referenced_catalogue]` for smart-pricing
+  consumers); the lists are concatenated, not replaced.
   """
-  @spec list_items_for_category(Ecto.UUID.t()) :: [Item.t()]
-  def list_items_for_category(category_uuid) do
+  @spec list_items_for_category(Ecto.UUID.t(), keyword()) :: [Item.t()]
+  def list_items_for_category(category_uuid, opts \\ []) do
     from(i in Item,
       where: i.category_uuid == ^category_uuid and i.status != "deleted",
       order_by: [asc: i.position, asc: i.name],
-      preload: [:catalogue, category: :catalogue, manufacturer: []]
+      preload: ^Helpers.merge_preloads([:catalogue, category: :catalogue, manufacturer: []], opts)
     )
     |> repo().all()
   end
@@ -2354,16 +2423,17 @@ defmodule PhoenixKitCatalogue.Catalogue do
   Lists non-deleted items for a catalogue, ordered by category position then
   item name. Includes uncategorized items (those with no category) at the end.
 
-  Preloads catalogue, category (with catalogue) and manufacturer.
+  Default preloads `[:catalogue, category: :catalogue, manufacturer: []]`.
+  Pass `:preload` in `opts` to add more — see `list_items_for_category/2`.
   """
-  @spec list_items_for_catalogue(Ecto.UUID.t()) :: [Item.t()]
-  def list_items_for_catalogue(catalogue_uuid) do
+  @spec list_items_for_catalogue(Ecto.UUID.t(), keyword()) :: [Item.t()]
+  def list_items_for_catalogue(catalogue_uuid, opts \\ []) do
     from(i in Item,
       left_join: c in Category,
       on: i.category_uuid == c.uuid,
       where: i.catalogue_uuid == ^catalogue_uuid and i.status != "deleted",
       order_by: [asc_nulls_last: c.position, asc: i.position, asc: i.name],
-      preload: [:catalogue, category: :catalogue, manufacturer: []]
+      preload: ^Helpers.merge_preloads([:catalogue, category: :catalogue, manufacturer: []], opts)
     )
     |> repo().all()
   end
@@ -2375,6 +2445,9 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
     * `:mode` — `:active` (default) excludes deleted items;
       `:deleted` returns only deleted items.
+    * `:preload` — extra associations appended to the default
+      `[:catalogue, :manufacturer]` preloads. Pass
+      `[catalogue_rules: :referenced_catalogue]` for smart-pricing.
 
   ## Examples
 
@@ -2384,12 +2457,13 @@ defmodule PhoenixKitCatalogue.Catalogue do
   @spec list_uncategorized_items(Ecto.UUID.t(), keyword()) :: [Item.t()]
   def list_uncategorized_items(catalogue_uuid, opts \\ []) do
     mode = Keyword.get(opts, :mode, :active)
+    preloads = Helpers.merge_preloads([:catalogue, :manufacturer], opts)
 
     query =
       from(i in Item,
         where: i.catalogue_uuid == ^catalogue_uuid and is_nil(i.category_uuid),
         order_by: [asc: i.position, asc: i.name],
-        preload: [:manufacturer]
+        preload: ^preloads
       )
 
     query =
@@ -2401,19 +2475,86 @@ defmodule PhoenixKitCatalogue.Catalogue do
     repo().all(query)
   end
 
-  @doc "Fetches an item by UUID without preloads. Returns `nil` if not found."
-  @spec get_item(Ecto.UUID.t()) :: Item.t() | nil
-  def get_item(uuid), do: repo().get(Item, uuid)
+  @doc """
+  Fetches an item by UUID. Returns `nil` if not found.
+
+  ## Options
+
+    * `:preload` — list of associations to preload. Default `[]`.
+      Common smart-pricing preload: `[catalogue_rules: :referenced_catalogue]`.
+
+  ## Examples
+
+      Catalogue.get_item(uuid)
+      Catalogue.get_item(uuid, preload: [:catalogue, catalogue_rules: :referenced_catalogue])
+  """
+  @spec get_item(Ecto.UUID.t(), keyword()) :: Item.t() | nil
+  def get_item(uuid, opts \\ []) do
+    case repo().get(Item, uuid) do
+      nil -> nil
+      item -> repo().preload(item, Keyword.get(opts, :preload, []))
+    end
+  end
 
   @doc """
-  Fetches an item by UUID with preloaded category and manufacturer.
-  Raises `Ecto.NoResultsError` if not found.
+  Fetches an item by UUID with preloaded `:catalogue`, `:category`, and
+  `:manufacturer`. Raises `Ecto.NoResultsError` if not found.
+
+  Pass `:preload` to add more associations (concatenated with the
+  defaults).
   """
-  @spec get_item!(Ecto.UUID.t()) :: Item.t()
-  def get_item!(uuid) do
+  @spec get_item!(Ecto.UUID.t(), keyword()) :: Item.t()
+  def get_item!(uuid, opts \\ []) do
     Item
     |> repo().get!(uuid)
-    |> repo().preload([:category, :manufacturer])
+    |> repo().preload(Helpers.merge_preloads([:catalogue, :category, :manufacturer], opts))
+  end
+
+  @doc """
+  Bulk-fetches items by a list of UUIDs. Excludes soft-deleted items.
+  Result order matches the input UUID order; missing UUIDs are dropped
+  (no `nil` placeholders, no error). Duplicate input UUIDs collapse to
+  a single result.
+
+  Designed for snapshot rehydration — e.g. an order stored as a list of
+  item UUIDs that needs full item data on reload. Avoids the N+1 trap
+  of looping `get_item/1` per UUID.
+
+  ## Options
+
+    * `:preload` — extra associations appended to the default
+      `[:catalogue, :category, :manufacturer]`. Pass
+      `[catalogue_rules: :referenced_catalogue]` for smart-pricing.
+
+  ## Examples
+
+      Catalogue.list_items_by_uuids([uuid1, uuid2, uuid3])
+      Catalogue.list_items_by_uuids(uuids, preload: [catalogue_rules: :referenced_catalogue])
+  """
+  @spec list_items_by_uuids([Ecto.UUID.t()], keyword()) :: [Item.t()]
+  def list_items_by_uuids(uuids, opts \\ [])
+
+  def list_items_by_uuids([], _opts), do: []
+
+  def list_items_by_uuids(uuids, opts) when is_list(uuids) do
+    preloads = Helpers.merge_preloads([:catalogue, :category, :manufacturer], opts)
+
+    items_by_uuid =
+      from(i in Item,
+        where: i.uuid in ^uuids and i.status != "deleted",
+        preload: ^preloads
+      )
+      |> repo().all()
+      |> Map.new(&{&1.uuid, &1})
+
+    uuids
+    |> Enum.uniq()
+    |> Enum.flat_map(fn uuid ->
+      case Map.get(items_by_uuid, uuid) do
+        nil -> []
+        item -> [item]
+      end
+    end)
   end
 
   @doc """
@@ -3121,6 +3262,12 @@ defmodule PhoenixKitCatalogue.Catalogue do
   defdelegate create_catalogue_rule(attrs, opts \\ []), to: Rules
   defdelegate update_catalogue_rule(rule, attrs, opts \\ []), to: Rules
   defdelegate delete_catalogue_rule(rule, opts \\ []), to: Rules
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Smart-catalogue pricing — see PhoenixKitCatalogue.Catalogue.SmartPricing
+  # ═══════════════════════════════════════════════════════════════════
+
+  defdelegate evaluate_smart_rules(entries, opts \\ []), to: SmartPricing
 
   # ═══════════════════════════════════════════════════════════════════
   # Search — see PhoenixKitCatalogue.Catalogue.Search

--- a/lib/phoenix_kit_catalogue/catalogue/helpers.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/helpers.ex
@@ -91,4 +91,17 @@ defmodule PhoenixKitCatalogue.Catalogue.Helpers do
   def dedupe_keep_last(items) when is_list(items) do
     items |> Enum.reverse() |> Enum.uniq() |> Enum.reverse()
   end
+
+  @doc """
+  Concatenates the caller-provided `:preload` opt onto the bulk-fetcher's
+  defaults. Ecto handles atom dedup at preload time, so a caller passing
+  `[:catalogue]` redundantly is safe. Callers passing nested
+  specifications (e.g. `catalogue: :categories`) on a key already
+  present as a bare atom should know what they're doing — Ecto silently
+  prefers the nested spec.
+  """
+  @spec merge_preloads(list(), keyword()) :: list()
+  def merge_preloads(defaults, opts) do
+    defaults ++ Keyword.get(opts, :preload, [])
+  end
 end

--- a/lib/phoenix_kit_catalogue/catalogue/search.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/search.ex
@@ -38,11 +38,15 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
       is a logical contradiction and raises `ArgumentError`.
     * `:limit` — max results (default 50).
     * `:offset` — paging offset (default 0).
+    * `:preload` — extra associations appended to the default
+      `[:catalogue, category: :catalogue, manufacturer: []]`. Pass
+      `[catalogue_rules: :referenced_catalogue]` for smart-pricing.
   """
   @spec search_items(String.t(), keyword()) :: [Item.t()]
   def search_items(query, opts \\ []) do
     limit = Keyword.get(opts, :limit, 50)
     offset = Keyword.get(opts, :offset, 0)
+    preloads = Helpers.merge_preloads([:catalogue, category: :catalogue, manufacturer: []], opts)
 
     # Ordering note: `i.position` is intentionally NOT in the global
     # `search_items/2` order_by. `position` is per-`(catalogue_uuid,
@@ -55,7 +59,7 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
     |> order_by([i, _cat, _c], asc: i.name, asc: i.uuid)
     |> limit(^limit)
     |> offset(^offset)
-    |> preload([:catalogue, category: :catalogue, manufacturer: []])
+    |> preload(^preloads)
     |> repo().all()
   end
 
@@ -76,12 +80,16 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
   around `search_items/2` with `catalogue_uuids: [catalogue_uuid]`,
   but orders by category position first (then item name) for a stable
   walk through a catalogue's categories.
+
+  Same `:preload` opt as `search_items/2` (extra associations appended
+  to the default `[:catalogue, category: :catalogue, manufacturer: []]`).
   """
   @spec search_items_in_catalogue(Ecto.UUID.t(), String.t(), keyword()) :: [Item.t()]
   def search_items_in_catalogue(catalogue_uuid, query, opts \\ []) do
     limit = Keyword.get(opts, :limit, 50)
     offset = Keyword.get(opts, :offset, 0)
     opts = Keyword.put(opts, :catalogue_uuids, [catalogue_uuid])
+    preloads = Helpers.merge_preloads([:catalogue, category: :catalogue, manufacturer: []], opts)
 
     query
     |> search_items_base(opts)
@@ -93,7 +101,7 @@ defmodule PhoenixKitCatalogue.Catalogue.Search do
     )
     |> limit(^limit)
     |> offset(^offset)
-    |> preload([:catalogue, category: :catalogue, manufacturer: []])
+    |> preload(^preloads)
     |> repo().all()
   end
 

--- a/lib/phoenix_kit_catalogue/catalogue/smart_pricing.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/smart_pricing.ex
@@ -1,0 +1,181 @@
+defmodule PhoenixKitCatalogue.Catalogue.SmartPricing do
+  @moduledoc """
+  Public smart-pricing evaluator — the canonical implementation of the
+  algorithm previously documented as a copy-paste reference in
+  `guides/smart_catalogues.md`.
+
+  Mirrors `PhoenixKitCatalogue.Catalogue.item_pricing/1` for the smart
+  case: standard items pass through unchanged; smart items get a
+  computed price written to a configurable key on the entry map.
+
+  The unit semantics (`"percent"`, `"flat"`, `nil` value) and the
+  `CatalogueRule.effective/2` inheritance live here. The one piece of
+  consumer policy — what counts as an entry's contribution to its
+  catalogue's ref-sum — is injected via the `:line_total` option.
+
+  Public surface is re-exported from `PhoenixKitCatalogue.Catalogue` as
+  `evaluate_smart_rules/2`.
+
+  ## Required preloads
+
+  Every entry's `item` must have `:catalogue` preloaded (used for the
+  `kind` check). Smart items must additionally have `:catalogue_rules`
+  preloaded with `:referenced_catalogue` nested inside it. The bulk
+  fetchers in `Catalogue` accept a `:preload` option for exactly this:
+
+      Catalogue.list_items_for_catalogue(uuid,
+        preload: [catalogue_rules: :referenced_catalogue]
+      )
+
+  Missing preloads raise `ArgumentError` with a hint — better than a
+  silent `%Ecto.Association.NotLoaded{}` propagating into `Decimal`
+  math and crashing further downstream.
+
+  ## No rules → 0
+
+  A smart item with no rule rows is written `Decimal.new("0.00")`,
+  matching the reference implementation in the guide. The
+  `default_value` + `default_unit` "ruleless intrinsic fee" pattern is
+  not auto-applied — consumers wanting that behavior should post-process
+  the returned entries (the data is right there on `item.default_*`).
+  """
+
+  alias PhoenixKitCatalogue.Schemas.{CatalogueRule, Item}
+
+  @type entry :: %{
+          required(:item) => Item.t(),
+          required(:qty) => number() | Decimal.t(),
+          optional(any) => any
+        }
+
+  @doc """
+  Computes a price for every smart item in `entries`. Standard entries
+  pass through unchanged.
+
+  ## Options
+
+    * `:line_total` — `(entry -> Decimal.t())`. Computes the
+      contribution of one entry to its catalogue's ref-sum. Defaults to
+      `entry.item.base_price * entry.qty` (returns `Decimal.new(0)`
+      when `base_price` is `nil`). Override to apply discounts before
+      smart-pricing, exclude tax, or anything else your line-total
+      means in your domain.
+
+    * `:write_to` — atom key on each smart-item entry to receive the
+      computed price. Default `:smart_price`. The value is a
+      `Decimal.t()` rounded to 2 decimal places. Standard entries are
+      not modified.
+
+  ## Examples
+
+      # Default behavior — line_total = base_price × qty
+      Catalogue.evaluate_smart_rules([
+        %{item: panel, qty: 1},
+        %{item: hinge, qty: 4},
+        %{item: delivery, qty: 1}
+      ])
+      #=> [
+      #   %{item: panel, qty: 1},
+      #   %{item: hinge, qty: 4},
+      #   %{item: delivery, qty: 1, smart_price: Decimal.new("19.80")}
+      # ]
+
+      # Custom line_total: pre-discount the standard side
+      Catalogue.evaluate_smart_rules(entries,
+        line_total: fn %{item: i, qty: q} ->
+          base = i.base_price |> Decimal.mult(q)
+          markup = Decimal.add(Decimal.new(1), Decimal.div(i.markup_percentage || 0, 100))
+          discount = Decimal.sub(Decimal.new(1), Decimal.div(i.discount_percentage || 0, 100))
+          base |> Decimal.mult(markup) |> Decimal.mult(discount)
+        end,
+        write_to: :computed_price
+      )
+  """
+  @spec evaluate_smart_rules([entry()], keyword()) :: [entry()]
+  def evaluate_smart_rules(entries, opts \\ []) when is_list(entries) do
+    line_total_fn = Keyword.get(opts, :line_total, &default_line_total/1)
+    write_to = Keyword.get(opts, :write_to, :smart_price)
+
+    ref_sums = build_ref_sums(entries, line_total_fn)
+
+    Enum.map(entries, &compute_price(&1, ref_sums, write_to))
+  end
+
+  # Sum each standard catalogue's contribution to the order. Smart items
+  # deliberately don't contribute — their prices are themselves
+  # rule-computed and would yield the wrong answer (or 0) if mixed in.
+  defp build_ref_sums(entries, line_total_fn) do
+    entries
+    |> Enum.filter(&standard?/1)
+    |> Enum.group_by(& &1.item.catalogue_uuid)
+    |> Map.new(fn {uuid, group} ->
+      total =
+        Enum.reduce(group, Decimal.new(0), fn entry, acc ->
+          Decimal.add(acc, line_total_fn.(entry))
+        end)
+
+      {uuid, total}
+    end)
+  end
+
+  # Pattern-match on the preloaded `kind`. NotLoaded is a programmer
+  # error — raise loudly with a hint rather than silently returning 0
+  # everywhere or crashing inside Decimal math.
+  defp standard?(%{item: %Item{catalogue: %{kind: "standard"}}}), do: true
+  defp standard?(%{item: %Item{catalogue: %{kind: "smart"}}}), do: false
+
+  defp standard?(%{item: %Item{catalogue: %Ecto.Association.NotLoaded{}}}) do
+    raise ArgumentError,
+          "evaluate_smart_rules/2 requires :catalogue to be preloaded on every entry's item. " <>
+            "Use Catalogue.list_items_*(... preload: [catalogue_rules: :referenced_catalogue]) " <>
+            "or chain Repo.preload before calling."
+  end
+
+  defp compute_price(
+         %{item: %Item{catalogue: %{kind: "smart"}} = item} = entry,
+         ref_sums,
+         write_to
+       ) do
+    case item.catalogue_rules do
+      %Ecto.Association.NotLoaded{} ->
+        raise ArgumentError,
+              "evaluate_smart_rules/2 requires :catalogue_rules to be preloaded on smart items. " <>
+                "Pass `preload: [catalogue_rules: :referenced_catalogue]` to Catalogue.list_items_*."
+
+      rules when is_list(rules) ->
+        price =
+          rules
+          |> Enum.reduce(Decimal.new(0), fn rule, acc ->
+            Decimal.add(acc, rule_amount(rule, item, ref_sums))
+          end)
+          |> Decimal.round(2)
+
+        Map.put(entry, write_to, price)
+    end
+  end
+
+  # Standard entries pass through untouched. Same shape coming in and out.
+  defp compute_price(entry, _ref_sums, _write_to), do: entry
+
+  defp rule_amount(rule, item, ref_sums) do
+    {value, unit} = CatalogueRule.effective(rule, item)
+    ref_sum = Map.get(ref_sums, rule.referenced_catalogue_uuid, Decimal.new(0))
+
+    case {value, unit} do
+      {nil, _} -> Decimal.new(0)
+      {v, "percent"} -> Decimal.div(Decimal.mult(v, ref_sum), Decimal.new(100))
+      {v, "flat"} -> v
+      {_, _} -> Decimal.new(0)
+    end
+  end
+
+  defp default_line_total(%{item: %Item{base_price: nil}}), do: Decimal.new(0)
+
+  defp default_line_total(%{item: %Item{base_price: price}, qty: qty}) do
+    Decimal.mult(price, to_decimal(qty))
+  end
+
+  defp to_decimal(%Decimal{} = d), do: d
+  defp to_decimal(n) when is_integer(n), do: Decimal.new(n)
+  defp to_decimal(n) when is_float(n), do: Decimal.from_float(n)
+end

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -1935,6 +1935,234 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
     end
   end
 
+  describe ":preload opt on bulk fetchers (issue #19)" do
+    setup do
+      standard = create_catalogue(%{name: "Kitchen"})
+      smart = create_catalogue(%{name: "Services", kind: "smart"})
+      category = create_category(smart, %{name: "Delivery"})
+
+      smart_item =
+        create_item(%{
+          name: "Express Delivery",
+          category_uuid: category.uuid,
+          default_value: Decimal.new("5"),
+          default_unit: "percent"
+        })
+
+      {:ok, _rules} =
+        Catalogue.put_catalogue_rules(smart_item, [
+          %{
+            referenced_catalogue_uuid: standard.uuid,
+            value: Decimal.new("15"),
+            unit: "percent"
+          }
+        ])
+
+      %{smart: smart, category: category, smart_item: smart_item}
+    end
+
+    test "list_items_for_category/2 merges :preload with defaults", %{
+      category: category,
+      smart_item: smart_item
+    } do
+      [item] =
+        Catalogue.list_items_for_category(category.uuid,
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
+
+      assert item.uuid == smart_item.uuid
+      assert %PhoenixKitCatalogue.Schemas.Catalogue{} = item.catalogue
+      [rule] = item.catalogue_rules
+      assert %PhoenixKitCatalogue.Schemas.Catalogue{name: "Kitchen"} = rule.referenced_catalogue
+    end
+
+    test "list_items_for_catalogue/2 merges :preload with defaults", %{
+      smart: smart,
+      smart_item: smart_item
+    } do
+      [item] =
+        Catalogue.list_items_for_catalogue(smart.uuid,
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
+
+      assert item.uuid == smart_item.uuid
+      [rule] = item.catalogue_rules
+      assert rule.referenced_catalogue.name == "Kitchen"
+    end
+
+    test "list_uncategorized_items/2 merges :preload with defaults" do
+      smart = create_catalogue(%{name: "Loose Smart", kind: "smart"})
+      standard = create_catalogue(%{name: "Loose Std"})
+
+      loose =
+        create_item(%{
+          name: "Standalone",
+          catalogue_uuid: smart.uuid,
+          default_value: Decimal.new("10"),
+          default_unit: "flat"
+        })
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(loose, [
+          %{referenced_catalogue_uuid: standard.uuid, value: Decimal.new("5"), unit: "percent"}
+        ])
+
+      [item] =
+        Catalogue.list_uncategorized_items(smart.uuid,
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
+
+      assert item.uuid == loose.uuid
+      assert %PhoenixKitCatalogue.Schemas.Catalogue{} = item.catalogue
+      [rule] = item.catalogue_rules
+      assert rule.referenced_catalogue.name == "Loose Std"
+    end
+
+    test "search_items/2 merges :preload with defaults", %{smart_item: smart_item} do
+      [item] =
+        Catalogue.search_items("Express",
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
+
+      assert item.uuid == smart_item.uuid
+      [rule] = item.catalogue_rules
+      assert rule.referenced_catalogue.name == "Kitchen"
+    end
+
+    test "get_item/2 with :preload returns item with preloaded assocs", %{smart_item: smart_item} do
+      item =
+        Catalogue.get_item(smart_item.uuid, preload: [catalogue_rules: :referenced_catalogue])
+
+      assert item.uuid == smart_item.uuid
+      [rule] = item.catalogue_rules
+      assert rule.referenced_catalogue.name == "Kitchen"
+    end
+
+    test "get_item/1 still works with no preloads (backwards compat)", %{smart_item: smart_item} do
+      item = Catalogue.get_item(smart_item.uuid)
+      assert item.uuid == smart_item.uuid
+      assert %Ecto.Association.NotLoaded{} = item.catalogue_rules
+    end
+
+    test "get_item!/2 default preloads include :catalogue (was missing before)", %{
+      smart_item: smart_item
+    } do
+      item = Catalogue.get_item!(smart_item.uuid)
+
+      assert %PhoenixKitCatalogue.Schemas.Catalogue{} = item.catalogue
+      assert %PhoenixKitCatalogue.Schemas.Category{} = item.category
+    end
+
+    test "get_item!/2 with :preload merges with defaults", %{smart_item: smart_item} do
+      item =
+        Catalogue.get_item!(smart_item.uuid, preload: [catalogue_rules: :referenced_catalogue])
+
+      assert %PhoenixKitCatalogue.Schemas.Catalogue{} = item.catalogue
+      [rule] = item.catalogue_rules
+      assert rule.referenced_catalogue.name == "Kitchen"
+    end
+
+    test ":preload collision with default atom — Ecto merges to nested spec", %{
+      smart_item: smart_item
+    } do
+      # The default preload list includes `:catalogue` as a bare atom.
+      # Pinning the contract: a caller passing a nested spec on the same
+      # key (`catalogue: :categories`) gets both — Ecto loads `:catalogue`
+      # AND its nested `:categories` association. `Helpers.merge_preloads`
+      # docstring warns this is the expected behavior; this test makes
+      # the contract auditable so a future Ecto upgrade that changes the
+      # merge semantics surfaces here.
+      item = Catalogue.get_item!(smart_item.uuid, preload: [catalogue: :categories])
+
+      assert %PhoenixKitCatalogue.Schemas.Catalogue{} = item.catalogue
+      assert is_list(item.catalogue.categories)
+    end
+  end
+
+  describe "list_items_by_uuids/2 (issue #19)" do
+    test "preserves input order" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      b = create_item(%{name: "B", catalogue_uuid: cat.uuid})
+      c = create_item(%{name: "C", catalogue_uuid: cat.uuid})
+
+      result = Catalogue.list_items_by_uuids([c.uuid, a.uuid, b.uuid])
+
+      assert Enum.map(result, & &1.uuid) == [c.uuid, a.uuid, b.uuid]
+    end
+
+    test "drops missing UUIDs (no nil placeholders)" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      missing = Ecto.UUID.generate()
+
+      result = Catalogue.list_items_by_uuids([a.uuid, missing])
+
+      assert Enum.map(result, & &1.uuid) == [a.uuid]
+    end
+
+    test "excludes soft-deleted items" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      b = create_item(%{name: "B", catalogue_uuid: cat.uuid})
+      Catalogue.trash_item(b)
+
+      result = Catalogue.list_items_by_uuids([a.uuid, b.uuid])
+
+      assert Enum.map(result, & &1.uuid) == [a.uuid]
+    end
+
+    test "deduplicates input UUIDs" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+
+      result = Catalogue.list_items_by_uuids([a.uuid, a.uuid, a.uuid])
+
+      assert Enum.map(result, & &1.uuid) == [a.uuid]
+    end
+
+    test "returns [] for empty input without hitting the DB" do
+      assert Catalogue.list_items_by_uuids([]) == []
+    end
+
+    test "default preloads include :catalogue, :category, :manufacturer" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      a = create_item(%{name: "A", category_uuid: category.uuid})
+
+      [item] = Catalogue.list_items_by_uuids([a.uuid])
+
+      assert %PhoenixKitCatalogue.Schemas.Catalogue{} = item.catalogue
+      assert %PhoenixKitCatalogue.Schemas.Category{} = item.category
+    end
+
+    test "merges :preload with defaults (smart-rule rehydration use case)" do
+      standard = create_catalogue(%{name: "Std"})
+      smart = create_catalogue(%{name: "Smart", kind: "smart"})
+
+      smart_item =
+        create_item(%{
+          name: "S",
+          catalogue_uuid: smart.uuid,
+          default_value: Decimal.new("5"),
+          default_unit: "percent"
+        })
+
+      {:ok, _} =
+        Catalogue.put_catalogue_rules(smart_item, [
+          %{referenced_catalogue_uuid: standard.uuid, value: Decimal.new("10"), unit: "percent"}
+        ])
+
+      [item] =
+        Catalogue.list_items_by_uuids([smart_item.uuid],
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
+
+      [rule] = item.catalogue_rules
+      assert rule.referenced_catalogue.name == "Std"
+    end
+  end
+
   describe "paged helpers for infinite scroll" do
     test "list_categories_metadata_for_catalogue/2 returns categories without items, ordered by position" do
       cat = create_catalogue()
@@ -2139,6 +2367,52 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
 
       counts = Catalogue.item_counts_by_category_for_catalogue(cat.uuid)
       assert counts == %{cat_a.uuid => 1}
+    end
+
+    test "category_summary_for_catalogue/2 returns categories + counts + uncategorized in one shape" do
+      cat = create_catalogue()
+      cat_a = create_category(cat, %{name: "A", position: 1})
+      cat_b = create_category(cat, %{name: "B", position: 2})
+      _empty = create_category(cat, %{name: "Empty", position: 3})
+
+      for _ <- 1..3, do: create_item(%{name: "x", category_uuid: cat_a.uuid})
+      for _ <- 1..2, do: create_item(%{name: "y", category_uuid: cat_b.uuid})
+      create_item(%{name: "loose 1", catalogue_uuid: cat.uuid})
+      create_item(%{name: "loose 2", catalogue_uuid: cat.uuid})
+
+      summary = Catalogue.category_summary_for_catalogue(cat.uuid)
+
+      assert Enum.map(summary.categories, & &1.name) == ["A", "B", "Empty"]
+      assert summary.item_counts == %{cat_a.uuid => 3, cat_b.uuid => 2}
+      assert summary.uncategorized_count == 2
+    end
+
+    test "category_summary_for_catalogue/2 excludes deleted items in :active mode" do
+      cat = create_catalogue()
+      cat_a = create_category(cat, %{name: "A"})
+      create_item(%{name: "live", category_uuid: cat_a.uuid})
+      trashed = create_item(%{name: "dead", category_uuid: cat_a.uuid})
+      Catalogue.trash_item(trashed)
+
+      loose_trashed = create_item(%{name: "loose dead", catalogue_uuid: cat.uuid})
+      Catalogue.trash_item(loose_trashed)
+      create_item(%{name: "loose live", catalogue_uuid: cat.uuid})
+
+      active = Catalogue.category_summary_for_catalogue(cat.uuid)
+      deleted = Catalogue.category_summary_for_catalogue(cat.uuid, mode: :deleted)
+
+      assert active.item_counts == %{cat_a.uuid => 1}
+      assert active.uncategorized_count == 1
+
+      assert deleted.item_counts == %{cat_a.uuid => 1}
+      assert deleted.uncategorized_count == 1
+    end
+
+    test "category_summary_for_catalogue/2 omits empty catalogues + still returns a valid shape" do
+      cat = create_catalogue()
+
+      assert Catalogue.category_summary_for_catalogue(cat.uuid) ==
+               %{categories: [], item_counts: %{}, uncategorized_count: 0}
     end
   end
 

--- a/test/smart_catalogues_guide_test.exs
+++ b/test/smart_catalogues_guide_test.exs
@@ -1,64 +1,19 @@
 defmodule PhoenixKitCatalogue.SmartCataloguesGuideTest do
   @moduledoc """
   Exercises the worked example from `guides/smart_catalogues.md` end
-  to end. The reference implementation in the guide is repeated here
-  as `Apply` — keep them in sync. If this test breaks, either the
-  guide's example or the consumer-side math contract has shifted, and
-  the guide needs updating to match.
+  to end against real DB-loaded items. The guide directs consumers to
+  `Catalogue.evaluate_smart_rules/2`; this test calls it the same way
+  the guide tells them to. If this test breaks, either the guide is
+  out of date or the public evaluator's contract has shifted.
+
+  Pure-function coverage of every branch (NULL inheritance, missing
+  refs, NotLoaded guards, custom :line_total, etc.) lives in
+  `test/smart_pricing_test.exs`.
   """
 
   use PhoenixKitCatalogue.DataCase, async: true
 
   alias PhoenixKitCatalogue.Catalogue
-  alias PhoenixKitCatalogue.Schemas.{CatalogueRule, Item}
-
-  defmodule Apply do
-    @moduledoc false
-    # Verbatim transcription of the reference implementation in
-    # guides/smart_catalogues.md §4. Keep them in lockstep.
-
-    def apply_rules(entries) do
-      ref_sums = build_ref_sums(entries)
-      Enum.map(entries, &compute_price(&1, ref_sums))
-    end
-
-    defp build_ref_sums(entries) do
-      entries
-      |> Enum.filter(&(&1.item.catalogue.kind == "standard"))
-      |> Enum.group_by(& &1.item.catalogue_uuid)
-      |> Map.new(fn {catalogue_uuid, group} ->
-        {catalogue_uuid, Enum.reduce(group, Decimal.new(0), &Decimal.add(line_total(&1), &2))}
-      end)
-    end
-
-    defp line_total(%{item: %Item{base_price: nil}}), do: Decimal.new(0)
-
-    defp line_total(%{item: %Item{base_price: price}, qty: qty}),
-      do: Decimal.mult(price, Decimal.new(qty))
-
-    defp compute_price(%{item: %Item{catalogue: %{kind: "smart"}} = item} = entry, ref_sums) do
-      price =
-        Enum.reduce(item.catalogue_rules, Decimal.new(0), fn rule, acc ->
-          Decimal.add(acc, rule_amount(rule, item, ref_sums))
-        end)
-
-      Map.put(entry, :computed_price, price)
-    end
-
-    defp compute_price(entry, _ref_sums), do: entry
-
-    defp rule_amount(rule, item, ref_sums) do
-      {value, unit} = CatalogueRule.effective(rule, item)
-      ref_sum = Map.get(ref_sums, rule.referenced_catalogue_uuid, Decimal.new(0))
-
-      case {value, unit} do
-        {nil, _} -> Decimal.new(0)
-        {v, "percent"} -> Decimal.div(Decimal.mult(v, ref_sum), Decimal.new(100))
-        {v, "flat"} -> v
-        {_, _} -> Decimal.new(0)
-      end
-    end
-  end
 
   describe "guide §3 worked example: 15% delivery on a kitchen line" do
     test "smart item's computed price is 15% of the standard line total" do
@@ -90,21 +45,19 @@ defmodule PhoenixKitCatalogue.SmartCataloguesGuideTest do
           }
         ])
 
-      panel_loaded = repo().preload(panel, [:catalogue, :catalogue_rules])
+      [panel_loaded, delivery_loaded] =
+        Catalogue.list_items_by_uuids([panel.uuid, delivery.uuid],
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
 
-      delivery_loaded =
-        repo().preload(delivery, [:catalogue, catalogue_rules: :referenced_catalogue])
-
-      entries =
-        Apply.apply_rules([
+      [panel_entry, delivery_entry] =
+        Catalogue.evaluate_smart_rules([
           %{item: panel_loaded, qty: 1},
           %{item: delivery_loaded, qty: 1}
         ])
 
-      [panel_entry, delivery_entry] = entries
-
-      refute Map.has_key?(panel_entry, :computed_price)
-      assert Decimal.equal?(delivery_entry.computed_price, Decimal.new("15"))
+      refute Map.has_key?(panel_entry, :smart_price)
+      assert Decimal.equal?(delivery_entry.smart_price, Decimal.new("15"))
     end
 
     test "rule with NULL value inherits item.default_value (data-layer fallback)" do
@@ -132,19 +85,19 @@ defmodule PhoenixKitCatalogue.SmartCataloguesGuideTest do
           %{referenced_catalogue_uuid: kitchen.uuid, value: nil, unit: "percent"}
         ])
 
-      panel_loaded = repo().preload(panel, [:catalogue, :catalogue_rules])
-
-      delivery_loaded =
-        repo().preload(delivery, [:catalogue, catalogue_rules: :referenced_catalogue])
+      [panel_loaded, delivery_loaded] =
+        Catalogue.list_items_by_uuids([panel.uuid, delivery.uuid],
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
 
       [_, delivery_entry] =
-        Apply.apply_rules([
+        Catalogue.evaluate_smart_rules([
           %{item: panel_loaded, qty: 1},
           %{item: delivery_loaded, qty: 1}
         ])
 
       # 10% (inherited from default_value) of 200 = 20
-      assert Decimal.equal?(delivery_entry.computed_price, Decimal.new("20"))
+      assert Decimal.equal?(delivery_entry.smart_price, Decimal.new("20"))
     end
 
     test "flat unit ignores ref_sum and uses the value directly" do
@@ -172,20 +125,18 @@ defmodule PhoenixKitCatalogue.SmartCataloguesGuideTest do
           %{referenced_catalogue_uuid: kitchen.uuid, value: Decimal.new("20"), unit: "flat"}
         ])
 
-      panel_loaded = repo().preload(panel, [:catalogue, :catalogue_rules])
-
-      delivery_loaded =
-        repo().preload(delivery, [:catalogue, catalogue_rules: :referenced_catalogue])
+      [panel_loaded, delivery_loaded] =
+        Catalogue.list_items_by_uuids([panel.uuid, delivery.uuid],
+          preload: [catalogue_rules: :referenced_catalogue]
+        )
 
       [_, delivery_entry] =
-        Apply.apply_rules([
+        Catalogue.evaluate_smart_rules([
           %{item: panel_loaded, qty: 1},
           %{item: delivery_loaded, qty: 1}
         ])
 
-      assert Decimal.equal?(delivery_entry.computed_price, Decimal.new("20"))
+      assert Decimal.equal?(delivery_entry.smart_price, Decimal.new("20"))
     end
   end
-
-  defp repo, do: PhoenixKit.RepoHelper.repo()
 end

--- a/test/smart_pricing_test.exs
+++ b/test/smart_pricing_test.exs
@@ -1,0 +1,451 @@
+defmodule PhoenixKitCatalogue.SmartPricingTest do
+  @moduledoc """
+  Unit tests for the public smart-rules evaluator
+  (`PhoenixKitCatalogue.Catalogue.evaluate_smart_rules/2`).
+
+  All cases are pure — entries are plain structs/maps, no DB round trip
+  — so we can exercise every branch of the algorithm without sandbox
+  setup. Integration coverage that smart items hydrated from the DB
+  flow through correctly lives in `test/smart_catalogues_guide_test.exs`
+  and the `:preload` opt tests in `test/catalogue_test.exs`.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKitCatalogue.Catalogue
+  alias PhoenixKitCatalogue.Schemas.Catalogue, as: CatalogueSchema
+  alias PhoenixKitCatalogue.Schemas.{CatalogueRule, Item}
+
+  defp standard_catalogue(uuid \\ Ecto.UUID.generate()) do
+    %CatalogueSchema{uuid: uuid, kind: "standard", name: "Standard #{uuid}"}
+  end
+
+  defp smart_catalogue(uuid \\ Ecto.UUID.generate()) do
+    %CatalogueSchema{uuid: uuid, kind: "smart", name: "Smart #{uuid}"}
+  end
+
+  defp standard_item(catalogue, attrs \\ %{}) do
+    base = %Item{
+      uuid: Ecto.UUID.generate(),
+      name: "Std Item",
+      base_price: Decimal.new("100"),
+      catalogue_uuid: catalogue.uuid,
+      catalogue: catalogue,
+      catalogue_rules: []
+    }
+
+    Map.merge(base, attrs)
+  end
+
+  defp smart_item(catalogue, rules, attrs \\ %{}) do
+    base = %Item{
+      uuid: Ecto.UUID.generate(),
+      name: "Smart Item",
+      catalogue_uuid: catalogue.uuid,
+      catalogue: catalogue,
+      catalogue_rules: rules
+    }
+
+    Map.merge(base, attrs)
+  end
+
+  defp percent_rule(referenced_catalogue_uuid, value) do
+    %CatalogueRule{
+      uuid: Ecto.UUID.generate(),
+      referenced_catalogue_uuid: referenced_catalogue_uuid,
+      value: Decimal.new(value),
+      unit: "percent",
+      position: 0
+    }
+  end
+
+  defp flat_rule(referenced_catalogue_uuid, value) do
+    %CatalogueRule{
+      uuid: Ecto.UUID.generate(),
+      referenced_catalogue_uuid: referenced_catalogue_uuid,
+      value: Decimal.new(value),
+      unit: "flat",
+      position: 0
+    }
+  end
+
+  describe "evaluate_smart_rules/2 — pass-through" do
+    test "returns standard entries unchanged" do
+      kitchen = standard_catalogue()
+      panel = standard_item(kitchen)
+      entry = %{item: panel, qty: 2}
+
+      assert [^entry] = Catalogue.evaluate_smart_rules([entry])
+    end
+
+    test "empty input returns empty list" do
+      assert Catalogue.evaluate_smart_rules([]) == []
+    end
+
+    test "returns standard entries unchanged even when smart entries exist alongside" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen)
+      delivery = smart_item(services, [percent_rule(kitchen.uuid, "10")])
+
+      [out_panel, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 1},
+          %{item: delivery, qty: 1}
+        ])
+
+      assert out_panel == %{item: panel, qty: 1}
+      refute Map.has_key?(out_panel, :smart_price)
+      assert out_delivery.smart_price == Decimal.new("10.00")
+    end
+  end
+
+  describe "evaluate_smart_rules/2 — percent rules" do
+    test "writes computed price for one rule" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("200")})
+      delivery = smart_item(services, [percent_rule(kitchen.uuid, "15")])
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 1},
+          %{item: delivery, qty: 1}
+        ])
+
+      # 15% of 200 = 30.00
+      assert out_delivery.smart_price == Decimal.new("30.00")
+    end
+
+    test "sums multiple rules from the same smart item" do
+      kitchen = standard_catalogue()
+      plumbing = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+      pipe = standard_item(plumbing, %{base_price: Decimal.new("50")})
+
+      delivery =
+        smart_item(services, [
+          percent_rule(kitchen.uuid, "15"),
+          percent_rule(plumbing.uuid, "5")
+        ])
+
+      [_, _, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 1},
+          %{item: pipe, qty: 1},
+          %{item: delivery, qty: 1}
+        ])
+
+      # 15% of 100 + 5% of 50 = 15.00 + 2.50 = 17.50
+      assert out_delivery.smart_price == Decimal.new("17.50")
+    end
+
+    test "ref_sum aggregates qty across same-catalogue entries" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+      delivery = smart_item(services, [percent_rule(kitchen.uuid, "10")])
+
+      [_, _, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 2},
+          %{item: panel, qty: 3},
+          %{item: delivery, qty: 1}
+        ])
+
+      # ref_sum for kitchen = (100 × 2) + (100 × 3) = 500
+      # 10% of 500 = 50.00
+      assert out_delivery.smart_price == Decimal.new("50.00")
+    end
+  end
+
+  describe "evaluate_smart_rules/2 — flat rules" do
+    test "writes the flat value regardless of ref_sum" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("999")})
+      delivery = smart_item(services, [flat_rule(kitchen.uuid, "20")])
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 5},
+          %{item: delivery, qty: 1}
+        ])
+
+      assert out_delivery.smart_price == Decimal.new("20.00")
+    end
+
+    test "mixed flat + percent rules sum correctly" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+
+      delivery =
+        smart_item(services, [
+          flat_rule(kitchen.uuid, "20"),
+          percent_rule(kitchen.uuid, "5")
+        ])
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 1},
+          %{item: delivery, qty: 1}
+        ])
+
+      # 20 (flat) + 5% of 100 = 20 + 5 = 25.00
+      assert out_delivery.smart_price == Decimal.new("25.00")
+    end
+  end
+
+  describe "evaluate_smart_rules/2 — value inheritance" do
+    test "rule with NULL value falls back to item.default_value" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+
+      rule = %CatalogueRule{
+        uuid: Ecto.UUID.generate(),
+        referenced_catalogue_uuid: kitchen.uuid,
+        value: nil,
+        unit: "percent",
+        position: 0
+      }
+
+      delivery =
+        smart_item(services, [rule], %{
+          default_value: Decimal.new("8"),
+          default_unit: "percent"
+        })
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 1},
+          %{item: delivery, qty: 1}
+        ])
+
+      # 8% (inherited) of 100 = 8.00
+      assert out_delivery.smart_price == Decimal.new("8.00")
+    end
+
+    test "rule with NULL value AND no item default → 0 contribution" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+
+      rule = %CatalogueRule{
+        uuid: Ecto.UUID.generate(),
+        referenced_catalogue_uuid: kitchen.uuid,
+        value: nil,
+        unit: "percent",
+        position: 0
+      }
+
+      delivery = smart_item(services, [rule])
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 1},
+          %{item: delivery, qty: 1}
+        ])
+
+      assert out_delivery.smart_price == Decimal.new("0.00")
+    end
+  end
+
+  describe "evaluate_smart_rules/2 — edge cases" do
+    test "smart item with no rules → 0 (matches reference impl)" do
+      services = smart_catalogue()
+      delivery = smart_item(services, [])
+
+      [out] = Catalogue.evaluate_smart_rules([%{item: delivery, qty: 1}])
+
+      assert out.smart_price == Decimal.new("0.00")
+    end
+
+    test "rule referencing a catalogue not in the entry list → 0 contribution" do
+      services = smart_catalogue()
+      missing = standard_catalogue()
+      delivery = smart_item(services, [percent_rule(missing.uuid, "50")])
+
+      [out] = Catalogue.evaluate_smart_rules([%{item: delivery, qty: 1}])
+
+      assert out.smart_price == Decimal.new("0.00")
+    end
+
+    test "rule with unknown unit (not percent/flat) → 0 contribution" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+
+      bogus_rule = %CatalogueRule{
+        uuid: Ecto.UUID.generate(),
+        referenced_catalogue_uuid: kitchen.uuid,
+        value: Decimal.new("50"),
+        unit: "bogus_unit",
+        position: 0
+      }
+
+      delivery = smart_item(services, [bogus_rule])
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: panel, qty: 1},
+          %{item: delivery, qty: 1}
+        ])
+
+      # Pins the {_, _} -> 0 fallback in `rule_amount/3`. If a future
+      # migration adds a new unit (`per_meter`, etc.) the evaluator
+      # falls through to 0 silently — flag this test if you add a new
+      # unit so the fallback is intentional, not forgotten.
+      assert out_delivery.smart_price == Decimal.new("0.00")
+    end
+
+    test "standard item with nil base_price contributes 0 to ref_sums" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      free_panel = standard_item(kitchen, %{base_price: nil})
+      delivery = smart_item(services, [percent_rule(kitchen.uuid, "10")])
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules([
+          %{item: free_panel, qty: 5},
+          %{item: delivery, qty: 1}
+        ])
+
+      assert out_delivery.smart_price == Decimal.new("0.00")
+    end
+
+    test "smart items don't contribute to ref_sums (smart→standard rule with smart entry)" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      # Two smart items in the same smart catalogue. If smart contributed,
+      # delivery_b would include itself indirectly via ref_sums.
+      delivery_a =
+        smart_item(services, [flat_rule(kitchen.uuid, "10")], %{
+          base_price: Decimal.new("999")
+        })
+
+      delivery_b = smart_item(services, [percent_rule(services.uuid, "100")])
+
+      [_, out_b] =
+        Catalogue.evaluate_smart_rules([
+          %{item: delivery_a, qty: 1},
+          %{item: delivery_b, qty: 1}
+        ])
+
+      # ref_sum for services should be empty (only standard items contribute);
+      # 100% of 0 = 0.
+      assert out_b.smart_price == Decimal.new("0.00")
+    end
+
+    test "qty accepts integer, Decimal, and float" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+      delivery = smart_item(services, [percent_rule(kitchen.uuid, "10")])
+
+      for qty <- [3, Decimal.new("3"), 3.0] do
+        [_, out_delivery] =
+          Catalogue.evaluate_smart_rules([
+            %{item: panel, qty: qty},
+            %{item: delivery, qty: 1}
+          ])
+
+        # 10% of (100 × 3) = 30.00
+        assert Decimal.equal?(out_delivery.smart_price, Decimal.new("30.00")),
+               "qty #{inspect(qty)} produced #{out_delivery.smart_price}"
+      end
+    end
+  end
+
+  describe "evaluate_smart_rules/2 — preload guards" do
+    test "raises ArgumentError when item.catalogue is NotLoaded" do
+      services = smart_catalogue()
+      delivery = smart_item(services, [])
+      bad_item = %{delivery | catalogue: %Ecto.Association.NotLoaded{}}
+
+      assert_raise ArgumentError, ~r/:catalogue to be preloaded/, fn ->
+        Catalogue.evaluate_smart_rules([%{item: bad_item, qty: 1}])
+      end
+    end
+
+    test "raises ArgumentError when smart item.catalogue_rules is NotLoaded" do
+      services = smart_catalogue()
+      delivery = smart_item(services, [])
+      bad_item = %{delivery | catalogue_rules: %Ecto.Association.NotLoaded{}}
+
+      assert_raise ArgumentError, ~r/:catalogue_rules to be preloaded/, fn ->
+        Catalogue.evaluate_smart_rules([%{item: bad_item, qty: 1}])
+      end
+    end
+  end
+
+  describe "evaluate_smart_rules/2 — :write_to opt" do
+    test "uses the configured key" do
+      services = smart_catalogue()
+      delivery = smart_item(services, [])
+
+      [out] =
+        Catalogue.evaluate_smart_rules([%{item: delivery, qty: 1}], write_to: :computed_price)
+
+      assert out.computed_price == Decimal.new("0.00")
+      refute Map.has_key?(out, :smart_price)
+    end
+  end
+
+  describe "evaluate_smart_rules/2 — :line_total opt" do
+    test "custom line_total controls the ref_sum" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+      panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
+      delivery = smart_item(services, [percent_rule(kitchen.uuid, "10")])
+
+      # Override: each entry contributes 1000 regardless of price/qty
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules(
+          [
+            %{item: panel, qty: 1},
+            %{item: delivery, qty: 1}
+          ],
+          line_total: fn _entry -> Decimal.new("1000") end
+        )
+
+      # 10% of 1000 = 100.00
+      assert out_delivery.smart_price == Decimal.new("100.00")
+    end
+
+    test "custom line_total models discount-pre-rule (the issue author's case)" do
+      kitchen = standard_catalogue()
+      services = smart_catalogue()
+
+      # Standard item with a 10% discount baked into the line total
+      panel =
+        standard_item(kitchen, %{
+          base_price: Decimal.new("100"),
+          discount_percentage: Decimal.new("10")
+        })
+
+      delivery = smart_item(services, [percent_rule(kitchen.uuid, "15")])
+
+      discounted_line_total = fn %{item: i, qty: q} ->
+        i.base_price
+        |> Decimal.mult(Decimal.new(q))
+        |> Decimal.mult(
+          Decimal.sub(Decimal.new(1), Decimal.div(i.discount_percentage, Decimal.new(100)))
+        )
+      end
+
+      [_, out_delivery] =
+        Catalogue.evaluate_smart_rules(
+          [
+            %{item: panel, qty: 1},
+            %{item: delivery, qty: 1}
+          ],
+          line_total: discounted_line_total
+        )
+
+      # ref_sum = 100 × 1 × 0.9 = 90; 15% of 90 = 13.50
+      assert out_delivery.smart_price == Decimal.new("13.50")
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -50,19 +50,19 @@ repo_available =
     try do
       {:ok, _} = PhoenixKitCatalogue.Test.Repo.start_link()
 
-      # Build the schema directly from core's versioned migrations — same
-      # call the host app makes in production. The catalogue tables come
-      # from core (V87 creates them; V89 / V96 / V97 / V102 / V103 / V108
-      # evolve them) along with phoenix_kit_settings (V03), the storage
-      # family (V20+), and the `uuid-ossp` / `pgcrypto` extensions and
-      # `uuid_generate_v7()` function (V40). No module-owned DDL anywhere.
-      Ecto.Migrator.run(
-        PhoenixKitCatalogue.Test.Repo,
-        [{0, PhoenixKit.Migration}],
-        :up,
-        all: true,
-        log: false
-      )
+      # Build the schema directly from core's versioned migrations.
+      # `ensure_current/2` re-applies any newly-shipped Vxxx migrations
+      # on every boot — the older
+      # `Ecto.Migrator.run([{0, PhoenixKit.Migration}])` pattern was
+      # idempotent at the outer Ecto.Migrator layer (version `0`
+      # cached in `schema_migrations`), so newly-shipped Vxxx versions
+      # silently never applied. The catalogue tables come from core
+      # (V87 creates them; V89 / V96 / V97 / V102 / V103 / V108 evolve
+      # them) along with phoenix_kit_settings (V03), the storage
+      # family (V20+), and the `uuid-ossp` / `pgcrypto` extensions +
+      # `uuid_generate_v7()` function (V40). No module-owned DDL
+      # anywhere.
+      PhoenixKit.Migration.ensure_current(PhoenixKitCatalogue.Test.Repo, log: false)
 
       Ecto.Adapters.SQL.Sandbox.mode(PhoenixKitCatalogue.Test.Repo, :manual)
       true


### PR DESCRIPTION
## Summary

Closes four open issues (#19, #20, #21) plus housekeeping closures for
#16 and #17 (already shipped in PR #18; never auto-closed).

Pairs with `BeamLabEU/phoenix_kit#515` — companion PR landing the
`PhoenixKit.Migration.ensure_current/2` helper that this PR's
`test_helper.exs` calls. Merge them together.

## Changes

### #19 — `:preload` on bulk fetchers + `list_items_by_uuids/2`

- `:preload` opt threads through `search_items/2`,
  `list_items_for_category/2`, `list_items_for_catalogue/2`,
  `list_uncategorized_items/2`, `list_items_for_category_paged/2`,
  `list_uncategorized_items_paged/2`. Concatenates onto each function's
  default preload list — Ecto dedups atoms.
- `get_item/2` arity-2 (was bare `repo.get`). `get_item!/2` defaults
  expanded to `[:catalogue, :category, :manufacturer]` (the bare-1
  arity was silently missing `:catalogue`).
- New `list_items_by_uuids/2` — order-preserving, soft-delete excluded,
  deduped, no `nil` placeholders for missing UUIDs. Designed for
  order-snapshot rehydration without leaking `Repo` to consumers.

### #20 — `Catalogue.evaluate_smart_rules/2`

The package now owns the canonical algorithm; consumers stop forking
the 100-line reference impl from the guide.

- New submodule `PhoenixKitCatalogue.Catalogue.SmartPricing`. Matches
  the existing `Rules` / `Search` / `Counts` pattern.
- Mirrors `item_pricing/1` for the smart case — standard entries pass
  through unchanged; smart items get a computed price written to
  `:smart_price` (configurable via `:write_to`).
- Single consumer-policy injection point: `:line_total` lambda. Default
  `base_price × qty` matches the old reference impl. Override for
  discount-pre-rule pricing or any other line-total flavor.
- Raises `ArgumentError` when `:catalogue` or `:catalogue_rules` is
  `%NotLoaded{}` on any entry — the new `:preload` opt above makes the
  right preloads a one-line addition.
- `guides/smart_catalogues.md` §4 rewritten to call the public
  function directly. The reference-impl copy-paste is gone.

### #21 — `Catalogue.category_summary_for_catalogue/2`

Lazy-load consumers wanted three primitives in one trip:
`list_categories_metadata_for_catalogue` + `item_counts_by_category_for_catalogue`
+ `uncategorized_count_for_catalogue`. The new helper returns
`%{categories:, item_counts:, uncategorized_count:}` in two queries
(categories metadata + a single `GROUP BY` items query collapsing
`NULL` → uncategorized).

### #16 / #17 — housekeeping

Both shipped in PR #18 (merged 2026-04-27, released in 0.1.14):

- #16: smart→smart references rejected at the changeset layer (see
  `Rules.build_rule_changeset/2:392-411`, error metadata
  `validation: :smart_chain`, 4 test pins).
- #17: `guides/smart_catalogues.md` (236 lines, all 5 sections from
  the issue), `test/smart_catalogues_guide_test.exs` (worked-example
  end-to-end), cross-linked from `Catalogue` and `CatalogueRule`
  moduledocs.

GitHub didn't auto-close them when #18 merged. Closing here.

## Other changes

- `merge_preloads/2` extracted to `Catalogue.Helpers` — was duplicated
  in `catalogue.ex` and `catalogue/search.ex` per the original `:preload`
  landing. Workspace single-source convention.
- `test/test_helper.exs` swapped to
  `PhoenixKit.Migration.ensure_current/2` (paired with core PR).
  Falls through the existing rescue branch against current Hex pin
  (1.7.103) until core ships 1.7.105 — integration tests resume on
  `mix deps.update phoenix_kit`.
- `guides/smart_catalogues.md` §5 (preload pitfall) updated to
  reference the new `:preload` opt.
- `AGENTS.md` test-setup section updated.

## Backwards-compat notes

- `list_uncategorized_items/2` default preload widened from
  `[:manufacturer]` to `[:catalogue, :manufacturer]`. Pure addition —
  old callers never ate a smaller payload, just got more associations
  loaded.
- `get_item!/1` arity preserved for backwards compat; default preloads
  now include `:catalogue`. Old callers that didn't access `.catalogue`
  are unaffected; old callers that did access it (via separate
  `Repo.preload`) can drop that workaround.

## Test plan

- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` — 1247 mods, no issues
- [x] `mix dialyzer` — 0 errors
- [x] `mix test` — 909 tests, 0 failures (584 integration excluded against current Hex pin; resumes on `mix deps.update phoenix_kit` once core ships 1.7.105)
- [x] Empirical: smart_pricing_test 20/20 pure-function pass; smart_catalogues_guide_test 3/3 integration pass via the parent's path-deps
- [x] Browser-verified end-to-end through `phoenix_kit_parent`:
  - Catalogues list (counts via `item_counts_by_catalogue` correct)
  - Smart Test catalogue detail (smart-only UI branch)
  - Delivery item edit form (`get_item!/2` new `:catalogue` default + smart-rules picker filtered to `kind: :standard` only — confirms #16 guard active)
  - Global search "delivery" (`search_items/2` `:preload` threading — result rendered with all default associations populated)
  - Test 1 catalogue (311 items, 2 categories, Active/Deleted tabs, `Catalogue.item_pricing/1` for the Price column)
  - 0 console errors across all flows
- [x] Phase 2 quality review applied — 3 fixes: `merge_preloads/2` deduped, unknown-unit branch test, `:preload` collision test pinning Ecto's silent-merge behavior