### PR TITLE
Catalogue detail: tabs, bulk actions, per-card pagination, cross-tab live updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,12 +76,59 @@ This is a **PhoenixKit module** that implements the `PhoenixKit.Module` behaviou
 - All per-catalogue queries (`list_items_for_catalogue`, `item_count_for_catalogue`, `item_counts_by_catalogue`, `deleted_item_count_for_catalogue`, `search_items_in_catalogue`) filter on `items.catalogue_uuid` and include both categorized and uncategorized items
 - Import executor passes `skip_derive: true` to `create_item/2` because it guarantees attrs consistency by construction (it owns the target catalogue and creates or constrains categories within it) — this avoids a per-item category lookup during bulk imports
 
-### Soft-Delete Cascade System
+### Soft-Delete System
 
-- **Downward on trash:** catalogue → categories + all items (categorized and uncategorized) in that catalogue. Category → **entire subtree** (V103) including descendant categories + their items.
-- **Upward on restore:** item → category → catalogue; category → **every deleted ancestor category** + catalogue + full deleted subtree + items. Restoring a deep child brings back ancestors so the restored node is reachable in the active tree.
-- **Permanent delete** follows same downward cascade but removes from DB; uncategorized items of the catalogue are removed too. For categories: subtree is walked, items hard-deleted, `parent_uuid` NULL'd across the subtree (V103's FK has no `ON DELETE CASCADE`), then rows deleted.
-- All cascading operations wrapped in `Repo.transaction/1`. Activity metadata on `category.trashed` / `category.restored` / `category.permanently_deleted` / `category.moved` carries `subtree_size` (categories touched, including root) and `items_cascaded` so the audit log tells the full story.
+The boss's principle as of 2026-05-08: **each entity's status is its
+own**; trash and restore don't ripple sideways unless the operator
+explicitly asks for it.
+
+- **`trash_catalogue/2`** — still cascades downward (catalogue →
+  categories + all items in it). Operator-driven catalogue trash is
+  rare and the cascade preserves a clean restore round-trip. Restore
+  symmetrically brings the subtree back.
+- **`trash_category/2`** — accepts an `:items` opt that the admin
+  picks via the "Delete category — what about the items?" modal in
+  the LV before the trash fires:
+    * `:cascade` (default for non-modal callers) — items in the V103
+      subtree flip to `"deleted"` alongside the categories. The "I
+      really want everything gone" path; flagged red in the modal.
+    * `:uncategorize` — items keep their `catalogue_uuid` but get
+      `category_uuid: nil`, surviving the category trash. Default in
+      the modal.
+    * `{:move_to, target_uuid}` — items move to a same-catalogue
+      target category before the category is trashed. The dropdown
+      excludes the deleting subtree (`list_move_target_categories/1`).
+  Activity log gains `items_handled` + `items_disposition` metadata.
+  Categories in the subtree always cascade-trash regardless of the
+  items disposition — the modal is about the items, not the tree.
+- **`trash_item/2`** — leaf operation, trivial flip.
+- **`restore_catalogue/2`** — still cascades downward (mirror of
+  trash_catalogue).
+- **`restore_category/2`** — **no cascades**. Only the target
+  category's status flips back to `"active"`. Refuses with
+  `{:error, :parent_catalogue_deleted}` when the parent catalogue is
+  itself deleted (operator must restore the catalogue first). Items
+  that came down via `:cascade` stay deleted; the operator restores
+  them individually from the Items-tab Deleted view, where
+  `restore_item/2` routes them through the now-active parent.
+  Descendant categories stay deleted too — `list_category_tree/2`'s
+  orphan-promotion surfaces a re-active leaf as a root.
+- **`restore_item/2`** — refuses if the parent catalogue is deleted.
+  When the parent **category** is deleted, the item is **uncategorized
+  on restore** (`category_uuid: nil`) so it surfaces in the
+  catalogue's Uncategorized bucket without auto-reviving the category.
+  Activity metadata adds `"detached_from_category" => true` in that
+  case. When the parent category is active, restore is in-place.
+- **`permanently_delete_catalogue/2` / `permanently_delete_category/2`**
+  — unchanged. Hard-delete cascade. Refuses on smart-rule references
+  (catalogue) unless `:force`. Subtree categories get `parent_uuid`
+  NULLed first since V103's self-FK has no `ON DELETE CASCADE`.
+
+All transactional. Activity-log atoms unchanged: `category.trashed` /
+`.restored` / `.permanently_deleted` etc. Metadata shapes:
+`category.trashed` carries `subtree_size`, `items_handled`,
+`items_disposition`. `category.restored` no longer reports
+`subtree_size` / `items_cascaded` (always 0 under the new rule).
 
 ### Nested Categories (V103)
 
@@ -201,7 +248,7 @@ that can fail returns one of:
     `:parent_not_found`, `:not_siblings`, `:category_not_found`,
     `:catalogue_not_found`, `:same_catalogue`, `:no_user`,
     `:unsupported`, `:unsupported_file_format`, `:not_found`,
-    `:missing_item_name`, `:csv_empty`)
+    `:missing_item_name`, `:csv_empty`, `:parent_catalogue_deleted`)
   * a tagged tuple (`{:referenced_by_smart_items, count}`,
     `{:duplicate_referenced_catalogue, uuid}`,
     `{:invalid_price, raw}`, `{:invalid_markup, raw}`,
@@ -232,7 +279,7 @@ Every mutating operation in `Catalogue` context is logged via `PhoenixKit.Activi
 
 - **Pattern**: Private `log_activity/1` helper guarded by `Code.ensure_loaded?(PhoenixKit.Activity)` with rescue to `Logger.warning`. Activity logging failures never crash the primary operation.
 - **Actor tracking**: All mutating functions accept `opts \\ []` keyword list. Pass `actor_uuid: user.uuid` to attribute the action.
-- **Actions logged**: `manufacturer.created/updated/deleted`, `supplier.created/updated/deleted`, `catalogue.created/updated/deleted/trashed/restored/permanently_deleted`, `category.created/updated/deleted/trashed/restored/permanently_deleted/moved/positions_swapped`, `item.created/updated/deleted/trashed/restored/permanently_deleted/moved/bulk_trashed`, `manufacturer.suppliers_synced`, `supplier.manufacturers_synced`, `smart_rules.synced` (with `added`/`updated`/`removed`/`total` counts), `import.started`, `import.completed`, `catalogue_module.enabled` / `catalogue_module.disabled` (logged from the `enable_system/0` / `disable_system/0` callbacks in `lib/phoenix_kit_catalogue.ex`). Since V103, `category.trashed` / `category.restored` / `category.permanently_deleted` carry `subtree_size` + `items_cascaded`; `category.moved` includes `from_parent_uuid` / `to_parent_uuid` (in-catalogue reparents via `move_category_under/3`) or `from_catalogue_uuid` / `to_catalogue_uuid` + `subtree_size` + `items_cascaded` (cross-catalogue moves). Attachments (file uploads, featured-image changes) are not individually logged — they're captured as part of the `item.updated` / `catalogue.updated` entry on the containing save.
+- **Actions logged**: `manufacturer.created/updated/deleted`, `supplier.created/updated/deleted`, `catalogue.created/updated/deleted/trashed/restored/permanently_deleted`, `category.created/updated/deleted/trashed/restored/permanently_deleted/moved/positions_swapped`, `item.created/updated/deleted/trashed/restored/permanently_deleted/moved/bulk_trashed`, `manufacturer.suppliers_synced`, `supplier.manufacturers_synced`, `smart_rules.synced` (with `added`/`updated`/`removed`/`total` counts), `import.started`, `import.completed`, `catalogue_module.enabled` / `catalogue_module.disabled` (logged from the `enable_system/0` / `disable_system/0` callbacks in `lib/phoenix_kit_catalogue.ex`). `category.trashed` carries `subtree_size`, `items_handled`, and `items_disposition` (`"cascade"` / `"uncategorize"` / `"move_to:<uuid>"` — see Soft-Delete System above). `item.restored` includes `"detached_from_category" => true` when the item was uncategorized on restore because its parent was still deleted. `category.moved` includes `from_parent_uuid` / `to_parent_uuid` (in-catalogue reparents via `move_category_under/3`) or `from_catalogue_uuid` / `to_catalogue_uuid` + `subtree_size` + `items_cascaded` (cross-catalogue moves). Attachments (file uploads, featured-image changes) are not individually logged — they're captured as part of the `item.updated` / `catalogue.updated` entry on the containing save.
 - **Mode**: `"manual"` for user actions, `"auto"` for import-created items/categories
 - **LiveViews**: extract actor UUID via `actor_opts/1` from `PhoenixKitCatalogue.Web.Helpers` (imported into every form LV). Reads `socket.assigns[:phoenix_kit_current_user]`. The companion `actor_uuid/1` returns the bare UUID when a context call wants the bare value (e.g. `Activity.log/1` metadata).
 - **Convention — `:ok`-only**: the `Catalogue.ActivityLog` helper logs only on the `{:ok, _}` branch, never on `{:error, _}`. Failed mutations surface as `{:error, _}` to the LV, which logs the rich error context via its own `log_operation_error/3`. The activity log is the user-visible audit trail; operation errors are an engineer-visible log stream. Mixing the two would drown the audit feed in validation noise.
@@ -283,6 +330,53 @@ The `scope_selector/1` component in `web/components.ex` renders a disclosure wit
 - **Components** (`PhoenixKitCatalogue.Web.Components`): Reusable components — `item_table`, `search_input`, `search_results_summary`, `scope_selector`, `catalogue_rules_picker` (smart catalogue rule editor), `empty_state`, `view_mode_toggle`. All features opt-in via attrs. All text localized via `Gettext.gettext(PhoenixKitWeb.Gettext, ...)`. Components never crash — unknown columns, unloaded associations, nil values, and bad function arguments produce "—" placeholders and Logger warnings. `scope_selector` is the partner of the scoped search API: it renders a disclosure with catalogue/category checkbox lists and emits customizable toggle/clear events — the LV owns the selected-UUIDs state and feeds them into `Catalogue.search_items/2`'s `:catalogue_uuids` / `:category_uuids` opts.
 - **Routes**: Admin routes auto-generated from `admin_tabs/0`
 - **Paths**: Centralized path helpers in `Paths` module — always use these instead of hardcoding URLs
+
+#### CatalogueDetailLive layout (2026-05-08)
+
+The detail page splits into two scoped tabs reflected into the URL via
+`?tab=items|categories` (`handle_params/3` → `push_patch` from
+`switch_tab`). Default is "items"; unknown values fall back.
+
+- **Items tab → Active**: streamed cards (one per category + an
+  Uncategorized bucket), infinite-scroll cursor (`@cursor`,
+  `@loaded_cards`, `@has_more`). Category DnD lives only on the
+  Categories tab; items reorder within their category card.
+- **Items tab → Deleted**: flat list ordered by deletion date desc
+  (`Catalogue.list_deleted_items_for_catalogue/2`, capped at 500).
+  No category grouping, no infinite scroll. Restore + Delete Forever
+  per row; restore detaches from any deleted parent.
+- **Categories tab → Active**: depth-indented compact category rows
+  with drag handles (when ≥2 siblings), Edit + Delete actions. The
+  "Delete category" path opens the item-disposition modal when the
+  subtree has any active items.
+- **Categories tab → Deleted**: list of deleted categories with
+  Restore + Delete Forever pill buttons. No item count badge on the
+  row (separate-status: items aren't tied to the category's deleted
+  state in the Categories tab UI).
+
+The Active/Deleted status switcher is **per-tab**: Items tab shows
+`active_item_count` / `deleted_item_count`; Categories tab shows
+`active_category_count` / `deleted_category_count`. The auto-flip back
+to Active also runs against the per-tab count via
+`maybe_auto_flip_to_active/1` — invoked from `reset_and_load`,
+`refresh_counts`, `refresh_in_place`, and `handle_params` so the user
+never lands in an empty Deleted view of either tab.
+
+#### Item-disposition modal
+
+The trash flow on `Catalogue.trash_category/2` accepts an `:items`
+opt — the LV's `request_trash_category` event opens a modal when the
+subtree has active items, otherwise trashes directly with `:cascade`.
+Three radio options:
+
+- **Make items uncategorized** (default — `:uncategorize`)
+- **Move items to another category** (`{:move_to, target_uuid}`,
+  same-catalogue dropdown via `list_move_target_categories/1`)
+- **Delete items along with the category** (`:cascade`, red border)
+
+`active_item_count_in_subtree/1` decides whether to skip the modal
+entirely. The Confirm button label flips to "Delete category and
+items" for cascade; otherwise "Move items and delete category".
 
 ### Form conventions (0.1.12+)
 

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -3148,16 +3148,73 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
-  Bulk-moves items to a target category. Target must live in the same
-  catalogue as the items; cross-catalogue moves are rejected. Use
-  `target_uuid: nil` to uncategorize all items (within whichever
-  catalogue each item already lives in).
+  Bulk-moves items to a target category within a single catalogue.
+
+  ## Required opts
+
+    * `:catalogue_uuid` — the calling LV's catalogue scope. Every item
+      in `uuids` MUST already belong to this catalogue, and `target_uuid`
+      (when not `nil`) must live in this catalogue. The single-item DnD
+      handler enforces the same scope; this guard makes the bulk path
+      symmetric so a crafted client request can't silently flip an
+      item's `catalogue_uuid` cross-catalogue.
+
+  Pass `target_uuid: nil` to uncategorize all items within their
+  catalogue.
+
+  Returns `{:ok, count}`, `{:error, :category_not_found}` (target),
+  `{:error, :wrong_catalogue_scope}` (target lives elsewhere or one or
+  more items don't belong to `:catalogue_uuid`), or
+  `{:error, :missing_catalogue_scope}` (caller forgot the required opt).
   """
   @spec bulk_move_items_to_category([Ecto.UUID.t()], Ecto.UUID.t() | nil, keyword()) ::
-          {:ok, non_neg_integer()} | {:error, :category_not_found}
+          {:ok, non_neg_integer()}
+          | {:error, :category_not_found}
+          | {:error, :wrong_catalogue_scope}
+          | {:error, :missing_catalogue_scope}
   def bulk_move_items_to_category([], _target, _opts), do: {:ok, 0}
 
-  def bulk_move_items_to_category(uuids, nil, opts) when is_list(uuids) do
+  def bulk_move_items_to_category(uuids, target_uuid, opts) when is_list(uuids) do
+    case Keyword.fetch(opts, :catalogue_uuid) do
+      :error ->
+        {:error, :missing_catalogue_scope}
+
+      {:ok, catalogue_uuid} when is_binary(catalogue_uuid) ->
+        with :ok <- ensure_items_in_catalogue(uuids, catalogue_uuid),
+             {:ok, target} <- resolve_move_target(target_uuid, catalogue_uuid) do
+          do_bulk_move(uuids, target, catalogue_uuid, opts)
+        end
+    end
+  end
+
+  defp ensure_items_in_catalogue(uuids, catalogue_uuid) do
+    foreign? =
+      from(i in Item,
+        where: i.uuid in ^uuids and i.catalogue_uuid != ^catalogue_uuid,
+        limit: 1,
+        select: i.uuid
+      )
+      |> repo().exists?()
+
+    if foreign?, do: {:error, :wrong_catalogue_scope}, else: :ok
+  end
+
+  defp resolve_move_target(nil, _catalogue_uuid), do: {:ok, nil}
+
+  defp resolve_move_target(target_uuid, catalogue_uuid) do
+    case repo().get(Category, target_uuid) do
+      nil ->
+        {:error, :category_not_found}
+
+      %Category{catalogue_uuid: ^catalogue_uuid} = cat ->
+        {:ok, cat}
+
+      %Category{} ->
+        {:error, :wrong_catalogue_scope}
+    end
+  end
+
+  defp do_bulk_move(uuids, nil, catalogue_uuid, opts) do
     {count, _} =
       from(i in Item, where: i.uuid in ^uuids)
       |> repo().update_all(set: [category_uuid: nil, updated_at: DateTime.utc_now()])
@@ -3168,6 +3225,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
         mode: "manual",
         actor_uuid: opts[:actor_uuid],
         resource_type: "item",
+        parent_catalogue_uuid: catalogue_uuid,
         metadata: %{"count" => count, "to_category_uuid" => nil}
       })
     end
@@ -3175,38 +3233,27 @@ defmodule PhoenixKitCatalogue.Catalogue do
     {:ok, count}
   end
 
-  def bulk_move_items_to_category(uuids, target_uuid, opts) when is_list(uuids) do
-    case repo().get(Category, target_uuid) do
-      nil ->
-        {:error, :category_not_found}
+  defp do_bulk_move(uuids, %Category{} = target, _catalogue_uuid, opts) do
+    {count, _} =
+      from(i in Item, where: i.uuid in ^uuids)
+      |> repo().update_all(set: [category_uuid: target.uuid, updated_at: DateTime.utc_now()])
 
-      %Category{} = target ->
-        {count, _} =
-          from(i in Item, where: i.uuid in ^uuids)
-          |> repo().update_all(
-            set: [
-              category_uuid: target.uuid,
-              catalogue_uuid: target.catalogue_uuid,
-              updated_at: DateTime.utc_now()
-            ]
-          )
-
-        if count > 0 do
-          log_activity(%{
-            action: "item.bulk_moved",
-            mode: "manual",
-            actor_uuid: opts[:actor_uuid],
-            resource_type: "item",
-            metadata: %{
-              "count" => count,
-              "to_category_uuid" => target.uuid,
-              "to_catalogue_uuid" => target.catalogue_uuid
-            }
-          })
-        end
-
-        {:ok, count}
+    if count > 0 do
+      log_activity(%{
+        action: "item.bulk_moved",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "item",
+        parent_catalogue_uuid: target.catalogue_uuid,
+        metadata: %{
+          "count" => count,
+          "to_category_uuid" => target.uuid,
+          "to_catalogue_uuid" => target.catalogue_uuid
+        }
+      })
     end
+
+    {:ok, count}
   end
 
   @doc """
@@ -3228,27 +3275,27 @@ defmodule PhoenixKitCatalogue.Catalogue do
   def bulk_trash_categories(uuids, disposition, opts) when is_list(uuids) do
     repo().transaction(fn ->
       Enum.reduce_while(uuids, %{categories: 0, items_handled: 0}, fn uuid, acc ->
-        case repo().get(Category, uuid) do
-          nil ->
-            {:cont, acc}
-
-          %Category{status: "deleted"} ->
-            {:cont, acc}
-
-          %Category{} = category ->
-            case trash_category(category, Keyword.put(opts, :items, disposition)) do
-              {:ok, _} ->
-                {:cont, %{acc | categories: acc.categories + 1}}
-
-              {:error, reason} ->
-                repo().rollback(reason)
-            end
-        end
+        bulk_trash_category_step(uuid, disposition, opts, acc)
       end)
     end)
     |> case do
       {:ok, summary} -> {:ok, summary}
       error -> error
+    end
+  end
+
+  defp bulk_trash_category_step(uuid, disposition, opts, acc) do
+    case repo().get(Category, uuid) do
+      nil -> {:cont, acc}
+      %Category{status: "deleted"} -> {:cont, acc}
+      %Category{} = category -> trash_one_in_bulk(category, disposition, opts, acc)
+    end
+  end
+
+  defp trash_one_in_bulk(category, disposition, opts, acc) do
+    case trash_category(category, Keyword.put(opts, :items, disposition)) do
+      {:ok, _} -> {:cont, %{acc | categories: acc.categories + 1}}
+      {:error, reason} -> {:halt, repo().rollback(reason)}
     end
   end
 

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -1254,43 +1254,61 @@ defmodule PhoenixKitCatalogue.Catalogue do
   Soft-deletes a category and its entire subtree by setting their
   status to `"deleted"`.
 
-  **Cascades downward** in a transaction, following the nested-category
-  tree introduced in V103:
-  1. All non-deleted items in this category and any descendant → status `"deleted"`
-  2. This category and every descendant category → status `"deleted"`
+  **Cascades the categories downward** in a transaction (the category
+  itself and every descendant flip to `"deleted"`), following the V103
+  nested-category tree.
+
+  **Items in the subtree** are handled per the `:items` opt:
+
+    * `:cascade` (default) — items in the subtree flip to `"deleted"`
+      alongside the categories. Original behavior, kept for programmatic
+      callers + admin "delete and trash everything" intent.
+    * `:uncategorize` — items in the subtree keep their `catalogue_uuid`
+      but get `category_uuid: nil`, surviving the category trash. Used
+      by the admin modal when the operator wants the category gone but
+      the items kept in the same catalogue.
+    * `{:move_to, target_uuid}` — items move to the target category
+      (which must live in the same catalogue) before the category is
+      trashed. Cross-catalogue moves aren't supported here; the LV
+      restricts the dropdown to same-catalogue targets.
 
   Logs a single `category.trashed` activity on the root with
-  `subtree_size` (categories touched, including root) and
-  `items_cascaded` (items touched) in the metadata.
+  `subtree_size`, `items_handled`, and `items_disposition` in metadata.
 
   ## Examples
 
       {:ok, _} = Catalogue.trash_category(category)
+      {:ok, _} = Catalogue.trash_category(category, items: :uncategorize)
+      {:ok, _} = Catalogue.trash_category(category, items: {:move_to, target_uuid})
   """
-  @spec trash_category(Category.t(), keyword()) :: {:ok, Category.t()} | {:error, term()}
+  @spec trash_category(Category.t(), keyword()) ::
+          {:ok, Category.t()}
+          | {:error, :move_target_not_found | :cross_catalogue_move | term()}
   def trash_category(%Category{} = category, opts \\ []) do
+    disposition = Keyword.get(opts, :items, :cascade)
+
     result =
       repo().transaction(fn ->
         now = DateTime.utc_now()
         subtree = Tree.subtree_uuids(category.uuid)
 
-        {items_cascaded, _} =
-          from(i in Item,
-            where: i.category_uuid in ^subtree and i.status != "deleted"
-          )
-          |> repo().update_all(set: [status: "deleted", updated_at: now])
+        case apply_item_disposition(disposition, subtree, category, now) do
+          {:ok, items_handled} ->
+            from(c in Category,
+              where: c.uuid in ^subtree and c.status != "deleted"
+            )
+            |> repo().update_all(set: [status: "deleted", updated_at: now])
 
-        from(c in Category,
-          where: c.uuid in ^subtree and c.status != "deleted"
-        )
-        |> repo().update_all(set: [status: "deleted", updated_at: now])
+            updated = repo().get!(Category, category.uuid)
+            {updated, length(subtree), items_handled}
 
-        updated = repo().get!(Category, category.uuid)
-        {updated, length(subtree), items_cascaded}
+          {:error, reason} ->
+            repo().rollback(reason)
+        end
       end)
 
     case result do
-      {:ok, {updated, subtree_size, items_cascaded}} ->
+      {:ok, {updated, subtree_size, items_handled}} ->
         log_activity(%{
           action: "category.trashed",
           mode: "manual",
@@ -1302,7 +1320,8 @@ defmodule PhoenixKitCatalogue.Catalogue do
             "name" => category.name,
             "catalogue_uuid" => category.catalogue_uuid,
             "subtree_size" => subtree_size,
-            "items_cascaded" => items_cascaded
+            "items_handled" => items_handled,
+            "items_disposition" => disposition_to_metadata(disposition)
           }
         })
 
@@ -1312,6 +1331,53 @@ defmodule PhoenixKitCatalogue.Catalogue do
         error
     end
   end
+
+  defp apply_item_disposition(:cascade, subtree, _category, now) do
+    {count, _} =
+      from(i in Item,
+        where: i.category_uuid in ^subtree and i.status != "deleted"
+      )
+      |> repo().update_all(set: [status: "deleted", updated_at: now])
+
+    {:ok, count}
+  end
+
+  defp apply_item_disposition(:uncategorize, subtree, category, now) do
+    {count, _} =
+      from(i in Item,
+        where: i.category_uuid in ^subtree and i.status != "deleted"
+      )
+      |> repo().update_all(
+        set: [category_uuid: nil, catalogue_uuid: category.catalogue_uuid, updated_at: now]
+      )
+
+    {:ok, count}
+  end
+
+  defp apply_item_disposition({:move_to, target_uuid}, subtree, category, now) do
+    case repo().get(Category, target_uuid) do
+      nil ->
+        {:error, :move_target_not_found}
+
+      %Category{catalogue_uuid: target_cat_uuid} when target_cat_uuid != category.catalogue_uuid ->
+        {:error, :cross_catalogue_move}
+
+      %Category{uuid: ^target_uuid} = target ->
+        {count, _} =
+          from(i in Item,
+            where: i.category_uuid in ^subtree and i.status != "deleted"
+          )
+          |> repo().update_all(
+            set: [category_uuid: target.uuid, catalogue_uuid: target.catalogue_uuid, updated_at: now]
+          )
+
+        {:ok, count}
+    end
+  end
+
+  defp disposition_to_metadata(:cascade), do: "cascade"
+  defp disposition_to_metadata(:uncategorize), do: "uncategorize"
+  defp disposition_to_metadata({:move_to, uuid}), do: "move_to:#{uuid}"
 
   @doc """
   Restores a soft-deleted category (and its deleted subtree) by
@@ -1329,48 +1395,37 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
       {:ok, _} = Catalogue.restore_category(category)
   """
-  @spec restore_category(Category.t(), keyword()) :: {:ok, Category.t()} | {:error, term()}
+  @spec restore_category(Category.t(), keyword()) ::
+          {:ok, Category.t()}
+          | {:error, :parent_catalogue_deleted | term()}
   def restore_category(%Category{} = category, opts \\ []) do
     result =
       repo().transaction(fn ->
-        now = DateTime.utc_now()
-        subtree = Tree.subtree_uuids(category.uuid)
-        ancestors = Tree.ancestor_uuids(category.uuid)
-
-        # Upward: catalogue first, then ancestor categories — both
-        # before the subtree so parents are active before children.
+        # Refuse if the parent catalogue is itself deleted. The operator
+        # must restore the catalogue explicitly first.
         case repo().get(Catalogue, category.catalogue_uuid) do
-          %Catalogue{status: "deleted"} = cat ->
-            cat |> Catalogue.changeset(%{status: "active"}) |> repo().update!()
+          %Catalogue{status: "deleted"} ->
+            repo().rollback(:parent_catalogue_deleted)
 
           _ ->
             :ok
         end
 
-        if ancestors != [] do
-          from(c in Category,
-            where: c.uuid in ^ancestors and c.status == "deleted"
-          )
-          |> repo().update_all(set: [status: "active", updated_at: now])
-        end
-
-        from(c in Category,
-          where: c.uuid in ^subtree and c.status == "deleted"
-        )
-        |> repo().update_all(set: [status: "active", updated_at: now])
-
-        {items_cascaded, _} =
-          from(i in Item,
-            where: i.category_uuid in ^subtree and i.status == "deleted"
-          )
-          |> repo().update_all(set: [status: "active", updated_at: now])
-
-        updated = repo().get!(Category, category.uuid)
-        {updated, length(subtree), items_cascaded}
+        # Only flip the target category's status — no cascades. Items,
+        # descendant categories, and ancestor categories all keep their
+        # current statuses. The boss's principle: each entity's status
+        # is its own; restore-as-undo doesn't ripple sideways. Items
+        # that were cascade-trashed alongside this category stay
+        # deleted; the operator restores them separately (where
+        # `restore_item/2` will route them through the same parent the
+        # restored category sits in if it's now active).
+        category
+        |> Category.changeset(%{status: "active"})
+        |> repo().update!()
       end)
 
     case result do
-      {:ok, {updated, subtree_size, items_cascaded}} ->
+      {:ok, updated} ->
         log_activity(%{
           action: "category.restored",
           mode: "manual",
@@ -1380,9 +1435,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
           parent_catalogue_uuid: category.catalogue_uuid,
           metadata: %{
             "name" => category.name,
-            "catalogue_uuid" => category.catalogue_uuid,
-            "subtree_size" => subtree_size,
-            "items_cascaded" => items_cascaded
+            "catalogue_uuid" => category.catalogue_uuid
           }
         })
 
@@ -1762,6 +1815,32 @@ defmodule PhoenixKitCatalogue.Catalogue do
   """
   @spec list_category_ancestors(Ecto.UUID.t()) :: [Category.t()]
   defdelegate list_category_ancestors(category_uuid), to: Tree, as: :ancestors_in_order
+
+  @doc """
+  Returns same-catalogue active categories that can receive items from
+  a category about to be deleted (the category itself and its V103
+  descendants are excluded). Used by the admin "delete category" modal
+  to populate the move-target dropdown.
+
+  Each entry is `{category, depth}`, depth-first order — the same shape
+  `list_category_tree/2` returns so callers can render the same indent
+  rules.
+  """
+  @spec list_move_target_categories(Category.t()) :: [{Category.t(), non_neg_integer()}]
+  def list_move_target_categories(%Category{} = category) do
+    # `Tree.subtree_uuids/1` returns raw 16-byte binaries; `list_category_tree/2`
+    # returns Ecto-loaded categories whose `:uuid` is the textual form.
+    # Normalise both to text via `load_uuid/1` so the membership check fires.
+    subtree =
+      category.uuid
+      |> Tree.subtree_uuids()
+      |> Enum.map(&load_uuid/1)
+      |> MapSet.new()
+
+    category.catalogue_uuid
+    |> list_category_tree(mode: :active)
+    |> Enum.reject(fn {cat, _depth} -> MapSet.member?(subtree, cat.uuid) end)
+  end
 
   @doc """
   Returns the categories in a catalogue paired with their tree depth,
@@ -2440,6 +2519,38 @@ defmodule PhoenixKitCatalogue.Catalogue do
   end
 
   @doc """
+  Lists soft-deleted items in a catalogue as a flat list, ordered by
+  deletion date (most-recently-deleted first). `updated_at` is the
+  deletion-time proxy — flipping `status` to `"deleted"` always bumps
+  it. Used by the Items tab Deleted view, which surfaces a recency-
+  ordered audit list rather than category-grouped cards.
+
+  ## Options
+
+    * `:limit` — caps the list (default 500). Pagination isn't wired
+      yet; if a catalogue routinely exceeds the limit, layer a cursor
+      on top of this query.
+    * `:preload` — extra associations on top of the default
+      `[:catalogue, category: :catalogue, manufacturer: []]`.
+
+  ## Examples
+
+      Catalogue.list_deleted_items_for_catalogue(catalogue_uuid)
+  """
+  @spec list_deleted_items_for_catalogue(Ecto.UUID.t(), keyword()) :: [Item.t()]
+  def list_deleted_items_for_catalogue(catalogue_uuid, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 500)
+
+    from(i in Item,
+      where: i.catalogue_uuid == ^catalogue_uuid and i.status == "deleted",
+      order_by: [desc: i.updated_at, asc: i.uuid],
+      limit: ^limit,
+      preload: ^Helpers.merge_preloads([:catalogue, category: :catalogue, manufacturer: []], opts)
+    )
+    |> repo().all()
+  end
+
+  @doc """
   Lists uncategorized items (no category assigned) for a specific catalogue.
 
   ## Options
@@ -2791,25 +2902,53 @@ defmodule PhoenixKitCatalogue.Catalogue do
   @doc """
   Restores a soft-deleted item by setting its status to `"active"`.
 
-  **Cascades upward** in a transaction: if the parent category is deleted,
-  restores it too (so the item is visible in the active view).
+  Refuses with `{:error, :parent_catalogue_deleted}` when the item's
+  parent catalogue is itself deleted — the operator must restore the
+  catalogue first. (An item cannot exist outside a catalogue.)
+
+  When the parent catalogue is active but the item's category is
+  deleted, the item is **uncategorized on restore**: `category_uuid` is
+  set to `nil` so the item resurfaces in the catalogue's Uncategorized
+  bucket. This avoids the surprising side-effect of auto-reviving the
+  whole category structure. If the user wants the category back, they
+  restore the category explicitly (which cascades downward and brings
+  the item with it via `category_uuid` matching).
 
   ## Examples
 
       {:ok, item} = Catalogue.restore_item(item)
+      {:error, :parent_catalogue_deleted} =
+        Catalogue.restore_item(item_under_deleted_catalogue)
   """
-  @spec restore_item(Item.t(), keyword()) :: {:ok, Item.t()} | {:error, term()}
+  @spec restore_item(Item.t(), keyword()) ::
+          {:ok, Item.t()} | {:error, :parent_catalogue_deleted | term()}
   def restore_item(%Item{} = item, opts \\ []) do
     result =
       repo().transaction(fn ->
-        maybe_restore_parent_hierarchy(item.category_uuid)
+        case repo().get(Catalogue, item.catalogue_uuid) do
+          %Catalogue{status: "deleted"} ->
+            repo().rollback(:parent_catalogue_deleted)
 
-        item
-        |> Item.changeset(%{status: "active"})
-        |> repo().update!()
+          _ ->
+            :ok
+        end
+
+        detached? = category_deleted?(item.category_uuid)
+
+        attrs =
+          if detached?,
+            do: %{status: "active", category_uuid: nil},
+            else: %{status: "active"}
+
+        restored =
+          item
+          |> Item.changeset(attrs)
+          |> repo().update!()
+
+        {restored, detached?}
       end)
 
-    with {:ok, restored} <- result do
+    with {:ok, {restored, detached?}} <- result do
       log_activity(%{
         action: "item.restored",
         mode: "manual",
@@ -2817,33 +2956,21 @@ defmodule PhoenixKitCatalogue.Catalogue do
         resource_type: "item",
         resource_uuid: restored.uuid,
         parent_catalogue_uuid: restored.catalogue_uuid,
-        metadata: %{"name" => restored.name}
+        metadata:
+          %{"name" => restored.name}
+          |> Map.merge(if detached?, do: %{"detached_from_category" => true}, else: %{})
       })
 
       {:ok, restored}
     end
   end
 
-  defp maybe_restore_parent_hierarchy(nil), do: :ok
+  defp category_deleted?(nil), do: false
 
-  defp maybe_restore_parent_hierarchy(category_uuid) do
+  defp category_deleted?(category_uuid) do
     case repo().get(Category, category_uuid) do
-      %Category{status: "deleted"} = cat ->
-        maybe_restore_parent_catalogue(cat.catalogue_uuid)
-        cat |> Category.changeset(%{status: "active"}) |> repo().update!()
-
-      _ ->
-        :ok
-    end
-  end
-
-  defp maybe_restore_parent_catalogue(catalogue_uuid) do
-    case repo().get(Catalogue, catalogue_uuid) do
-      %Catalogue{status: "deleted"} = cat ->
-        cat |> Catalogue.changeset(%{status: "active"}) |> repo().update!()
-
-      _ ->
-        :ok
+      %Category{status: "deleted"} -> true
+      _ -> false
     end
   end
 
@@ -3287,6 +3414,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
   defdelegate item_count_for_catalogue(catalogue_uuid), to: Counts
   defdelegate item_counts_by_catalogue(), to: Counts
+  defdelegate active_item_count_in_subtree(category_uuid), to: Counts
   defdelegate category_count_for_catalogue(catalogue_uuid), to: Counts
   defdelegate category_counts_by_catalogue(), to: Counts
   defdelegate deleted_item_count_for_catalogue(catalogue_uuid), to: Counts

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -1359,7 +1359,8 @@ defmodule PhoenixKitCatalogue.Catalogue do
       nil ->
         {:error, :move_target_not_found}
 
-      %Category{catalogue_uuid: target_cat_uuid} when target_cat_uuid != category.catalogue_uuid ->
+      %Category{catalogue_uuid: target_cat_uuid}
+      when target_cat_uuid != category.catalogue_uuid ->
         {:error, :cross_catalogue_move}
 
       %Category{uuid: ^target_uuid} = target ->
@@ -1368,7 +1369,11 @@ defmodule PhoenixKitCatalogue.Catalogue do
             where: i.category_uuid in ^subtree and i.status != "deleted"
           )
           |> repo().update_all(
-            set: [category_uuid: target.uuid, catalogue_uuid: target.catalogue_uuid, updated_at: now]
+            set: [
+              category_uuid: target.uuid,
+              catalogue_uuid: target.catalogue_uuid,
+              updated_at: now
+            ]
           )
 
         {:ok, count}
@@ -3030,6 +3035,221 @@ defmodule PhoenixKitCatalogue.Catalogue do
     end
 
     {count, nil}
+  end
+
+  # ── Bulk actions on UUID lists (admin selection toolbar) ──────
+
+  @doc """
+  Bulk soft-deletes items by UUID. Empty list is a no-op. Logs a single
+  `item.bulk_trashed` activity row when count > 0.
+  """
+  @spec bulk_trash_items([Ecto.UUID.t()], keyword()) :: {non_neg_integer(), nil}
+  def bulk_trash_items([], _opts), do: {0, nil}
+
+  def bulk_trash_items(uuids, opts) when is_list(uuids) do
+    {count, _} =
+      from(i in Item, where: i.uuid in ^uuids and i.status != "deleted")
+      |> repo().update_all(set: [status: "deleted", updated_at: DateTime.utc_now()])
+
+    if count > 0 do
+      log_activity(%{
+        action: "item.bulk_trashed",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "item",
+        metadata: %{"count" => count, "uuids" => uuids}
+      })
+    end
+
+    {count, nil}
+  end
+
+  @doc """
+  Bulk restores items by UUID. Refuses any item whose parent catalogue
+  is deleted (returns the count of *attempted* successes; skipped ones
+  are excluded). Items with deleted parent categories are uncategorized
+  on restore — same rule as `restore_item/2`.
+  """
+  @spec bulk_restore_items([Ecto.UUID.t()], keyword()) :: {non_neg_integer(), nil}
+  def bulk_restore_items([], _opts), do: {0, nil}
+
+  def bulk_restore_items(uuids, opts) when is_list(uuids) do
+    now = DateTime.utc_now()
+
+    items =
+      from(i in Item,
+        where: i.uuid in ^uuids and i.status == "deleted",
+        preload: [:catalogue, :category]
+      )
+      |> repo().all()
+      |> Enum.reject(fn i -> i.catalogue && i.catalogue.status == "deleted" end)
+
+    {ok_uuids, detached_uuids} =
+      Enum.reduce(items, {[], []}, fn item, {ok_acc, det_acc} ->
+        if item.category && item.category.status == "deleted" do
+          {[item.uuid | ok_acc], [item.uuid | det_acc]}
+        else
+          {[item.uuid | ok_acc], det_acc}
+        end
+      end)
+
+    {count_attached, _} =
+      from(i in Item,
+        where: i.uuid in ^(ok_uuids -- detached_uuids) and i.status == "deleted"
+      )
+      |> repo().update_all(set: [status: "active", updated_at: now])
+
+    {count_detached, _} =
+      from(i in Item, where: i.uuid in ^detached_uuids and i.status == "deleted")
+      |> repo().update_all(set: [status: "active", category_uuid: nil, updated_at: now])
+
+    count = count_attached + count_detached
+
+    if count > 0 do
+      log_activity(%{
+        action: "item.bulk_restored",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "item",
+        metadata: %{
+          "count" => count,
+          "detached_count" => count_detached,
+          "uuids" => ok_uuids
+        }
+      })
+    end
+
+    {count, nil}
+  end
+
+  @doc """
+  Bulk hard-deletes items by UUID. Use with care — no soft-delete cycle.
+  Logs a single `item.bulk_permanently_deleted` activity row when
+  count > 0.
+  """
+  @spec bulk_permanently_delete_items([Ecto.UUID.t()], keyword()) ::
+          {non_neg_integer(), nil}
+  def bulk_permanently_delete_items([], _opts), do: {0, nil}
+
+  def bulk_permanently_delete_items(uuids, opts) when is_list(uuids) do
+    {count, _} = from(i in Item, where: i.uuid in ^uuids) |> repo().delete_all()
+
+    if count > 0 do
+      log_activity(%{
+        action: "item.bulk_permanently_deleted",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "item",
+        metadata: %{"count" => count, "uuids" => uuids}
+      })
+    end
+
+    {count, nil}
+  end
+
+  @doc """
+  Bulk-moves items to a target category. Target must live in the same
+  catalogue as the items; cross-catalogue moves are rejected. Use
+  `target_uuid: nil` to uncategorize all items (within whichever
+  catalogue each item already lives in).
+  """
+  @spec bulk_move_items_to_category([Ecto.UUID.t()], Ecto.UUID.t() | nil, keyword()) ::
+          {:ok, non_neg_integer()} | {:error, :category_not_found}
+  def bulk_move_items_to_category([], _target, _opts), do: {:ok, 0}
+
+  def bulk_move_items_to_category(uuids, nil, opts) when is_list(uuids) do
+    {count, _} =
+      from(i in Item, where: i.uuid in ^uuids)
+      |> repo().update_all(set: [category_uuid: nil, updated_at: DateTime.utc_now()])
+
+    if count > 0 do
+      log_activity(%{
+        action: "item.bulk_moved",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "item",
+        metadata: %{"count" => count, "to_category_uuid" => nil}
+      })
+    end
+
+    {:ok, count}
+  end
+
+  def bulk_move_items_to_category(uuids, target_uuid, opts) when is_list(uuids) do
+    case repo().get(Category, target_uuid) do
+      nil ->
+        {:error, :category_not_found}
+
+      %Category{} = target ->
+        {count, _} =
+          from(i in Item, where: i.uuid in ^uuids)
+          |> repo().update_all(
+            set: [
+              category_uuid: target.uuid,
+              catalogue_uuid: target.catalogue_uuid,
+              updated_at: DateTime.utc_now()
+            ]
+          )
+
+        if count > 0 do
+          log_activity(%{
+            action: "item.bulk_moved",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "item",
+            metadata: %{
+              "count" => count,
+              "to_category_uuid" => target.uuid,
+              "to_catalogue_uuid" => target.catalogue_uuid
+            }
+          })
+        end
+
+        {:ok, count}
+    end
+  end
+
+  @doc """
+  Bulk soft-deletes categories by UUID with a uniform item disposition
+  (cascade / uncategorize / move_to). Each category goes through the
+  same logic as `trash_category/2`. Returns `{:ok, %{categories:
+  count, items_handled: count}}` or surfaces the first error.
+  """
+  @spec bulk_trash_categories(
+          [Ecto.UUID.t()],
+          :cascade | :uncategorize | {:move_to, Ecto.UUID.t()},
+          keyword()
+        ) ::
+          {:ok, %{categories: non_neg_integer(), items_handled: non_neg_integer()}}
+          | {:error, term()}
+  def bulk_trash_categories([], _disposition, _opts),
+    do: {:ok, %{categories: 0, items_handled: 0}}
+
+  def bulk_trash_categories(uuids, disposition, opts) when is_list(uuids) do
+    repo().transaction(fn ->
+      Enum.reduce_while(uuids, %{categories: 0, items_handled: 0}, fn uuid, acc ->
+        case repo().get(Category, uuid) do
+          nil ->
+            {:cont, acc}
+
+          %Category{status: "deleted"} ->
+            {:cont, acc}
+
+          %Category{} = category ->
+            case trash_category(category, Keyword.put(opts, :items, disposition)) do
+              {:ok, _} ->
+                {:cont, %{acc | categories: acc.categories + 1}}
+
+              {:error, reason} ->
+                repo().rollback(reason)
+            end
+        end
+      end)
+    end)
+    |> case do
+      {:ok, summary} -> {:ok, summary}
+      error -> error
+    end
   end
 
   @doc """

--- a/lib/phoenix_kit_catalogue/catalogue/counts.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/counts.ex
@@ -23,6 +23,21 @@ defmodule PhoenixKitCatalogue.Catalogue.Counts do
   end
 
   @doc """
+  Counts active items in a category subtree (the category itself and
+  every V103 descendant). Used by the admin "delete category" modal to
+  decide whether to ask the operator what should happen to the items.
+  """
+  @spec active_item_count_in_subtree(Ecto.UUID.t()) :: non_neg_integer()
+  def active_item_count_in_subtree(category_uuid) do
+    subtree = PhoenixKitCatalogue.Catalogue.Tree.subtree_uuids(category_uuid)
+
+    from(i in Item,
+      where: i.category_uuid in ^subtree and i.status != "deleted"
+    )
+    |> repo().aggregate(:count)
+  end
+
+  @doc """
   Returns a map of `%{catalogue_uuid => non_deleted_item_count}` for all catalogues.
 
   Single-query batch version of `item_count_for_catalogue/1` — avoids N+1 when

--- a/lib/phoenix_kit_catalogue/catalogue/pub_sub.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/pub_sub.ex
@@ -87,4 +87,95 @@ defmodule PhoenixKitCatalogue.Catalogue.PubSub do
 
     :ok
   end
+
+  @doc """
+  Broadcasts a card-refresh event so other open detail pages re-fetch
+  a single category card's items after a reorder.
+
+  `scope` is a category UUID or `:uncategorized`. `from` is the
+  originating process; receivers compare against `self()` to skip
+  self-originated events (the source LV already updated locally).
+
+  `flash_uuid` + `flash_status` let the receiver fire a
+  `sortable:flash` push_event keyed to the moved row, so a second
+  open tab sees the same green/red flash the originator did.
+  """
+  @spec broadcast_card_refresh(
+          Ecto.UUID.t(),
+          Ecto.UUID.t() | :uncategorized,
+          Ecto.UUID.t() | nil,
+          atom(),
+          pid()
+        ) :: :ok
+  def broadcast_card_refresh(catalogue_uuid, scope, flash_uuid, flash_status, from \\ self()) do
+    if Code.ensure_loaded?(PhoenixKit.PubSubHelper) do
+      PhoenixKit.PubSubHelper.broadcast(
+        @topic,
+        {:catalogue_card_refresh, catalogue_uuid, scope, flash_uuid, flash_status, from}
+      )
+    end
+
+    :ok
+  end
+
+  @doc """
+  Broadcasts a category-reorder event so other open detail pages
+  re-fetch the category list (positions changed). Heavier than
+  `broadcast_card_refresh/5` — receivers do a full reset_and_load
+  since category order affects every streamed card on the page.
+  """
+  @spec broadcast_category_reorder(
+          Ecto.UUID.t(),
+          Ecto.UUID.t() | nil,
+          atom(),
+          pid()
+        ) :: :ok
+  def broadcast_category_reorder(catalogue_uuid, moved_id, status, from \\ self()) do
+    if Code.ensure_loaded?(PhoenixKit.PubSubHelper) do
+      PhoenixKit.PubSubHelper.broadcast(
+        @topic,
+        {:catalogue_category_reorder, catalogue_uuid, moved_id, status, from}
+      )
+    end
+
+    :ok
+  end
+
+  @doc """
+  Broadcasts a bulk-change event so other open detail pages animate
+  the affected items leaving / arriving on screen.
+
+  `kind`:
+    * `:trashed` — items are going away (red flash → state refresh).
+    * `:restored` — items are coming back (state refresh → green flash).
+    * `:moved` — items are leaving one scope and entering another
+      (red flash on source DOM → state refresh → green flash on
+      destination DOM).
+    * `:permanent_delete` — items are gone for good (same animation
+      as `:trashed`; the row removal is harder to undo but the visual
+      cue is the same).
+
+  `uuids` is the affected item list. `scopes` is the list of category
+  scopes (UUIDs or `:uncategorized`) whose cards need to refresh — for
+  moves this is the union of source and destination; for trash/restore
+  it's the scope that gained/lost items.
+  """
+  @spec broadcast_bulk_change(
+          Ecto.UUID.t(),
+          :trashed | :restored | :moved | :permanent_delete,
+          [Ecto.UUID.t()],
+          [Ecto.UUID.t() | :uncategorized],
+          pid()
+        ) :: :ok
+  def broadcast_bulk_change(catalogue_uuid, kind, uuids, scopes, from \\ self())
+      when is_atom(kind) and is_list(uuids) and is_list(scopes) do
+    if Code.ensure_loaded?(PhoenixKit.PubSubHelper) do
+      PhoenixKit.PubSubHelper.broadcast(
+        @topic,
+        {:catalogue_bulk_change, catalogue_uuid, kind, uuids, scopes, from}
+      )
+    end
+
+    :ok
+  end
 end

--- a/lib/phoenix_kit_catalogue/errors.ex
+++ b/lib/phoenix_kit_catalogue/errors.ex
@@ -55,6 +55,7 @@ defmodule PhoenixKitCatalogue.Errors do
           | :missing_item_name
           | :unsupported_file_format
           | :csv_empty
+          | :parent_catalogue_deleted
 
   @doc """
   Translates an error reason into a user-facing string via gettext.
@@ -127,6 +128,13 @@ defmodule PhoenixKitCatalogue.Errors do
 
   def message(:csv_empty),
     do: Gettext.gettext(PhoenixKitWeb.Gettext, "CSV file is empty.")
+
+  def message(:parent_catalogue_deleted),
+    do:
+      Gettext.gettext(
+        PhoenixKitWeb.Gettext,
+        "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
+      )
 
   # Tagged tuples — atoms that carry a single parameter.
 

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -32,6 +32,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   alias PhoenixKitCatalogue.Web.Components.PdfSearchModal
 
   @per_page 100
+  @per_card 25
+  # Show-more button timeout — if the deferred :apply_expand doesn't
+  # complete within this window the button restores so the user can
+  # retry. Calibrated for "user lost network mid-click" not "the DB is
+  # slow" — the inline query itself rarely takes more than 50ms.
+  @expand_timeout_ms 8_000
 
   @impl true
   def mount(%{"uuid" => uuid}, _session, socket) do
@@ -45,8 +51,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         category_counts: %{},
         uncategorized_total: 0,
         loaded_cards: [],
-        cursor: initial_cursor(),
-        has_more: false,
+        expanding_cards: MapSet.new(),
         loading: false,
         confirm_delete: nil,
         trash_modal: nil,
@@ -253,6 +258,62 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     {:noreply, socket}
   end
 
+  # Deferred apply for the show-more click. The handler that scheduled
+  # this might have been outraced by `:expand_timeout` (operator on a
+  # bad connection) — in that case the scope is no longer in
+  # `expanding_cards` and we no-op.
+  def handle_info({:apply_expand, scope}, socket) do
+    if MapSet.member?(socket.assigns.expanding_cards, scope) do
+      mode = view_mode_to_atom(socket.assigns.view_mode)
+      catalogue_uuid = socket.assigns.catalogue_uuid
+
+      cards =
+        Enum.map(socket.assigns.loaded_cards, fn card ->
+          if scope_matches_card?(scope, card) do
+            more =
+              fetch_card_items(
+                card_scope(card),
+                catalogue_uuid,
+                mode,
+                @per_card,
+                length(card.items)
+              )
+
+            %{card | items: card.items ++ more}
+          else
+            card
+          end
+        end)
+
+      {:noreply,
+       socket
+       |> assign(:loaded_cards, cards)
+       |> assign(:expanding_cards, MapSet.delete(socket.assigns.expanding_cards, scope))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # Smart-fail: if the apply hasn't landed within @expand_timeout_ms
+  # (network hiccup, BEAM stuck), restore the button and surface a
+  # flash so the operator can retry.
+  def handle_info({:expand_timeout, scope}, socket) do
+    if MapSet.member?(socket.assigns.expanding_cards, scope) do
+      {:noreply,
+       socket
+       |> assign(:expanding_cards, MapSet.delete(socket.assigns.expanding_cards, scope))
+       |> put_flash(
+         :error,
+         Gettext.gettext(
+           PhoenixKitWeb.Gettext,
+           "Loading more items took too long. Please try again."
+         )
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_info(msg, socket) do
     Logger.debug("CatalogueDetailLive ignored unhandled message: #{inspect(msg)}")
     {:noreply, socket}
@@ -298,18 +359,42 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     {:noreply, push_patch(socket, to: target)}
   end
 
+  # `load_more` is now only used by the search results pagination —
+  # the category cards expand on-demand via `expand_card` instead of
+  # via a global bottom sentinel.
   def handle_event("load_more", _params, socket) do
-    cond do
-      socket.assigns.search_results != nil and socket.assigns.search_has_more and
-          not socket.assigns.search_loading ->
-        {:noreply, start_search_page(socket)}
+    if socket.assigns.search_results != nil and socket.assigns.search_has_more and
+         not socket.assigns.search_loading do
+      {:noreply, start_search_page(socket)}
+    else
+      {:noreply, socket}
+    end
+  end
 
-      is_nil(socket.assigns.search_results) and socket.assigns.has_more and
-          not socket.assigns.loading ->
-        {:noreply, socket |> assign(:loading, true) |> load_next_batch()}
+  # Per-card "Show N more" button. `scope` is either a category UUID
+  # or the literal string "uncategorized".
+  #
+  # Deferred apply pattern: the event handler returns immediately after
+  # marking the card as expanding (so the LV re-renders the disabled
+  # "Loading…" button), then `:apply_expand` does the actual fetch on
+  # the next mailbox tick. Without this defer the LV would block in
+  # one go and the user would never see the loading state.
+  #
+  # Smart-fail: if the apply doesn't land within @expand_timeout_ms
+  # (default 8s), `:expand_timeout` clears the expanding flag and
+  # surfaces a flash so the user can retry. The query itself runs
+  # inline (not async) so the timeout fires only when the BEAM /
+  # socket is genuinely stuck, not when the DB is just slow — but
+  # that's the failure mode worth recovering from.
+  def handle_event("expand_card", %{"scope" => scope}, socket) do
+    if MapSet.member?(socket.assigns.expanding_cards, scope) do
+      {:noreply, socket}
+    else
+      send(self(), {:apply_expand, scope})
+      Process.send_after(self(), {:expand_timeout, scope}, @expand_timeout_ms)
 
-      true ->
-        {:noreply, socket}
+      {:noreply,
+       assign(socket, :expanding_cards, MapSet.put(socket.assigns.expanding_cards, scope))}
     end
   end
 
@@ -896,6 +981,24 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     end
   end
 
+  # ── Per-card expand helpers ──────────────────────────────────────
+
+  # Template helper: turns a card map into the scope key used by
+  # `expanding_cards` / `expand_card` events.
+  defp scope_key(%{kind: :uncategorized}), do: "uncategorized"
+  defp scope_key(%{kind: :category, category: %{uuid: uuid}}), do: uuid
+
+  defp scope_matches_card?("uncategorized", %{kind: :uncategorized}), do: true
+
+  defp scope_matches_card?(uuid, %{kind: :category, category: %{uuid: cat_uuid}})
+       when is_binary(uuid),
+       do: uuid == cat_uuid
+
+  defp scope_matches_card?(_, _), do: false
+
+  defp card_scope(%{kind: :uncategorized}), do: :uncategorized
+  defp card_scope(%{kind: :category, category: %{uuid: uuid}}), do: uuid
+
   # ── Bulk-action helpers ──────────────────────────────────────────
 
   defp toggle(set, uuid) do
@@ -1124,8 +1227,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # actor_opts/1, actor_uuid/1, and log_operation_error/3 imported from
   # PhoenixKitCatalogue.Web.Helpers.
 
-  defp initial_cursor, do: %{phase: :categories, category_index: 0, item_offset: 0}
-
   # Resets paging state and loads the first batch. Called on mount, when
   # the user switches active/deleted tabs, and after any structural
   # change (category trash/restore/permanent-delete/reorder) because
@@ -1133,10 +1234,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp reset_and_load(socket) do
     uuid = socket.assigns.catalogue_uuid
 
-    # Pre-compute tab-relevant deleted count for the auto-flip decision.
-    # The flip rule: if the tab the user is in has no deleted entries
-    # AND they're sitting in the Deleted view, snap them back to Active
-    # so they don't land in an empty Deleted bucket.
     deleted_item_count = Catalogue.deleted_item_count_for_catalogue(uuid)
     deleted_category_count = Catalogue.deleted_category_count_for_catalogue(uuid)
     deleted_count = deleted_item_count + deleted_category_count
@@ -1160,11 +1257,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     category_counts = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode)
     uncategorized_total = Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
 
-    has_any_content = category_list != [] or uncategorized_total > 0
-
-    # Items tab Deleted view is a flat recency-ordered list, not the
-    # category-grouped streamed cards. Skip the cursor / load_next_batch
-    # machinery in that branch and load the flat list directly.
     items_tab_deleted? = view_mode == "deleted" and socket.assigns.tab == "items"
 
     deleted_items =
@@ -1172,29 +1264,71 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         do: Catalogue.list_deleted_items_for_catalogue(uuid),
         else: []
 
-    socket =
-      socket
-      |> assign(
-        page_title: catalogue.name,
-        catalogue: catalogue,
-        category_list: category_list,
-        category_depths: category_depths,
-        category_counts: category_counts,
-        uncategorized_total: uncategorized_total,
-        loaded_cards: [],
-        cursor: initial_cursor(),
-        has_more: not items_tab_deleted? and has_any_content,
-        loading: not items_tab_deleted? and has_any_content,
-        deleted_count: deleted_count,
-        active_item_count: Catalogue.item_count_for_catalogue(uuid),
-        deleted_item_count: deleted_item_count,
-        active_category_count: Catalogue.category_count_for_catalogue(uuid),
-        deleted_category_count: deleted_category_count,
-        view_mode: view_mode,
-        deleted_items: deleted_items
-      )
+    # Per-card preview build. Each category gets its first @per_card
+    # items + a total; uncategorized too. The "Show N more" button on
+    # each card requests the next slice via `expand_card`. Replaces the
+    # global cursor walk + bottom-sentinel infinite scroll.
+    loaded_cards =
+      if items_tab_deleted? do
+        []
+      else
+        build_loaded_cards(uuid, category_list, category_counts, uncategorized_total, mode)
+      end
 
-    if items_tab_deleted?, do: socket, else: load_next_batch(socket)
+    socket
+    |> assign(
+      page_title: catalogue.name,
+      catalogue: catalogue,
+      category_list: category_list,
+      category_depths: category_depths,
+      category_counts: category_counts,
+      uncategorized_total: uncategorized_total,
+      loaded_cards: loaded_cards,
+      deleted_count: deleted_count,
+      active_item_count: Catalogue.item_count_for_catalogue(uuid),
+      deleted_item_count: deleted_item_count,
+      active_category_count: Catalogue.category_count_for_catalogue(uuid),
+      deleted_category_count: deleted_category_count,
+      view_mode: view_mode,
+      deleted_items: deleted_items
+    )
+  end
+
+  # Builds the full set of cards eagerly — one per category in display
+  # order, then an Uncategorized card if applicable. Each card holds
+  # its first @per_card items plus the total count so the template can
+  # render a "Show N more" button when more items exist.
+  defp build_loaded_cards(uuid, category_list, category_counts, uncategorized_total, mode) do
+    category_cards =
+      Enum.map(category_list, fn category ->
+        total = Map.get(category_counts, category.uuid, 0)
+
+        items =
+          if total > 0,
+            do:
+              Catalogue.list_items_for_category_paged(category.uuid,
+                mode: mode,
+                offset: 0,
+                limit: @per_card
+              ),
+            else: []
+
+        %{kind: :category, category: category, items: items, total: total}
+      end)
+
+    if uncategorized_total > 0 do
+      uncat_items =
+        Catalogue.list_uncategorized_items_paged(uuid,
+          mode: mode,
+          offset: 0,
+          limit: @per_card
+        )
+
+      category_cards ++
+        [%{kind: :uncategorized, items: uncat_items, total: uncategorized_total}]
+    else
+      category_cards
+    end
   end
 
   # Refreshes the header counts (Active / Deleted tabs) and the
@@ -1217,6 +1351,20 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         do: Catalogue.list_deleted_items_for_catalogue(uuid),
         else: socket.assigns[:deleted_items] || []
 
+    category_counts = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode)
+    uncategorized_total = Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
+
+    refreshed_cards =
+      Enum.map(socket.assigns.loaded_cards, fn card ->
+        case card do
+          %{kind: :category, category: %{uuid: cat_uuid}} ->
+            %{card | total: Map.get(category_counts, cat_uuid, 0)}
+
+          %{kind: :uncategorized} ->
+            %{card | total: uncategorized_total}
+        end
+      end)
+
     socket =
       assign(socket,
         deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
@@ -1224,9 +1372,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
         active_category_count: Catalogue.category_count_for_catalogue(uuid),
         deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid),
-        category_counts: Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode),
-        uncategorized_total: Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode),
-        deleted_items: deleted_items
+        category_counts: category_counts,
+        uncategorized_total: uncategorized_total,
+        deleted_items: deleted_items,
+        loaded_cards: refreshed_cards
       )
 
     maybe_auto_flip_to_active(socket)
@@ -1272,6 +1421,23 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     tree = Catalogue.list_category_tree(uuid, mode: mode)
     category_list = Enum.map(tree, fn {cat, _depth} -> cat end)
     category_depths = Map.new(tree, fn {cat, depth} -> {cat.uuid, depth} end)
+    category_counts = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode)
+    uncategorized_total = Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
+
+    # Re-sync each card's `total` from the fresh counts so the
+    # "Show N more (k)" button reflects current reality after a
+    # cross-tab mutation. Loaded `items` lists are intentionally left
+    # alone to preserve the user's expanded slice.
+    refreshed_cards =
+      Enum.map(socket.assigns.loaded_cards, fn card ->
+        case card do
+          %{kind: :category, category: %{uuid: cat_uuid}} ->
+            %{card | total: Map.get(category_counts, cat_uuid, 0)}
+
+          %{kind: :uncategorized} ->
+            %{card | total: uncategorized_total}
+        end
+      end)
 
     socket
     |> assign(
@@ -1279,8 +1445,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       catalogue: catalogue,
       category_list: category_list,
       category_depths: category_depths,
-      category_counts: Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode),
-      uncategorized_total: Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode),
+      category_counts: category_counts,
+      uncategorized_total: uncategorized_total,
+      loaded_cards: refreshed_cards,
       deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
       active_item_count: Catalogue.item_count_for_catalogue(uuid),
       deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
@@ -1288,64 +1455,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid)
     )
     |> maybe_auto_flip_to_active()
-  end
-
-  # Loads one batch (up to `@per_page` items) based on the current
-  # cursor and appends/merges it into `loaded_cards`. Advances the
-  # cursor. Sets `has_more = false` when nothing else remains to load.
-  defp load_next_batch(socket) do
-    %{
-      cursor: cursor,
-      catalogue_uuid: uuid,
-      view_mode: view_mode,
-      category_list: categories,
-      loaded_cards: cards
-    } = socket.assigns
-
-    mode = view_mode_to_atom(view_mode)
-
-    case fetch_next(cursor, uuid, categories, mode) do
-      :done ->
-        assign(socket, has_more: false, loading: false)
-
-      {:category, category, items, exhausted?} ->
-        new_cards = merge_category_card(cards, category, items)
-
-        new_cursor =
-          if exhausted? do
-            %{cursor | category_index: cursor.category_index + 1, item_offset: 0}
-          else
-            %{cursor | item_offset: cursor.item_offset + length(items)}
-          end
-
-        assign(socket,
-          loaded_cards: new_cards,
-          cursor: new_cursor,
-          has_more: true,
-          loading: false
-        )
-
-      {:uncategorized, items, exhausted?} ->
-        new_cards = merge_uncategorized_card(cards, items)
-
-        new_cursor =
-          if exhausted? do
-            %{cursor | phase: :done}
-          else
-            %{
-              phase: :uncategorized,
-              category_index: 0,
-              item_offset: cursor.item_offset + length(items)
-            }
-          end
-
-        assign(socket,
-          loaded_cards: new_cards,
-          cursor: new_cursor,
-          has_more: new_cursor.phase != :done,
-          loading: false
-        )
-    end
   end
 
   # Runs a fresh search query asynchronously. If a prior search is still
@@ -1488,93 +1597,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     )
   end
 
-  # Drives the cursor walk. Returns the next batch to render, or
-  # `:done` when the cursor has nothing left in either phase. Walks:
-  # categories (in display order) → uncategorized → done.
-  defp fetch_next(%{phase: :categories} = cursor, uuid, categories, mode) do
-    case Enum.at(categories, cursor.category_index) do
-      nil ->
-        fetch_next(
-          %{phase: :uncategorized, category_index: 0, item_offset: 0},
-          uuid,
-          categories,
-          mode
-        )
-
-      category ->
-        fetch_category_batch(category, cursor, uuid, categories, mode)
-    end
-  end
-
-  defp fetch_next(%{phase: :uncategorized, item_offset: off}, uuid, _categories, mode) do
-    items =
-      Catalogue.list_uncategorized_items_paged(uuid,
-        mode: mode,
-        offset: off,
-        limit: @per_page
-      )
-
-    if items == [] do
-      :done
-    else
-      {:uncategorized, items, length(items) < @per_page}
-    end
-  end
-
-  defp fetch_next(%{phase: :done}, _uuid, _categories, _mode), do: :done
-
-  defp fetch_category_batch(category, cursor, uuid, categories, mode) do
-    items =
-      Catalogue.list_items_for_category_paged(category.uuid,
-        mode: mode,
-        offset: cursor.item_offset,
-        limit: @per_page
-      )
-
-    cond do
-      # Empty category — push an empty card on the first visit so the
-      # category is still visible with its controls, then advance.
-      items == [] and cursor.item_offset == 0 ->
-        {:category, category, [], true}
-
-      items == [] ->
-        fetch_next(
-          %{phase: :categories, category_index: cursor.category_index + 1, item_offset: 0},
-          uuid,
-          categories,
-          mode
-        )
-
-      true ->
-        {:category, category, items, length(items) < @per_page}
-    end
-  end
-
-  # Appends items to the last card if it's already for this category,
-  # otherwise pushes a fresh card.
-  defp merge_category_card(cards, category, items) do
-    case List.last(cards) do
-      %{kind: :category, category: last_cat, items: existing}
-      when last_cat.uuid == category.uuid ->
-        updated = %{kind: :category, category: category, items: existing ++ items}
-        List.replace_at(cards, length(cards) - 1, updated)
-
-      _ ->
-        cards ++ [%{kind: :category, category: category, items: items}]
-    end
-  end
-
-  defp merge_uncategorized_card(cards, items) do
-    case List.last(cards) do
-      %{kind: :uncategorized, items: existing} ->
-        updated = %{kind: :uncategorized, items: existing ++ items}
-        List.replace_at(cards, length(cards) - 1, updated)
-
-      _ ->
-        cards ++ [%{kind: :uncategorized, items: items}]
-    end
-  end
-
   # Removes a trashed/restored/deleted item from its card's items list
   # in place. No DB reload, so scroll position is preserved.
   defp remove_item_locally(socket, item_uuid) do
@@ -1604,18 +1626,31 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     catalogue_uuid = socket.assigns.catalogue_uuid
     mode = view_mode_to_atom(socket.assigns.view_mode)
 
+    fresh_total = card_total(scope, catalogue_uuid, mode)
+
     cards =
       Enum.map(socket.assigns.loaded_cards, fn card ->
         if card_matches_scope?(card, scope) do
-          limit = max(length(card.items) + delta, 1)
+          # Keep the same loaded slice (clamped to the new total) so a
+          # reorder/move doesn't collapse a card the user expanded.
+          limit = max(length(card.items) + delta, @per_card)
           fresh = fetch_card_items(scope, catalogue_uuid, mode, limit)
-          %{card | items: fresh}
+          %{card | items: fresh, total: fresh_total}
         else
           card
         end
       end)
 
     assign(socket, :loaded_cards, cards)
+  end
+
+  defp card_total(:uncategorized, catalogue_uuid, mode) do
+    Catalogue.uncategorized_count_for_catalogue(catalogue_uuid, mode: mode)
+  end
+
+  defp card_total(category_uuid, catalogue_uuid, mode) when is_binary(category_uuid) do
+    Catalogue.item_counts_by_category_for_catalogue(catalogue_uuid, mode: mode)
+    |> Map.get(category_uuid, 0)
   end
 
   defp card_matches_scope?(%{kind: :category, category: %{uuid: uuid}}, scope)
@@ -1625,19 +1660,21 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp card_matches_scope?(%{kind: :uncategorized}, :uncategorized), do: true
   defp card_matches_scope?(_, _), do: false
 
-  defp fetch_card_items(:uncategorized, catalogue_uuid, mode, limit) do
+  defp fetch_card_items(scope, catalogue_uuid, mode, limit, offset \\ 0)
+
+  defp fetch_card_items(:uncategorized, catalogue_uuid, mode, limit, offset) do
     Catalogue.list_uncategorized_items_paged(catalogue_uuid,
       mode: mode,
-      offset: 0,
+      offset: offset,
       limit: limit
     )
   end
 
-  defp fetch_card_items(category_uuid, _catalogue_uuid, mode, limit)
+  defp fetch_card_items(category_uuid, _catalogue_uuid, mode, limit, offset)
        when is_binary(category_uuid) do
     Catalogue.list_items_for_category_paged(category_uuid,
       mode: mode,
-      offset: 0,
+      offset: offset,
       limit: limit
     )
   end
@@ -1918,9 +1955,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
         <%!-- Status switcher moved to the tabs row above. --%>
 
-        <%!-- Normal (non-search) view: infinite-scroll cards --%>
-        <%!-- Empty states only shown when nothing is loading AND nothing was ever loaded --%>
-        <div :if={is_nil(@search_results) and not @search_loading and @loaded_cards == [] and not @has_more and not @loading and @view_mode == "active"} class="card bg-base-100 shadow">
+        <%!-- Empty states --%>
+        <div :if={is_nil(@search_results) and not @search_loading and @loaded_cards == [] and @view_mode == "active"} class="card bg-base-100 shadow">
           <div class="card-body items-center text-center py-12">
             <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No categories or items yet. Add a category or item to get started.")}</p>
           </div>
@@ -1932,9 +1968,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-        <%!-- Active view: streamed cards (one per category + Uncategorized).
-             Category DnD lives on the Categories tab — Items tab is
-             read-only structure so admins focus on item-level edits. --%>
+        <%!-- Active view: every category card eagerly rendered with a
+             25-item preview. Each card has its own "Show N more"
+             button (PdfSearchModal-style per-group expand) so the user
+             can scan the catalogue's structure at a glance and drill
+             into the categories they care about. --%>
         <div
           :if={is_nil(@search_results) and not @search_loading and @view_mode == "active" and @loaded_cards != []}
           id="catalogue-detail-cards"
@@ -1953,6 +1991,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 uncategorized_total={@uncategorized_total}
                 catalogue={@catalogue}
                 selected_items={@selected_items}
+                expanding={MapSet.member?(@expanding_cards, scope_key(card))}
               />
             </div>
           <% end %>
@@ -1980,24 +2019,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             on_toggle_select="toggle_select_item"
           />
         </div>
-
-        <%!-- Infinite-scroll sentinel (active view only — deleted view
-             is a one-shot 500-row list and doesn't paginate yet). --%>
-        <div
-          :if={is_nil(@search_results) and not @search_loading and @view_mode == "active" and @has_more}
-          id="detail-load-more-sentinel"
-          phx-hook="InfiniteScroll"
-          data-cursor={"#{@cursor.phase}-#{@cursor.category_index}-#{@cursor.item_offset}"}
-          class="py-4"
-        >
-          <div class="flex justify-center">
-            <span class="loading loading-spinner loading-sm text-base-content/30"></span>
-          </div>
-        </div>
-
-          <div :if={is_nil(@search_results) and not @search_loading and @view_mode == "active" and not @has_more and @loaded_cards != []} class="text-center text-xs text-base-content/40 py-2">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "All items loaded")}
-          </div>
         </div>
         <%!-- ── /Items tab ───────────────────────────────────────── --%>
 
@@ -2382,14 +2403,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   attr(:uncategorized_total, :integer, required: true)
   attr(:catalogue, :any, required: true)
   attr(:selected_items, :any, default: nil)
+  attr(:expanding, :boolean, default: false)
 
   defp detail_card(%{card: %{kind: :category}} = assigns) do
     %{uuid: uuid} = assigns.card.category
 
     assigns =
       assigns
-      |> assign(:total, Map.get(assigns.category_counts, uuid, 0))
+      |> assign(:total, assigns.card[:total] || Map.get(assigns.category_counts, uuid, 0))
       |> assign(:depth, Map.get(assigns.category_depths, uuid, 0))
+      |> assign(:loaded, length(assigns.card.items))
 
     ~H"""
     <div
@@ -2473,6 +2496,25 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             selected_uuids={@selected_items}
             on_toggle_select="toggle_select_item"
           />
+          <%!-- Per-category "Show N more" — same expand-on-demand
+               pattern as the PDF search modal. --%>
+          <div :if={@loaded < @total} class="flex justify-center pt-2">
+            <button
+              type="button"
+              phx-click="expand_card"
+              phx-value-scope={@card.category.uuid}
+              disabled={@expanding}
+              class="btn btn-ghost btn-xs"
+            >
+              <%= if @expanding do %>
+                <span class="loading loading-spinner loading-xs"></span>
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Loading…")}
+              <% else %>
+                <.icon name="hero-chevron-down" class="w-3 h-3" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Show %{n} more", n: @total - @loaded)}
+              <% end %>
+            </button>
+          </div>
         </div>
         <%!-- Items table: deleted mode --%>
         <div :if={@card.items != [] and @view_mode == "deleted"} class="mt-2">
@@ -2500,6 +2542,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   end
 
   defp detail_card(%{card: %{kind: :uncategorized}} = assigns) do
+    assigns = assign(assigns, :loaded, length(assigns.card.items))
+
     ~H"""
     <div class="card bg-base-100 shadow">
       <div class="card-body">
@@ -2532,6 +2576,23 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             selected_uuids={@selected_items}
             on_toggle_select="toggle_select_item"
           />
+          <div :if={@loaded < @uncategorized_total and @view_mode == "active"} class="flex justify-center pt-2">
+            <button
+              type="button"
+              phx-click="expand_card"
+              phx-value-scope="uncategorized"
+              disabled={@expanding}
+              class="btn btn-ghost btn-xs"
+            >
+              <%= if @expanding do %>
+                <span class="loading loading-spinner loading-xs"></span>
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Loading…")}
+              <% else %>
+                <.icon name="hero-chevron-down" class="w-3 h-3" />
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Show %{n} more", n: @uncategorized_total - @loaded)}
+              <% end %>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -51,6 +51,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         view_mode: "active",
         deleted_count: 0,
         active_item_count: 0,
+        deleted_item_count: 0,
+        active_category_count: 0,
+        deleted_category_count: 0,
         search_query: "",
         search_results: nil,
         search_offset: 0,
@@ -58,7 +61,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         search_has_more: false,
         search_loading: false,
         show_pdf_search: false,
-        pdf_search_item: nil
+        pdf_search_item: nil,
+        tab: "items"
       )
 
     if connected?(socket) do
@@ -81,6 +85,20 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     else
       {:ok, socket}
     end
+  end
+
+  # `?tab=items|categories` is reflected into socket assigns on every
+  # patch. The default is "items"; any unknown value falls back to
+  # "items" so a stale link can't push the LV into an undefined tab.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    tab =
+      case params["tab"] do
+        "categories" -> "categories"
+        _ -> "items"
+      end
+
+    {:noreply, assign(socket, :tab, tab)}
   end
 
   # PubSub: another LV touched a category/item/catalogue/smart-rule.
@@ -148,6 +166,19 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
      |> assign(:view_mode, mode)
      |> assign(:confirm_delete, nil)
      |> reset_and_load()}
+  end
+
+  # Items/Categories tab switch. URL is patched so the choice survives
+  # back-button + reload + share-link. handle_params/3 echoes the param
+  # into the :tab assign, so we don't update assigns here directly.
+  def handle_event("switch_tab", %{"tab" => tab}, socket) when tab in ~w(items categories) do
+    target =
+      case tab do
+        "items" -> Paths.catalogue_detail(socket.assigns.catalogue_uuid)
+        "categories" -> Paths.catalogue_detail(socket.assigns.catalogue_uuid) <> "?tab=categories"
+      end
+
+    {:noreply, push_patch(socket, to: target)}
   end
 
   def handle_event("load_more", _params, socket) do
@@ -611,6 +642,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       loading: has_any_content,
       deleted_count: deleted_count,
       active_item_count: Catalogue.item_count_for_catalogue(uuid),
+      deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
+      active_category_count: Catalogue.category_count_for_catalogue(uuid),
+      deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid),
       view_mode: view_mode
     )
     |> load_next_batch()
@@ -626,6 +660,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     assign(socket,
       deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
       active_item_count: Catalogue.item_count_for_catalogue(uuid),
+      deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
+      active_category_count: Catalogue.category_count_for_catalogue(uuid),
+      deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid),
       category_counts: Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode),
       uncategorized_total: Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
     )
@@ -669,7 +706,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       category_counts: Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode),
       uncategorized_total: Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode),
       deleted_count: deleted_count,
-      active_item_count: Catalogue.item_count_for_catalogue(uuid)
+      active_item_count: Catalogue.item_count_for_catalogue(uuid),
+      deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
+      active_category_count: Catalogue.category_count_for_catalogue(uuid),
+      deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid)
     )
   end
 
@@ -1141,20 +1181,41 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </:actions>
         </.admin_page_header>
 
-        <div :if={@catalogue.description || Decimal.gt?(@catalogue.markup_percentage, Decimal.new("0"))} class="-mt-4">
-          <p :if={@catalogue.description} class="text-base-content/60">
+        <div :if={@catalogue.description} class="-mt-4">
+          <p class="text-base-content/60">
             {@catalogue.description}
-          </p>
-          <p :if={Decimal.gt?(@catalogue.markup_percentage, Decimal.new("0"))} class="text-sm text-base-content/50 mt-0.5">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Markup: %{percentage}%", percentage: Decimal.to_string(@catalogue.markup_percentage, :normal))}
           </p>
         </div>
 
-        <%!-- Search --%>
-        <.search_input :if={@view_mode == "active"} query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items by name, description, or SKU...")} />
+        <%!-- Items / Categories tab bar --%>
+        <div role="tablist" class="tabs tabs-bordered">
+          <button
+            type="button"
+            role="tab"
+            phx-click="switch_tab"
+            phx-value-tab="items"
+            class={["tab", @tab == "items" && "tab-active"]}
+          >
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Items")}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            phx-click="switch_tab"
+            phx-value-tab="categories"
+            class={["tab", @tab == "categories" && "tab-active"]}
+          >
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Categories")} ({length(@category_list)})
+          </button>
+        </div>
 
-        <%!-- View toggle --%>
-        <.view_mode_toggle :if={@category_list != []} storage_key="catalogue-detail-items" />
+        <%!-- ── Items tab ────────────────────────────────────────── --%>
+        <div :if={@tab == "items"} class="flex flex-col gap-6">
+          <%!-- Search (Items tab only — Categories tab has no search yet) --%>
+          <.search_input :if={@view_mode == "active"} query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items by name, description, or SKU...")} />
+
+          <%!-- View toggle --%>
+          <.view_mode_toggle :if={@category_list != []} storage_key="catalogue-detail-items" />
 
         <%!-- Search results (visible when the user has typed a query) --%>
         <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
@@ -1177,7 +1238,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           <div :if={@search_results not in [nil, []]} class={["transition-opacity", @search_loading && "opacity-50"]}>
             <.item_table
               items={@search_results}
-              columns={[:name, :sku, :base_price, :price, :unit, :status]}
+              columns={[:name, :sku, :price, :unit, :status]}
               markup_percentage={@catalogue.markup_percentage}
               edit_path={&Paths.item_edit/1}
               pdf_search_event="show_pdf_search"
@@ -1202,8 +1263,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-        <%!-- Status tabs --%>
-        <div :if={@deleted_count > 0 and is_nil(@search_results) and not @search_loading} class="flex items-center gap-0.5 border-b border-base-200">
+        <%!-- Status tabs (item counts — items tab) --%>
+        <div :if={(@deleted_item_count > 0 or @view_mode == "deleted") and is_nil(@search_results) and not @search_loading} class="flex items-center gap-0.5 border-b border-base-200">
           <button
             type="button"
             phx-click="switch_view"
@@ -1230,7 +1291,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               )
             ]}
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_count})
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_item_count})
           </button>
         </div>
 
@@ -1248,30 +1309,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-        <%!-- Streamed cards (one per category, one for uncategorized). --%>
+        <%!-- Streamed cards (one per category, one for uncategorized).
+             Category DnD lives on the Categories tab — Items tab is
+             read-only structure so admins focus on item-level edits. --%>
         <div
           :if={is_nil(@search_results) and not @search_loading and @loaded_cards != []}
           id="catalogue-detail-cards"
           class="flex flex-col gap-6"
-          data-sortable="true"
-          data-sortable-event="reorder_categories"
-          data-sortable-items=".sortable-item"
-          data-sortable-hide-source="false"
-          data-sortable-group="catalogue-categories"
-          data-sortable-handle=".pk-drag-handle"
-          phx-hook={if @view_mode == "active", do: "SortableGrid"}
         >
           <%= for {card, card_idx} <- Enum.with_index(@loaded_cards) do %>
-            <div
-              class={
-                cond do
-                  card.kind == :uncategorized -> "sortable-ignore"
-                  card.category && card.category.status == "deleted" -> "sortable-ignore"
-                  true -> "sortable-item"
-                end
-              }
-              data-id={card.kind == :category && card.category && card.category.uuid}
-            >
+            <div>
               <.detail_card
                 card={card}
                 card_idx={card_idx}
@@ -1300,9 +1347,88 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-        <div :if={is_nil(@search_results) and not @search_loading and not @has_more and @loaded_cards != []} class="text-center text-xs text-base-content/40 py-2">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "All items loaded")}
+          <div :if={is_nil(@search_results) and not @search_loading and not @has_more and @loaded_cards != []} class="text-center text-xs text-base-content/40 py-2">
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "All items loaded")}
+          </div>
         </div>
+        <%!-- ── /Items tab ───────────────────────────────────────── --%>
+
+        <%!-- ── Categories tab ───────────────────────────────────── --%>
+        <div :if={@tab == "categories"} class="flex flex-col gap-4">
+          <%!-- Status switcher (category counts — categories tab) --%>
+          <div :if={@deleted_category_count > 0 or @view_mode == "deleted"} class="flex items-center gap-0.5 border-b border-base-200">
+            <button
+              type="button"
+              phx-click="switch_view"
+              phx-value-mode="active"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@view_mode == "active",
+                  do: "border-primary text-primary",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")} ({@active_category_count})
+            </button>
+            <button
+              type="button"
+              phx-click="switch_view"
+              phx-value-mode="deleted"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@view_mode == "deleted",
+                  do: "border-error text-error",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_category_count})
+            </button>
+          </div>
+
+          <% visible_category_count =
+            if @view_mode == "deleted", do: @deleted_category_count, else: @active_category_count %>
+
+          <div :if={visible_category_count == 0} class="card bg-base-100 shadow">
+            <div class="card-body items-center text-center py-12">
+              <p class="text-base-content/60">
+                {if @view_mode == "deleted",
+                  do: Gettext.gettext(PhoenixKitWeb.Gettext, "No deleted categories."),
+                  else: Gettext.gettext(PhoenixKitWeb.Gettext, "No categories yet. Add one to start organizing items.")}
+              </p>
+              <.link :if={@view_mode == "active"} navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-primary btn-sm mt-2">
+                <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Add Category")}
+              </.link>
+            </div>
+          </div>
+
+          <%!-- Flat list of categories with depth indent. Same DnD wiring
+               as the Items tab so reorder works identically. --%>
+          <div
+            :if={visible_category_count > 0}
+            id="catalogue-categories-list"
+            class="flex flex-col gap-2"
+            data-sortable="true"
+            data-sortable-event="reorder_categories"
+            data-sortable-items=".sortable-item"
+            data-sortable-hide-source="false"
+            data-sortable-group="catalogue-categories-tab"
+            data-sortable-handle=".pk-drag-handle"
+            phx-hook={if @view_mode == "active", do: "SortableGrid"}
+          >
+            <%= for cat <- @category_list do %>
+              <.category_row
+                category={cat}
+                depth={Map.get(@category_depths, cat.uuid, 0)}
+                count={Map.get(@category_counts, cat.uuid, 0)}
+                view_mode={@view_mode}
+                sibling_count={Enum.count(@category_list, &(&1.parent_uuid == cat.parent_uuid))}
+              />
+            <% end %>
+          </div>
+        </div>
+        <%!-- ── /Categories tab ──────────────────────────────────── --%>
       </div>
 
       <.confirm_modal
@@ -1381,15 +1507,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   attr(:catalogue, :any, required: true)
 
   defp detail_card(%{card: %{kind: :category}} = assigns) do
-    %{uuid: uuid, parent_uuid: parent_uuid} = assigns.card.category
-    siblings = Enum.filter(assigns.category_list, &(&1.parent_uuid == parent_uuid))
-    sibling_count = length(siblings)
+    %{uuid: uuid} = assigns.card.category
 
     assigns =
       assigns
       |> assign(:total, Map.get(assigns.category_counts, uuid, 0))
       |> assign(:depth, Map.get(assigns.category_depths, uuid, 0))
-      |> assign(:sibling_count, sibling_count)
 
     ~H"""
     <div
@@ -1400,13 +1523,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       <div class="card-body">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <div
-              :if={@view_mode == "active" and @sibling_count > 1}
-              class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
-              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder (among siblings)")}
-            >
-              <.icon name="hero-bars-3" class="w-4 h-4" />
-            </div>
             <.link
               :if={@view_mode == "active"}
               navigate={Paths.category_edit(@card.category.uuid)}
@@ -1468,7 +1584,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <div :if={@card.items != [] and @view_mode == "active"} class="mt-2">
           <.item_table
             items={@card.items}
-            columns={[:name, :sku, :base_price, :price, :unit, :status]}
+            columns={[:name, :sku, :price, :unit, :status]}
             markup_percentage={@catalogue.markup_percentage}
             edit_path={&Paths.item_edit/1}
             on_delete="delete_item"
@@ -1490,7 +1606,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <div :if={@card.items != [] and @view_mode == "deleted"} class="mt-2">
           <.item_table
             items={@card.items}
-            columns={[:name, :sku, :base_price, :price, :unit, :status]}
+            columns={[:name, :sku, :price, :unit, :status]}
             markup_percentage={@catalogue.markup_percentage}
             on_restore="restore_item"
             on_permanent_delete="show_delete_confirm"
@@ -1523,7 +1639,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <div class={if @category_total > 0, do: "mt-2", else: ""}>
           <.item_table
             items={@card.items}
-            columns={[:name, :sku, :base_price, :unit, :status]}
+            columns={[:name, :sku, :unit, :status]}
             edit_path={if @view_mode == "active", do: &Paths.item_edit/1}
             on_delete={if @view_mode == "active", do: "delete_item"}
             on_restore={if @view_mode == "deleted", do: "restore_item"}
@@ -1541,6 +1657,95 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               category_uuid: nil
             }}
           />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # One row in the Categories tab — a compact card with depth indent,
+  # drag handle (active mode only, when there are siblings to swap with),
+  # name (linked to edit), item count, and per-mode actions.
+  attr(:category, :map, required: true)
+  attr(:depth, :integer, required: true)
+  attr(:count, :integer, required: true)
+  attr(:view_mode, :string, required: true)
+  attr(:sibling_count, :integer, required: true)
+
+  defp category_row(assigns) do
+    ~H"""
+    <div
+      :if={@view_mode == "active" or @category.status == "deleted"}
+      class={
+        cond do
+          @view_mode == "active" and @category.status == "active" -> "sortable-item"
+          true -> "sortable-ignore"
+        end
+      }
+      data-id={@category.status == "active" && @category.uuid}
+      style={"margin-left: #{@depth * 1.5}rem"}
+    >
+      <div class="card card-sm bg-base-100 shadow">
+        <div class="card-body py-3 flex-row items-center justify-between gap-3">
+          <div class="flex items-center gap-2 min-w-0">
+            <div
+              :if={@view_mode == "active" and @sibling_count > 1 and @category.status == "active"}
+              class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
+              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder (among siblings)")}
+            >
+              <.icon name="hero-bars-3" class="w-4 h-4" />
+            </div>
+            <.link
+              :if={@view_mode == "active" and @category.status == "active"}
+              navigate={Paths.category_edit(@category.uuid)}
+              class="font-medium link link-hover truncate"
+            >
+              {@category.name}
+            </.link>
+            <span
+              :if={@view_mode != "active" or @category.status != "active"}
+              class={["font-medium truncate", @category.status == "deleted" && "text-error/70"]}
+            >
+              {@category.name}
+            </span>
+            <span :if={@category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
+            <span class="badge badge-ghost badge-sm">{@count} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
+          </div>
+
+          <%!-- Active mode: Edit + Delete --%>
+          <div :if={@view_mode == "active" and @category.status == "active"} class="flex gap-1 shrink-0">
+            <.link navigate={Paths.category_edit(@category.uuid)} class="btn btn-ghost btn-xs">
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
+            </.link>
+            <button
+              phx-click="trash_category"
+              phx-value-uuid={@category.uuid}
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
+              class="btn btn-ghost btn-xs text-error"
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+            </button>
+          </div>
+
+          <%!-- Deleted mode: Restore + Permanent Delete --%>
+          <div :if={@view_mode == "deleted" and @category.status == "deleted"} class="flex gap-1 shrink-0">
+            <button
+              phx-click="restore_category"
+              phx-value-uuid={@category.uuid}
+              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")}
+              class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+            </button>
+            <button
+              phx-click="show_delete_confirm"
+              phx-value-uuid={@category.uuid}
+              phx-value-type="category"
+              class="btn btn-ghost btn-xs text-error"
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -38,6 +38,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # retry. Calibrated for "user lost network mid-click" not "the DB is
   # slow" — the inline query itself rarely takes more than 50ms.
   @expand_timeout_ms 8_000
+  # Cross-tab bulk-change red-flash → state-refresh delay. Long enough
+  # that the receiver sees the leaving rows pulse red before they
+  # vanish on the refresh, short enough not to feel laggy.
+  @bulk_change_apply_delay_ms 800
 
   @impl true
   def mount(%{"uuid" => uuid}, _session, socket) do
@@ -236,7 +240,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         do: Enum.reduce(uuids, socket, &flash_reorder(&2, &1, leaving_status)),
         else: socket
 
-    Process.send_after(self(), {:bulk_change_apply, kind, uuids}, 800)
+    Process.send_after(self(), {:bulk_change_apply, kind, uuids}, @bulk_change_apply_delay_ms)
 
     {:noreply, socket}
   end
@@ -264,33 +268,32 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # `expanding_cards` and we no-op.
   def handle_info({:apply_expand, scope}, socket) do
     if MapSet.member?(socket.assigns.expanding_cards, scope) do
-      mode = view_mode_to_atom(socket.assigns.view_mode)
-      catalogue_uuid = socket.assigns.catalogue_uuid
-
-      cards =
-        Enum.map(socket.assigns.loaded_cards, fn card ->
-          if scope_matches_card?(scope, card) do
-            more =
-              fetch_card_items(
-                card_scope(card),
-                catalogue_uuid,
-                mode,
-                @per_card,
-                length(card.items)
-              )
-
-            %{card | items: card.items ++ more}
-          else
-            card
-          end
-        end)
-
-      {:noreply,
-       socket
-       |> assign(:loaded_cards, cards)
-       |> assign(:expanding_cards, MapSet.delete(socket.assigns.expanding_cards, scope))}
+      {:noreply, do_apply_expand(socket, scope)}
     else
       {:noreply, socket}
+    end
+  end
+
+  defp do_apply_expand(socket, scope) do
+    mode = view_mode_to_atom(socket.assigns.view_mode)
+    catalogue_uuid = socket.assigns.catalogue_uuid
+
+    cards =
+      Enum.map(socket.assigns.loaded_cards, &expand_one_card(&1, scope, catalogue_uuid, mode))
+
+    socket
+    |> assign(:loaded_cards, cards)
+    |> assign(:expanding_cards, MapSet.delete(socket.assigns.expanding_cards, scope))
+  end
+
+  defp expand_one_card(card, scope, catalogue_uuid, mode) do
+    if scope_matches_card?(scope, card) do
+      more =
+        fetch_card_items(card_scope(card), catalogue_uuid, mode, @per_card, length(card.items))
+
+      %{card | items: card.items ++ more}
+    else
+      card
     end
   end
 
@@ -876,7 +879,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   def handle_event(
         "reorder_items",
         %{"ordered_ids" => ordered_ids, "moved_id" => moved_id, "fromCatalogueUuid" => _} =
-            params,
+          params,
         socket
       )
       when is_list(ordered_ids) and is_binary(moved_id) do
@@ -1024,7 +1027,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     socket
     |> assign(:bulk_confirm, nil)
     |> assign(:selected_items, MapSet.new())
-    |> put_flash(:info, "Deleted #{count} items.")
+    |> put_flash(
+      :info,
+      Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted %{count} items.", count: count)
+    )
     |> reset_and_load()
     |> then(&{:noreply, &1})
   end
@@ -1037,7 +1043,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     socket
     |> assign(:bulk_confirm, nil)
     |> assign(:selected_items, MapSet.new())
-    |> put_flash(:info, "Permanently deleted #{count} items.")
+    |> put_flash(
+      :info,
+      Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently deleted %{count} items.", count: count)
+    )
     |> reset_and_load()
     |> then(&{:noreply, &1})
   end
@@ -1049,7 +1058,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
     socket
     |> assign(:selected_items, MapSet.new())
-    |> put_flash(:info, "Restored #{count} items.")
+    |> put_flash(
+      :info,
+      Gettext.gettext(PhoenixKitWeb.Gettext, "Restored %{count} items.", count: count)
+    )
     |> reset_and_load()
     |> then(&{:noreply, &1})
   end
@@ -1057,7 +1069,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp do_bulk_move_items(socket, target_uuid) do
     uuids = socket.assigns.selected_items |> MapSet.to_list()
 
-    case Catalogue.bulk_move_items_to_category(uuids, target_uuid, actor_opts(socket)) do
+    opts =
+      actor_opts(socket) |> Keyword.put(:catalogue_uuid, socket.assigns.catalogue_uuid)
+
+    case Catalogue.bulk_move_items_to_category(uuids, target_uuid, opts) do
       {:ok, count} ->
         # `:moved` triggers the receiver's full red-fade → refresh →
         # green-fade sequence on every other open tab.
@@ -1066,12 +1081,33 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         socket
         |> assign(:bulk_move_modal, nil)
         |> assign(:selected_items, MapSet.new())
-        |> put_flash(:info, "Moved #{count} items.")
+        |> put_flash(
+          :info,
+          Gettext.gettext(PhoenixKitWeb.Gettext, "Moved %{count} items.", count: count)
+        )
         |> reset_and_load()
         |> then(&{:noreply, &1})
 
       {:error, :category_not_found} ->
-        {:noreply, put_flash(socket, :error, "Target category not found.")}
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Target category not found.")
+         )}
+
+      {:error, scope_err} when scope_err in [:wrong_catalogue_scope, :missing_catalogue_scope] ->
+        log_operation_error(socket, "bulk_move_items_to_category", %{reason: scope_err})
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(
+             PhoenixKitWeb.Gettext,
+             "Items can only be moved within this catalogue."
+           )
+         )}
     end
   end
 
@@ -1091,14 +1127,22 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         socket
         |> assign(:bulk_confirm, nil)
         |> assign(:selected_categories, MapSet.new())
-        |> put_flash(:info, "Deleted #{count} categories.")
+        |> put_flash(
+          :info,
+          Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted %{count} categories.", count: count)
+        )
         |> reset_and_load()
         |> then(&{:noreply, &1})
 
       {:error, reason} ->
         log_operation_error(socket, "bulk_trash_categories", %{reason: reason})
 
-        {:noreply, put_flash(socket, :error, "Failed to delete categories: #{inspect(reason)}")}
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete categories.")
+         )}
     end
   end
 
@@ -1117,14 +1161,27 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     socket =
       socket
       |> assign(:selected_categories, MapSet.new())
-      |> put_flash(:info, "Restored #{ok} categories.")
+      |> put_flash(
+        :info,
+        Gettext.gettext(PhoenixKitWeb.Gettext, "Restored %{count} categories.", count: ok)
+      )
       |> reset_and_load()
 
-    if errors == [],
-      do: {:noreply, socket},
-      else:
-        {:noreply,
-         put_flash(socket, :error, "Some categories couldn't be restored: #{inspect(errors)}")}
+    if errors == [] do
+      {:noreply, socket}
+    else
+      log_operation_error(socket, "bulk_restore_categories_partial", %{reasons: errors})
+
+      {:noreply,
+       put_flash(
+         socket,
+         :error,
+         Gettext.gettext(
+           PhoenixKitWeb.Gettext,
+           "Some categories couldn't be restored. The catalogue may be deleted — restore it first."
+         )
+       )}
+    end
   end
 
   defp build_trash_modal_state(%Category{} = category, item_count) do

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -1258,6 +1258,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           data-sortable-items=".sortable-item"
           data-sortable-hide-source="false"
           data-sortable-group="catalogue-categories"
+          data-sortable-handle=".pk-drag-handle"
           phx-hook={if @view_mode == "active", do: "SortableGrid"}
         >
           <%= for {card, card_idx} <- Enum.with_index(@loaded_cards) do %>
@@ -1401,7 +1402,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           <div class="flex items-center gap-2">
             <div
               :if={@view_mode == "active" and @sibling_count > 1}
-              class="cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
+              class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
               title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder (among siblings)")}
             >
               <.icon name="hero-bars-3" class="w-4 h-4" />

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -161,6 +161,98 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     {:noreply, assign(socket, show_pdf_search: false, pdf_search_item: nil)}
   end
 
+  # Cross-tab live reorder: another open detail page just reordered
+  # items inside a card on the same catalogue. Refresh just that card's
+  # items (preserves scroll) and fire the same flash the originator
+  # saw. `from == self()` is the originating LV — already updated
+  # locally, skip to avoid double-flashing.
+  def handle_info(
+        {:catalogue_card_refresh, cat_uuid, scope, flash_uuid, flash_status, from},
+        %{assigns: %{catalogue_uuid: catalogue_uuid}} = socket
+      )
+      when cat_uuid == catalogue_uuid and from != self() do
+    socket = refresh_card_items(socket, scope)
+
+    socket =
+      if is_binary(flash_uuid),
+        do: flash_reorder(socket, flash_uuid, flash_status),
+        else: socket
+
+    {:noreply, socket}
+  end
+
+  # Sender's own broadcast — already handled locally; ignore.
+  def handle_info({:catalogue_card_refresh, _, _, _, _, from}, socket) when from == self(),
+    do: {:noreply, socket}
+
+  # Cross-tab live reorder for categories: order positions changed,
+  # which affects how every streamed card is laid out. Heavier
+  # reset_and_load — same trade-off the local reorder makes.
+  def handle_info(
+        {:catalogue_category_reorder, cat_uuid, moved_id, status, from},
+        %{assigns: %{catalogue_uuid: catalogue_uuid}} = socket
+      )
+      when cat_uuid == catalogue_uuid and from != self() do
+    socket = reset_and_load(socket)
+
+    socket =
+      if is_binary(moved_id),
+        do: flash_reorder(socket, moved_id, status),
+        else: socket
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:catalogue_category_reorder, _, _, _, from}, socket) when from == self(),
+    do: {:noreply, socket}
+
+  # Cross-tab live bulk change: another open detail page just bulk-
+  # trashed / restored / moved / hard-deleted items. Two-step animation
+  # for receivers — flash the "leaving" colour on every affected DOM
+  # row immediately, schedule the actual state refresh after the flash
+  # plays out (~800ms), then on refresh fire green flash for the
+  # arriving rows when the kind is :restored or :moved.
+  def handle_info(
+        {:catalogue_bulk_change, cat_uuid, kind, uuids, _scopes, from},
+        %{assigns: %{catalogue_uuid: catalogue_uuid}} = socket
+      )
+      when cat_uuid == catalogue_uuid and from != self() do
+    leaving_status =
+      case kind do
+        # Restored items aren't currently visible — nothing to flash red.
+        :restored -> nil
+        # Trashed / moved / permanent-deleted: they're on this tab now,
+        # so red-flash them as they're about to leave.
+        _ -> :error
+      end
+
+    socket =
+      if leaving_status,
+        do: Enum.reduce(uuids, socket, &flash_reorder(&2, &1, leaving_status)),
+        else: socket
+
+    Process.send_after(self(), {:bulk_change_apply, kind, uuids}, 800)
+
+    {:noreply, socket}
+  end
+
+  # Originator's own bulk-change broadcast — already updated locally.
+  def handle_info({:catalogue_bulk_change, _, _, _, _, from}, socket) when from == self(),
+    do: {:noreply, socket}
+
+  # Tail of the cross-tab bulk animation — applies the actual state
+  # refresh and the arriving-side green flash (for moves / restores).
+  def handle_info({:bulk_change_apply, kind, uuids}, socket) do
+    socket = socket |> reset_and_load() |> refresh_counts()
+
+    socket =
+      if kind in [:restored, :moved],
+        do: Enum.reduce(uuids, socket, &flash_reorder(&2, &1, :ok)),
+        else: socket
+
+    {:noreply, socket}
+  end
+
   def handle_info(msg, socket) do
     Logger.debug("CatalogueDetailLive ignored unhandled message: #{inspect(msg)}")
     {:noreply, socket}
@@ -748,6 +840,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                ) do
           from_scope = from_category_uuid || :uncategorized
           to_scope = to_category_uuid || :uncategorized
+          # Source loses an item, destination gains one — broadcast both
+          # so other open tabs refresh both cards. Flash only on the
+          # destination scope (where the row landed).
+          PubSub.broadcast_card_refresh(to_catalogue_uuid, from_scope, nil, :ok)
+          PubSub.broadcast_card_refresh(to_catalogue_uuid, to_scope, moved_id, :ok)
 
           {:noreply,
            socket
@@ -819,6 +916,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp do_bulk_trash_items(socket) do
     uuids = socket.assigns.selected_items |> MapSet.to_list()
     {count, _} = Catalogue.bulk_trash_items(uuids, actor_opts(socket))
+    PubSub.broadcast_bulk_change(socket.assigns.catalogue_uuid, :trashed, uuids, [])
 
     socket
     |> assign(:bulk_confirm, nil)
@@ -831,6 +929,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp do_bulk_permanent_delete_items(socket) do
     uuids = socket.assigns.selected_items |> MapSet.to_list()
     {count, _} = Catalogue.bulk_permanently_delete_items(uuids, actor_opts(socket))
+    PubSub.broadcast_bulk_change(socket.assigns.catalogue_uuid, :permanent_delete, uuids, [])
 
     socket
     |> assign(:bulk_confirm, nil)
@@ -843,6 +942,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp do_bulk_restore_items(socket) do
     uuids = socket.assigns.selected_items |> MapSet.to_list()
     {count, _} = Catalogue.bulk_restore_items(uuids, actor_opts(socket))
+    PubSub.broadcast_bulk_change(socket.assigns.catalogue_uuid, :restored, uuids, [])
 
     socket
     |> assign(:selected_items, MapSet.new())
@@ -856,6 +956,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
     case Catalogue.bulk_move_items_to_category(uuids, target_uuid, actor_opts(socket)) do
       {:ok, count} ->
+        # `:moved` triggers the receiver's full red-fade → refresh →
+        # green-fade sequence on every other open tab.
+        PubSub.broadcast_bulk_change(socket.assigns.catalogue_uuid, :moved, uuids, [])
+
         socket
         |> assign(:bulk_move_modal, nil)
         |> assign(:selected_items, MapSet.new())
@@ -965,6 +1069,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          ) do
       :ok ->
         scope = category_uuid || :uncategorized
+        # Tell other open detail tabs to refresh this card + flash.
+        PubSub.broadcast_card_refresh(catalogue_uuid, scope, moved_id, :ok)
 
         {:noreply,
          socket
@@ -1607,6 +1713,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
     case result do
       :ok ->
+        # Other open tabs need a full reset_and_load to pick up the new
+        # category order — affects how every streamed card renders.
+        PubSub.broadcast_category_reorder(socket.assigns.catalogue_uuid, moved_id, :ok)
         {:noreply, flash_reorder(socket, moved_id, :ok)}
 
       {:error, reason} ->

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -50,6 +50,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         loading: false,
         confirm_delete: nil,
         trash_modal: nil,
+        bulk_move_modal: nil,
+        bulk_confirm: nil,
+        selected_items: MapSet.new(),
+        selected_categories: MapSet.new(),
         view_mode: "active",
         deleted_count: 0,
         active_item_count: 0,
@@ -103,6 +107,18 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       case params["tab"] do
         "categories" -> "categories"
         _ -> "items"
+      end
+
+    socket =
+      if tab == socket.assigns[:tab] do
+        socket
+      else
+        # Tab change: drop both selection sets — selection is per-tab
+        # in the UI, but they share the same modal/action-bar pipes,
+        # so a stale set across tabs would mis-target bulk actions.
+        socket
+        |> assign(:selected_items, MapSet.new())
+        |> assign(:selected_categories, MapSet.new())
       end
 
     {:noreply, socket |> assign(:tab, tab) |> maybe_auto_flip_to_active()}
@@ -172,6 +188,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
      socket
      |> assign(:view_mode, mode)
      |> assign(:confirm_delete, nil)
+     |> assign(:selected_items, MapSet.new())
+     |> assign(:selected_categories, MapSet.new())
      |> reset_and_load()}
   end
 
@@ -281,8 +299,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          )}
 
       {:error, :parent_catalogue_deleted} ->
-        {:noreply,
-         put_flash(socket, :error, Errors.message(:parent_catalogue_deleted))}
+        {:noreply, put_flash(socket, :error, Errors.message(:parent_catalogue_deleted))}
 
       {:error, reason} ->
         log_operation_error(socket, "restore_item", %{
@@ -393,6 +410,17 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   def handle_event("confirm_trash_category", _params, socket) do
     case socket.assigns.trash_modal do
+      %{bulk: true, bulk_uuids: uuids, disposition: disp, target_uuid: target_uuid} ->
+        items_opt = disposition_to_items_opt(disp, target_uuid)
+
+        if is_nil(items_opt) do
+          {:noreply, socket}
+        else
+          socket
+          |> assign(:trash_modal, nil)
+          |> do_bulk_trash_categories_with(uuids, items_opt)
+        end
+
       %{category: category, disposition: :uncategorize} ->
         socket
         |> assign(:trash_modal, nil)
@@ -419,6 +447,158 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     {:noreply, assign(socket, :trash_modal, nil)}
   end
 
+  # ── Bulk selection + actions ────────────────────────────────────
+
+  def handle_event("toggle_select_item", %{"uuid" => uuid}, socket) do
+    {:noreply, assign(socket, :selected_items, toggle(socket.assigns.selected_items, uuid))}
+  end
+
+  def handle_event("toggle_select_category", %{"uuid" => uuid}, socket) do
+    {:noreply,
+     assign(socket, :selected_categories, toggle(socket.assigns.selected_categories, uuid))}
+  end
+
+  def handle_event("clear_selection", _params, socket) do
+    {:noreply,
+     assign(socket,
+       selected_items: MapSet.new(),
+       selected_categories: MapSet.new()
+     )}
+  end
+
+  # Bulk delete items — opens a confirm modal stamped with the selection
+  # count and the operation type. Confirmation routes through
+  # `confirm_bulk_action` below.
+  def handle_event("request_bulk_delete_items", _params, socket) do
+    count = MapSet.size(socket.assigns.selected_items)
+
+    if count == 0 do
+      {:noreply, socket}
+    else
+      mode =
+        if socket.assigns.view_mode == "deleted",
+          do: :permanent,
+          else: :trash
+
+      {:noreply, assign(socket, :bulk_confirm, %{kind: :items, mode: mode, count: count})}
+    end
+  end
+
+  def handle_event("request_bulk_restore_items", _params, socket) do
+    count = MapSet.size(socket.assigns.selected_items)
+    if count == 0, do: {:noreply, socket}, else: do_bulk_restore_items(socket)
+  end
+
+  def handle_event("request_bulk_move_items", _params, socket) do
+    count = MapSet.size(socket.assigns.selected_items)
+
+    if count == 0 do
+      {:noreply, socket}
+    else
+      targets =
+        socket.assigns.catalogue_uuid
+        |> Catalogue.list_category_tree(mode: :active)
+
+      {:noreply,
+       assign(socket, :bulk_move_modal, %{
+         count: count,
+         targets: targets,
+         disposition: :uncategorize,
+         target_uuid: nil
+       })}
+    end
+  end
+
+  def handle_event("set_bulk_move_disposition", %{"disposition" => disp}, socket) do
+    modal = socket.assigns.bulk_move_modal || %{}
+
+    new_modal =
+      case disp do
+        "uncategorize" -> %{modal | disposition: :uncategorize, target_uuid: nil}
+        "move_to" -> %{modal | disposition: :move_to}
+        _ -> modal
+      end
+
+    {:noreply, assign(socket, :bulk_move_modal, new_modal)}
+  end
+
+  def handle_event("select_bulk_move_target", %{"category_uuid" => uuid}, socket) do
+    modal = socket.assigns.bulk_move_modal || %{}
+    {:noreply, assign(socket, :bulk_move_modal, %{modal | target_uuid: blank_to_nil(uuid)})}
+  end
+
+  def handle_event("confirm_bulk_move_items", _params, socket) do
+    case socket.assigns.bulk_move_modal do
+      %{disposition: :uncategorize} ->
+        do_bulk_move_items(socket, nil)
+
+      %{disposition: :move_to, target_uuid: target_uuid} when not is_nil(target_uuid) ->
+        do_bulk_move_items(socket, target_uuid)
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("cancel_bulk_move", _params, socket) do
+    {:noreply, assign(socket, :bulk_move_modal, nil)}
+  end
+
+  def handle_event("confirm_bulk_action", _params, socket) do
+    case socket.assigns.bulk_confirm do
+      %{kind: :items, mode: :trash} ->
+        do_bulk_trash_items(socket)
+
+      %{kind: :items, mode: :permanent} ->
+        do_bulk_permanent_delete_items(socket)
+
+      %{kind: :categories} ->
+        do_bulk_trash_categories(socket)
+
+      _ ->
+        {:noreply, assign(socket, :bulk_confirm, nil)}
+    end
+  end
+
+  def handle_event("cancel_bulk_action", _params, socket) do
+    {:noreply, assign(socket, :bulk_confirm, nil)}
+  end
+
+  # Bulk delete categories: routes through trash_modal with bulk: true
+  # so the disposition picker is shared with the single-category flow.
+  def handle_event("request_bulk_delete_categories", _params, socket) do
+    uuids = socket.assigns.selected_categories |> MapSet.to_list()
+
+    if uuids == [] do
+      {:noreply, socket}
+    else
+      # The bulk modal needs at least one category struct for the
+      # name preview + same-catalogue target list. Pull one and use
+      # it as the surface.
+      case Catalogue.get_category(hd(uuids)) do
+        nil ->
+          {:noreply, socket}
+
+        category ->
+          {:noreply,
+           assign(socket, :trash_modal, %{
+             category: category,
+             item_count: bulk_subtree_item_count(uuids),
+             targets: Catalogue.list_move_target_categories(category),
+             disposition: :uncategorize,
+             target_uuid: nil,
+             bulk: true,
+             bulk_uuids: uuids
+           })}
+      end
+    end
+  end
+
+  def handle_event("request_bulk_restore_categories", _params, socket) do
+    uuids = socket.assigns.selected_categories |> MapSet.to_list()
+    if uuids == [], do: {:noreply, socket}, else: do_bulk_restore_categories(socket, uuids)
+  end
+
   def handle_event("restore_category", %{"uuid" => uuid}, socket) do
     with %{} = category <- Catalogue.get_category(uuid),
          {:ok, _} <- Catalogue.restore_category(category, actor_opts(socket)) do
@@ -436,8 +616,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          )}
 
       {:error, :parent_catalogue_deleted} ->
-        {:noreply,
-         put_flash(socket, :error, Errors.message(:parent_catalogue_deleted))}
+        {:noreply, put_flash(socket, :error, Errors.message(:parent_catalogue_deleted))}
 
       {:error, reason} ->
         log_operation_error(socket, "restore_category", %{
@@ -608,6 +787,127 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     else
       apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids)
     end
+  end
+
+  # ── Bulk-action helpers ──────────────────────────────────────────
+
+  defp toggle(set, uuid) do
+    if MapSet.member?(set, uuid), do: MapSet.delete(set, uuid), else: MapSet.put(set, uuid)
+  end
+
+  defp disposition_to_items_opt(:uncategorize, _), do: :uncategorize
+  defp disposition_to_items_opt(:cascade, _), do: :cascade
+  defp disposition_to_items_opt(:move_to, target) when not is_nil(target), do: {:move_to, target}
+  defp disposition_to_items_opt(_, _), do: nil
+
+  defp bulk_subtree_item_count(uuids) do
+    Enum.reduce(uuids, 0, fn uuid, acc ->
+      acc + Catalogue.active_item_count_in_subtree(uuid)
+    end)
+  end
+
+  defp do_bulk_trash_items(socket) do
+    uuids = socket.assigns.selected_items |> MapSet.to_list()
+    {count, _} = Catalogue.bulk_trash_items(uuids, actor_opts(socket))
+
+    socket
+    |> assign(:bulk_confirm, nil)
+    |> assign(:selected_items, MapSet.new())
+    |> put_flash(:info, "Deleted #{count} items.")
+    |> reset_and_load()
+    |> then(&{:noreply, &1})
+  end
+
+  defp do_bulk_permanent_delete_items(socket) do
+    uuids = socket.assigns.selected_items |> MapSet.to_list()
+    {count, _} = Catalogue.bulk_permanently_delete_items(uuids, actor_opts(socket))
+
+    socket
+    |> assign(:bulk_confirm, nil)
+    |> assign(:selected_items, MapSet.new())
+    |> put_flash(:info, "Permanently deleted #{count} items.")
+    |> reset_and_load()
+    |> then(&{:noreply, &1})
+  end
+
+  defp do_bulk_restore_items(socket) do
+    uuids = socket.assigns.selected_items |> MapSet.to_list()
+    {count, _} = Catalogue.bulk_restore_items(uuids, actor_opts(socket))
+
+    socket
+    |> assign(:selected_items, MapSet.new())
+    |> put_flash(:info, "Restored #{count} items.")
+    |> reset_and_load()
+    |> then(&{:noreply, &1})
+  end
+
+  defp do_bulk_move_items(socket, target_uuid) do
+    uuids = socket.assigns.selected_items |> MapSet.to_list()
+
+    case Catalogue.bulk_move_items_to_category(uuids, target_uuid, actor_opts(socket)) do
+      {:ok, count} ->
+        socket
+        |> assign(:bulk_move_modal, nil)
+        |> assign(:selected_items, MapSet.new())
+        |> put_flash(:info, "Moved #{count} items.")
+        |> reset_and_load()
+        |> then(&{:noreply, &1})
+
+      {:error, :category_not_found} ->
+        {:noreply, put_flash(socket, :error, "Target category not found.")}
+    end
+  end
+
+  defp do_bulk_trash_categories(socket) do
+    # Without a disposition picker, default cascade. The bulk modal
+    # path goes through confirm_trash_category instead.
+    do_bulk_trash_categories_with(
+      socket,
+      socket.assigns.selected_categories |> MapSet.to_list(),
+      :cascade
+    )
+  end
+
+  defp do_bulk_trash_categories_with(socket, uuids, items_opt) do
+    case Catalogue.bulk_trash_categories(uuids, items_opt, actor_opts(socket)) do
+      {:ok, %{categories: count}} ->
+        socket
+        |> assign(:bulk_confirm, nil)
+        |> assign(:selected_categories, MapSet.new())
+        |> put_flash(:info, "Deleted #{count} categories.")
+        |> reset_and_load()
+        |> then(&{:noreply, &1})
+
+      {:error, reason} ->
+        log_operation_error(socket, "bulk_trash_categories", %{reason: reason})
+
+        {:noreply, put_flash(socket, :error, "Failed to delete categories: #{inspect(reason)}")}
+    end
+  end
+
+  defp do_bulk_restore_categories(socket, uuids) do
+    {ok, errors} =
+      Enum.reduce(uuids, {0, []}, fn uuid, {ok, errs} ->
+        with %{} = category <- Catalogue.get_category(uuid),
+             {:ok, _} <- Catalogue.restore_category(category, actor_opts(socket)) do
+          {ok + 1, errs}
+        else
+          {:error, reason} -> {ok, [reason | errs]}
+          _ -> {ok, errs}
+        end
+      end)
+
+    socket =
+      socket
+      |> assign(:selected_categories, MapSet.new())
+      |> put_flash(:info, "Restored #{ok} categories.")
+      |> reset_and_load()
+
+    if errors == [],
+      do: {:noreply, socket},
+      else:
+        {:noreply,
+         put_flash(socket, :error, "Some categories couldn't be restored: #{inspect(errors)}")}
   end
 
   defp build_trash_modal_state(%Category{} = category, item_count) do
@@ -1333,26 +1633,77 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </p>
         </div>
 
-        <%!-- Items / Categories tab bar --%>
-        <div role="tablist" class="tabs tabs-bordered">
-          <button
-            type="button"
-            role="tab"
-            phx-click="switch_tab"
-            phx-value-tab="items"
-            class={["tab", @tab == "items" && "tab-active"]}
+        <%!-- Items / Categories tab bar + per-tab Active/Deleted mode
+             switcher on the same row. The switcher's counts and
+             visibility track the current tab. --%>
+        <div class="flex items-end justify-between border-b border-base-200 gap-4">
+          <div role="tablist" class="tabs tabs-bordered border-none">
+            <button
+              type="button"
+              role="tab"
+              phx-click="switch_tab"
+              phx-value-tab="items"
+              class={["tab", @tab == "items" && "tab-active"]}
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Items")}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              phx-click="switch_tab"
+              phx-value-tab="categories"
+              class={["tab", @tab == "categories" && "tab-active"]}
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Categories")} ({length(@category_list)})
+            </button>
+          </div>
+
+          <%!-- Inline mode switcher. Visibility per-tab: Items tab
+               shows it when deleted_item_count > 0 (or already in
+               deleted view); Categories tab uses the category count.
+               Hidden during a live search. --%>
+          <div
+            :if={
+              is_nil(@search_results) and not @search_loading and
+                ((@tab == "items" and (@deleted_item_count > 0 or @view_mode == "deleted")) or
+                   (@tab == "categories" and
+                      (@deleted_category_count > 0 or @view_mode == "deleted")))
+            }
+            class="flex items-center gap-0.5 pb-1"
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Items")}
-          </button>
-          <button
-            type="button"
-            role="tab"
-            phx-click="switch_tab"
-            phx-value-tab="categories"
-            class={["tab", @tab == "categories" && "tab-active"]}
-          >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Categories")} ({length(@category_list)})
-          </button>
+            <button
+              type="button"
+              phx-click="switch_view"
+              phx-value-mode="active"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@view_mode == "active",
+                  do: "border-primary text-primary",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")} ({if @tab == "categories",
+                do: @active_category_count,
+                else: @active_item_count})
+            </button>
+            <button
+              type="button"
+              phx-click="switch_view"
+              phx-value-mode="deleted"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@view_mode == "deleted",
+                  do: "border-error text-error",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({if @tab == "categories",
+                do: @deleted_category_count,
+                else: @deleted_item_count})
+            </button>
+          </div>
         </div>
 
         <%!-- ── Items tab ────────────────────────────────────────── --%>
@@ -1360,8 +1711,28 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           <%!-- Search (Items tab only — Categories tab has no search yet) --%>
           <.search_input :if={@view_mode == "active"} query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items by name, description, or SKU...")} />
 
-          <%!-- View toggle --%>
-          <.view_mode_toggle :if={@category_list != []} storage_key="catalogue-detail-items" />
+          <%!-- Combined row: bulk-action contents on the left (when
+               items are selected), card/table view toggle on the right.
+               Becomes sticky + styled when bulk is active so the
+               actions stay reachable while the user scrolls. --%>
+          <div
+            :if={MapSet.size(@selected_items) > 0 or @category_list != []}
+            class={[
+              "flex items-center justify-between gap-3",
+              MapSet.size(@selected_items) > 0 &&
+                "sticky top-[72px] z-40 -mx-1 px-3 py-2 rounded-lg bg-base-100/95 border border-primary/40 shadow-md backdrop-blur"
+            ]}
+          >
+            <.items_bulk_actions
+              :if={MapSet.size(@selected_items) > 0}
+              count={MapSet.size(@selected_items)}
+              view_mode={@view_mode}
+            />
+            <%!-- Spacer keeps justify-between pushing the toggle right
+                 when nothing is selected. --%>
+            <div :if={MapSet.size(@selected_items) == 0}></div>
+            <.view_mode_toggle :if={@category_list != []} storage_key="catalogue-detail-items" />
+          </div>
 
         <%!-- Search results (visible when the user has typed a query) --%>
         <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
@@ -1409,37 +1780,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-        <%!-- Status tabs (item counts — items tab) --%>
-        <div :if={(@deleted_item_count > 0 or @view_mode == "deleted") and is_nil(@search_results) and not @search_loading} class="flex items-center gap-0.5 border-b border-base-200">
-          <button
-            type="button"
-            phx-click="switch_view"
-            phx-value-mode="active"
-            class={[
-              "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-              if(@view_mode == "active",
-                do: "border-primary text-primary",
-                else: "border-transparent text-base-content/50 hover:text-base-content"
-              )
-            ]}
-          >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")} ({@active_item_count})
-          </button>
-          <button
-            type="button"
-            phx-click="switch_view"
-            phx-value-mode="deleted"
-            class={[
-              "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-              if(@view_mode == "deleted",
-                do: "border-error text-error",
-                else: "border-transparent text-base-content/50 hover:text-base-content"
-              )
-            ]}
-          >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_item_count})
-          </button>
-        </div>
+        <%!-- Status switcher moved to the tabs row above. --%>
 
         <%!-- Normal (non-search) view: infinite-scroll cards --%>
         <%!-- Empty states only shown when nothing is loading AND nothing was ever loaded --%>
@@ -1475,6 +1816,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 category_list={@category_list}
                 uncategorized_total={@uncategorized_total}
                 catalogue={@catalogue}
+                selected_items={@selected_items}
               />
             </div>
           <% end %>
@@ -1497,6 +1839,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             show_toggle={false}
             storage_key="catalogue-detail-items"
             id="catalogue-deleted-items"
+            selectable={true}
+            selected_uuids={@selected_items}
+            on_toggle_select="toggle_select_item"
           />
         </div>
 
@@ -1522,37 +1867,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
         <%!-- ── Categories tab ───────────────────────────────────── --%>
         <div :if={@tab == "categories"} class="flex flex-col gap-4">
-          <%!-- Status switcher (category counts — categories tab) --%>
-          <div :if={@deleted_category_count > 0 or @view_mode == "deleted"} class="flex items-center gap-0.5 border-b border-base-200">
-            <button
-              type="button"
-              phx-click="switch_view"
-              phx-value-mode="active"
-              class={[
-                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-                if(@view_mode == "active",
-                  do: "border-primary text-primary",
-                  else: "border-transparent text-base-content/50 hover:text-base-content"
-                )
-              ]}
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")} ({@active_category_count})
-            </button>
-            <button
-              type="button"
-              phx-click="switch_view"
-              phx-value-mode="deleted"
-              class={[
-                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-                if(@view_mode == "deleted",
-                  do: "border-error text-error",
-                  else: "border-transparent text-base-content/50 hover:text-base-content"
-                )
-              ]}
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_category_count})
-            </button>
-          </div>
+          <%!-- Bulk-action bar for categories. Active view: Delete (opens
+               disposition modal in bulk mode). Deleted view: Restore.
+               Selection cleared on tab/view-mode switch. --%>
+          <.categories_bulk_bar
+            :if={MapSet.size(@selected_categories) > 0}
+            count={MapSet.size(@selected_categories)}
+            view_mode={@view_mode}
+          />
+
+          <%!-- Status switcher moved to the tabs row above. --%>
 
           <% visible_category_count =
             if @view_mode == "deleted", do: @deleted_category_count, else: @active_category_count %>
@@ -1591,6 +1915,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 count={Map.get(@category_counts, cat.uuid, 0)}
                 view_mode={@view_mode}
                 sibling_count={Enum.count(@category_list, &(&1.parent_uuid == cat.parent_uuid))}
+                selected={MapSet.member?(@selected_categories, cat.uuid)}
               />
             <% end %>
           </div>
@@ -1751,6 +2076,123 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         </div>
       </.confirm_modal>
 
+      <%!-- Bulk-action confirm modal (for items: trash or permanent
+           delete; categories use the trash_modal in bulk mode for the
+           item-disposition picker). --%>
+      <.confirm_modal
+        :if={@bulk_confirm}
+        show={true}
+        on_confirm="confirm_bulk_action"
+        on_cancel="cancel_bulk_action"
+        title={
+          case @bulk_confirm[:mode] do
+            :permanent -> Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently delete selected items?")
+            _ -> Gettext.gettext(PhoenixKitWeb.Gettext, "Delete selected items?")
+          end
+        }
+        title_icon="hero-trash"
+        confirm_text={
+          case @bulk_confirm[:mode] do
+            :permanent -> Gettext.gettext(PhoenixKitWeb.Gettext, "Delete forever")
+            _ -> Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")
+          end
+        }
+        danger={true}
+        messages={
+          case @bulk_confirm[:mode] do
+            :permanent ->
+              [
+                {:warning,
+                 Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} items will be permanently deleted. This cannot be undone.", count: @bulk_confirm[:count])}
+              ]
+
+            _ ->
+              [
+                {:warning,
+                 Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} items will be moved to the Deleted view. They can be restored later.", count: @bulk_confirm[:count])}
+              ]
+          end
+        }
+      />
+
+      <%!-- Bulk-move modal for items — same shape as the trash modal's
+           Move-to-another-category branch but applied to all selected
+           items. --%>
+      <.confirm_modal
+        :if={@bulk_move_modal}
+        show={true}
+        on_confirm="confirm_bulk_move_items"
+        on_cancel="cancel_bulk_move"
+        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Move selected items")}
+        title_icon="hero-arrows-right-left"
+        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Move items")}
+        confirm_disabled={
+          @bulk_move_modal[:disposition] == :move_to and is_nil(@bulk_move_modal[:target_uuid])
+        }
+      >
+        <p class="text-sm text-base-content/70">
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Pick where %{count} items should go.", count: @bulk_move_modal[:count])}
+        </p>
+
+        <div class="space-y-3 mt-4">
+          <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer hover:bg-base-200/50">
+            <input
+              type="radio"
+              name="bulk_move_disposition"
+              value="uncategorize"
+              checked={@bulk_move_modal[:disposition] == :uncategorize}
+              phx-click="set_bulk_move_disposition"
+              phx-value-disposition="uncategorize"
+              class="radio radio-sm radio-primary mt-0.5"
+            />
+            <div class="flex-1 min-w-0">
+              <p class="font-medium text-sm">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Make items uncategorized")}
+              </p>
+              <p class="text-xs text-base-content/60">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Items keep their catalogue but lose their category.")}
+              </p>
+            </div>
+          </label>
+
+          <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer hover:bg-base-200/50">
+            <input
+              type="radio"
+              name="bulk_move_disposition"
+              value="move_to"
+              checked={@bulk_move_modal[:disposition] == :move_to}
+              phx-click="set_bulk_move_disposition"
+              phx-value-disposition="move_to"
+              class="radio radio-sm radio-primary mt-0.5"
+            />
+            <div class="flex-1 min-w-0">
+              <p class="font-medium text-sm">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move items to another category")}
+              </p>
+              <%= if @bulk_move_modal[:targets] == [] do %>
+                <p class="text-xs text-warning">
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No categories available — use Uncategorized instead.")}
+                </p>
+              <% else %>
+                <select
+                  name="category_uuid"
+                  phx-change="select_bulk_move_target"
+                  disabled={@bulk_move_modal[:disposition] != :move_to}
+                  class="select select-sm select-bordered w-full mt-2"
+                >
+                  <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}</option>
+                  <%= for {cat, depth} <- @bulk_move_modal[:targets] do %>
+                    <option value={cat.uuid} selected={@bulk_move_modal[:target_uuid] == cat.uuid}>
+                      {String.duplicate("— ", depth)}{cat.name}
+                    </option>
+                  <% end %>
+                </select>
+              <% end %>
+            </div>
+          </label>
+        </div>
+      </.confirm_modal>
+
       <.live_component
         :if={@pdf_search_item}
         module={PdfSearchModal}
@@ -1803,6 +2245,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   attr(:category_list, :list, default: [])
   attr(:uncategorized_total, :integer, required: true)
   attr(:catalogue, :any, required: true)
+  attr(:selected_items, :any, default: nil)
 
   defp detail_card(%{card: %{kind: :category}} = assigns) do
     %{uuid: uuid} = assigns.card.category
@@ -1821,37 +2264,29 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       <div class="card-body">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <.link
-              :if={@view_mode == "active"}
-              navigate={Paths.category_edit(@card.category.uuid)}
-              class="card-title text-lg link link-hover"
-            >
-              {@card.category.name}
-            </.link>
             <h3
-              :if={@view_mode != "active"}
               class={["card-title text-lg", @card.category.status == "deleted" && "text-error/70"]}
             >
               {@card.category.name}
             </h3>
+            <%!-- Active categories: hover-revealed pencil icon to edit
+                 (replaces the old Edit button, per the boss). Delete
+                 moves into the bulk-action bar via row checkboxes. --%>
+            <.link
+              :if={@view_mode == "active" and @card.category.status == "active"}
+              navigate={Paths.category_edit(@card.category.uuid)}
+              class="text-base-content/40 hover:text-primary"
+              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit category")}
+            >
+              <.icon name="hero-pencil" class="w-4 h-4" />
+            </.link>
             <span :if={@card.category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
             <span class="badge badge-ghost badge-sm">{@total} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
           </div>
 
-          <%!-- Active mode: Edit + Delete --%>
-          <div :if={@view_mode == "active"} class="flex gap-1">
-            <.link navigate={Paths.category_edit(@card.category.uuid)} class="btn btn-ghost btn-xs">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
-            </.link>
-            <button
-              phx-click="request_trash_category"
-              phx-value-uuid={@card.category.uuid}
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
-              class="btn btn-ghost btn-xs text-error"
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
-            </button>
-          </div>
+          <%!-- Active mode: no per-card buttons. The Items tab is
+               read-only structure; deletion happens via item-level
+               selection or via the Categories tab. --%>
 
           <%!-- Deleted mode: Restore + Permanent Delete (for deleted categories) --%>
           <div :if={@view_mode == "deleted" && @card.category.status == "deleted"} class="flex gap-1">
@@ -1898,6 +2333,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               catalogue_uuid: @catalogue.uuid,
               category_uuid: @card.category.uuid
             }}
+            selectable={true}
+            selected_uuids={@selected_items}
+            on_toggle_select="toggle_select_item"
           />
         </div>
         <%!-- Items table: deleted mode --%>
@@ -1954,6 +2392,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               catalogue_uuid: @catalogue.uuid,
               category_uuid: nil
             }}
+            selectable={@view_mode == "active"}
+            selected_uuids={@selected_items}
+            on_toggle_select="toggle_select_item"
           />
         </div>
       </div>
@@ -1964,48 +2405,151 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # One row in the Categories tab — a compact card with depth indent,
   # drag handle (active mode only, when there are siblings to swap with),
   # name (linked to edit), item count, and per-mode actions.
+  # ── Bulk-action bars ─────────────────────────────────────────────
+
+  attr(:count, :integer, required: true)
+  attr(:view_mode, :string, required: true)
+
+  # Inline bulk-actions content for the Items tab. Renders as a flex
+  # cluster (count + buttons) without an outer box — the parent row
+  # supplies the sticky/styled container so the toggle and the bulk
+  # actions share one row.
+  defp items_bulk_actions(assigns) do
+    ~H"""
+    <div class="flex flex-wrap items-center gap-3 grow">
+      <span class="text-sm font-medium">
+        {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} selected", count: @count)}
+      </span>
+      <div class="flex items-center gap-2">
+        <%= if @view_mode == "active" do %>
+          <button phx-click="request_bulk_move_items" class="btn btn-sm btn-outline">
+            <.icon name="hero-arrows-right-left" class="w-4 h-4" />
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+          </button>
+          <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
+            <.icon name="hero-trash" class="w-4 h-4" />
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+          </button>
+        <% else %>
+          <button phx-click="request_bulk_restore_items" class="btn btn-sm btn-outline btn-success">
+            <.icon name="hero-arrow-path" class="w-4 h-4" />
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+          </button>
+          <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
+            <.icon name="hero-trash" class="w-4 h-4" />
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete forever")}
+          </button>
+        <% end %>
+        <button phx-click="clear_selection" class="btn btn-sm btn-ghost">
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  attr(:count, :integer, required: true)
+  attr(:view_mode, :string, required: true)
+
+  defp categories_bulk_bar(assigns) do
+    ~H"""
+    <div class="sticky top-[72px] z-40 -mx-1 px-3 py-2 rounded-lg bg-base-100/95 border border-primary/40 shadow-md backdrop-blur flex flex-wrap items-center gap-3">
+      <span class="text-sm font-medium">
+        {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} selected", count: @count)}
+      </span>
+      <div class="flex items-center gap-2 ml-auto">
+        <%= if @view_mode == "active" do %>
+          <button phx-click="request_bulk_delete_categories" class="btn btn-sm btn-outline btn-error">
+            <.icon name="hero-trash" class="w-4 h-4" />
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+          </button>
+        <% else %>
+          <button phx-click="request_bulk_restore_categories" class="btn btn-sm btn-outline btn-success">
+            <.icon name="hero-arrow-path" class="w-4 h-4" />
+            {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+          </button>
+        <% end %>
+        <button phx-click="clear_selection" class="btn btn-sm btn-ghost">
+          {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+        </button>
+      </div>
+    </div>
+    """
+  end
+
   attr(:category, :map, required: true)
   attr(:depth, :integer, required: true)
   attr(:count, :integer, required: true)
   attr(:view_mode, :string, required: true)
   attr(:sibling_count, :integer, required: true)
+  attr(:selected, :boolean, default: false)
 
   defp category_row(assigns) do
     ~H"""
     <div
       :if={@view_mode == "active" or @category.status == "deleted"}
-      class={
+      class={[
+        "group",
         cond do
           @view_mode == "active" and @category.status == "active" -> "sortable-item"
           true -> "sortable-ignore"
         end
-      }
+      ]}
       data-id={@category.status == "active" && @category.uuid}
       style={"margin-left: #{@depth * 1.5}rem"}
     >
       <div class="card card-sm bg-base-100 shadow">
         <div class="card-body py-3 flex-row items-center justify-between gap-3">
           <div class="flex items-center gap-2 min-w-0">
+            <%!-- Active mode: combined checkbox + hover-only drag handle.
+                 Checkbox is always visible; the bars-3 grip only shows on
+                 row hover so it doesn't compete with the row content. --%>
             <div
-              :if={@view_mode == "active" and @sibling_count > 1 and @category.status == "active"}
-              class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
-              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder (among siblings)")}
-            >
-              <.icon name="hero-bars-3" class="w-4 h-4" />
-            </div>
-            <.link
               :if={@view_mode == "active" and @category.status == "active"}
-              navigate={Paths.category_edit(@category.uuid)}
-              class="font-medium link link-hover truncate"
+              class="flex items-center gap-1.5"
             >
-              {@category.name}
-            </.link>
+              <span
+                :if={@sibling_count > 1}
+                class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 opacity-0 group-hover:opacity-100 transition-opacity"
+                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder (among siblings)")}
+              >
+                <.icon name="hero-bars-3" class="w-4 h-4" />
+              </span>
+              <input
+                type="checkbox"
+                class="checkbox checkbox-xs"
+                checked={@selected}
+                phx-click="toggle_select_category"
+                phx-value-uuid={@category.uuid}
+              />
+            </div>
+
             <span
               :if={@view_mode != "active" or @category.status != "active"}
               class={["font-medium truncate", @category.status == "deleted" && "text-error/70"]}
             >
               {@category.name}
             </span>
+
+            <%!-- Active row name + inline pencil edit icon. The edit
+                 button used to live on the right; removed by the boss
+                 to declutter the row in favour of the bulk-action bar.
+                 The pencil keeps a one-click path to the edit form. --%>
+            <span
+              :if={@view_mode == "active" and @category.status == "active"}
+              class="font-medium truncate"
+            >
+              {@category.name}
+            </span>
+            <.link
+              :if={@view_mode == "active" and @category.status == "active"}
+              navigate={Paths.category_edit(@category.uuid)}
+              class="text-base-content/40 hover:text-primary"
+              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit category")}
+            >
+              <.icon name="hero-pencil" class="w-4 h-4" />
+            </.link>
+
             <span :if={@category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
             <%!-- Item count only for active categories. Once a category
                  is deleted, its items are managed separately (Items tab
@@ -2014,22 +2558,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <span :if={@category.status == "active"} class="badge badge-ghost badge-sm">{@count} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
           </div>
 
-          <%!-- Active mode: Edit + Delete --%>
-          <div :if={@view_mode == "active" and @category.status == "active"} class="flex gap-1 shrink-0">
-            <.link navigate={Paths.category_edit(@category.uuid)} class="btn btn-ghost btn-xs">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
-            </.link>
-            <button
-              phx-click="request_trash_category"
-              phx-value-uuid={@category.uuid}
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
-              class="btn btn-ghost btn-xs text-error"
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
-            </button>
-          </div>
-
-          <%!-- Deleted mode: Restore + Permanent Delete --%>
+          <%!-- Deleted mode: Restore + Permanent Delete (per-row; bulk
+               actions live in the action bar). Active mode has no
+               per-row buttons — selection drives bulk actions. --%>
           <div :if={@view_mode == "deleted" and @category.status == "deleted"} class="flex gap-1 shrink-0">
             <button
               phx-click="restore_category"

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -26,6 +26,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Catalogue.PubSub
+  alias PhoenixKitCatalogue.Errors
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.{Category, Item}
   alias PhoenixKitCatalogue.Web.Components.PdfSearchModal
@@ -48,12 +49,14 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         has_more: false,
         loading: false,
         confirm_delete: nil,
+        trash_modal: nil,
         view_mode: "active",
         deleted_count: 0,
         active_item_count: 0,
         deleted_item_count: 0,
         active_category_count: 0,
         deleted_category_count: 0,
+        deleted_items: [],
         search_query: "",
         search_results: nil,
         search_offset: 0,
@@ -90,6 +93,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # `?tab=items|categories` is reflected into socket assigns on every
   # patch. The default is "items"; any unknown value falls back to
   # "items" so a stale link can't push the LV into an undefined tab.
+  #
+  # After updating the tab, run the per-tab auto-flip — if the user
+  # switches into a tab whose Deleted bucket is empty, flip them back
+  # to Active rather than land them in an empty Deleted view.
   @impl true
   def handle_params(params, _uri, socket) do
     tab =
@@ -98,7 +105,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         _ -> "items"
       end
 
-    {:noreply, assign(socket, :tab, tab)}
+    {:noreply, socket |> assign(:tab, tab) |> maybe_auto_flip_to_active()}
   end
 
   # PubSub: another LV touched a category/item/catalogue/smart-rule.
@@ -273,6 +280,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
            Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found.")
          )}
 
+      {:error, :parent_catalogue_deleted} ->
+        {:noreply,
+         put_flash(socket, :error, Errors.message(:parent_catalogue_deleted))}
+
       {:error, reason} ->
         log_operation_error(socket, "restore_item", %{
           entity_type: "item",
@@ -335,14 +346,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     end
   end
 
-  def handle_event("trash_category", %{"uuid" => uuid}, socket) do
-    with %{} = category <- Catalogue.get_category(uuid),
-         {:ok, _} <- Catalogue.trash_category(category, actor_opts(socket)) do
-      {:noreply,
-       socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Category moved to deleted."))
-       |> reset_and_load()}
-    else
+  # Entry point from the Items / Categories tab Delete buttons. When the
+  # category subtree has zero active items, trashes directly. Otherwise
+  # opens a modal so the operator chooses what happens to the items
+  # (move them to another category, or detach them as uncategorized in
+  # the same catalogue) before the category trash fires.
+  def handle_event("request_trash_category", %{"uuid" => uuid}, socket) do
+    case Catalogue.get_category(uuid) do
       nil ->
         {:noreply,
          put_flash(
@@ -351,20 +361,62 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
            Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found.")
          )}
 
-      {:error, reason} ->
-        log_operation_error(socket, "trash_category", %{
-          entity_type: "category",
-          entity_uuid: uuid,
-          reason: reason
-        })
+      category ->
+        item_count = Catalogue.active_item_count_in_subtree(uuid)
 
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete category.")
-         )}
+        if item_count == 0 do
+          do_trash_category(socket, category, items: :cascade)
+        else
+          {:noreply, assign(socket, :trash_modal, build_trash_modal_state(category, item_count))}
+        end
     end
+  end
+
+  def handle_event("set_trash_disposition", %{"disposition" => disp}, socket) do
+    modal = socket.assigns.trash_modal || %{}
+
+    new_modal =
+      case disp do
+        "uncategorize" -> %{modal | disposition: :uncategorize, target_uuid: nil}
+        "move_to" -> %{modal | disposition: :move_to}
+        "cascade" -> %{modal | disposition: :cascade, target_uuid: nil}
+        _ -> modal
+      end
+
+    {:noreply, assign(socket, :trash_modal, new_modal)}
+  end
+
+  def handle_event("select_trash_target", %{"category_uuid" => uuid}, socket) do
+    modal = socket.assigns.trash_modal || %{}
+    {:noreply, assign(socket, :trash_modal, %{modal | target_uuid: blank_to_nil(uuid)})}
+  end
+
+  def handle_event("confirm_trash_category", _params, socket) do
+    case socket.assigns.trash_modal do
+      %{category: category, disposition: :uncategorize} ->
+        socket
+        |> assign(:trash_modal, nil)
+        |> do_trash_category(category, items: :uncategorize)
+
+      %{category: category, disposition: :move_to, target_uuid: target_uuid}
+      when not is_nil(target_uuid) ->
+        socket
+        |> assign(:trash_modal, nil)
+        |> do_trash_category(category, items: {:move_to, target_uuid})
+
+      %{category: category, disposition: :cascade} ->
+        socket
+        |> assign(:trash_modal, nil)
+        |> do_trash_category(category, items: :cascade)
+
+      _ ->
+        # Confirm should be disabled in this state; defensive no-op.
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("cancel_trash_category", _params, socket) do
+    {:noreply, assign(socket, :trash_modal, nil)}
   end
 
   def handle_event("restore_category", %{"uuid" => uuid}, socket) do
@@ -382,6 +434,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
            :error,
            Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found.")
          )}
+
+      {:error, :parent_catalogue_deleted} ->
+        {:noreply,
+         put_flash(socket, :error, Errors.message(:parent_catalogue_deleted))}
 
       {:error, reason} ->
         log_operation_error(socket, "restore_category", %{
@@ -554,6 +610,42 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     end
   end
 
+  defp build_trash_modal_state(%Category{} = category, item_count) do
+    %{
+      category: category,
+      item_count: item_count,
+      targets: Catalogue.list_move_target_categories(category),
+      disposition: :uncategorize,
+      target_uuid: nil
+    }
+  end
+
+  defp do_trash_category(socket, category, opts) do
+    full_opts = Keyword.merge(opts, actor_opts(socket))
+
+    case Catalogue.trash_category(category, full_opts) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Category moved to deleted."))
+         |> reset_and_load()}
+
+      {:error, reason} ->
+        log_operation_error(socket, "trash_category", %{
+          entity_type: "category",
+          entity_uuid: category.uuid,
+          reason: reason
+        })
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete category.")
+         )}
+    end
+  end
+
   defp apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids) do
     case Catalogue.reorder_items(
            catalogue_uuid,
@@ -609,12 +701,23 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # those can affect which cards render and in what order.
   defp reset_and_load(socket) do
     uuid = socket.assigns.catalogue_uuid
-    deleted_count = Catalogue.deleted_count_for_catalogue(uuid)
 
-    # Auto-switch back to active if the deleted tab was visible but has
-    # no content left.
+    # Pre-compute tab-relevant deleted count for the auto-flip decision.
+    # The flip rule: if the tab the user is in has no deleted entries
+    # AND they're sitting in the Deleted view, snap them back to Active
+    # so they don't land in an empty Deleted bucket.
+    deleted_item_count = Catalogue.deleted_item_count_for_catalogue(uuid)
+    deleted_category_count = Catalogue.deleted_category_count_for_catalogue(uuid)
+    deleted_count = deleted_item_count + deleted_category_count
+
+    relevant_count =
+      case socket.assigns.tab do
+        "categories" -> deleted_category_count
+        _ -> deleted_item_count
+      end
+
     view_mode =
-      if deleted_count == 0 and socket.assigns.view_mode == "deleted",
+      if relevant_count == 0 and socket.assigns.view_mode == "deleted",
         do: "active",
         else: socket.assigns.view_mode
 
@@ -628,44 +731,94 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
     has_any_content = category_list != [] or uncategorized_total > 0
 
-    socket
-    |> assign(
-      page_title: catalogue.name,
-      catalogue: catalogue,
-      category_list: category_list,
-      category_depths: category_depths,
-      category_counts: category_counts,
-      uncategorized_total: uncategorized_total,
-      loaded_cards: [],
-      cursor: initial_cursor(),
-      has_more: has_any_content,
-      loading: has_any_content,
-      deleted_count: deleted_count,
-      active_item_count: Catalogue.item_count_for_catalogue(uuid),
-      deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
-      active_category_count: Catalogue.category_count_for_catalogue(uuid),
-      deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid),
-      view_mode: view_mode
-    )
-    |> load_next_batch()
+    # Items tab Deleted view is a flat recency-ordered list, not the
+    # category-grouped streamed cards. Skip the cursor / load_next_batch
+    # machinery in that branch and load the flat list directly.
+    items_tab_deleted? = view_mode == "deleted" and socket.assigns.tab == "items"
+
+    deleted_items =
+      if items_tab_deleted?,
+        do: Catalogue.list_deleted_items_for_catalogue(uuid),
+        else: []
+
+    socket =
+      socket
+      |> assign(
+        page_title: catalogue.name,
+        catalogue: catalogue,
+        category_list: category_list,
+        category_depths: category_depths,
+        category_counts: category_counts,
+        uncategorized_total: uncategorized_total,
+        loaded_cards: [],
+        cursor: initial_cursor(),
+        has_more: not items_tab_deleted? and has_any_content,
+        loading: not items_tab_deleted? and has_any_content,
+        deleted_count: deleted_count,
+        active_item_count: Catalogue.item_count_for_catalogue(uuid),
+        deleted_item_count: deleted_item_count,
+        active_category_count: Catalogue.category_count_for_catalogue(uuid),
+        deleted_category_count: deleted_category_count,
+        view_mode: view_mode,
+        deleted_items: deleted_items
+      )
+
+    if items_tab_deleted?, do: socket, else: load_next_batch(socket)
   end
 
   # Refreshes the header counts (Active / Deleted tabs) and the
   # per-category + uncategorized totals after an item mutation, without
   # reloading the card list. Preserves scroll position.
+  #
+  # Special case: when restoring/deleting drains the Deleted view to
+  # zero, we have to flip back to Active and reset_and_load — otherwise
+  # the loaded_cards (which were progressively drained by
+  # `remove_item_locally`) keep rendering empty content for items that
+  # are now active in another view. Symptom: badges show correct active
+  # counts but the cards are blank.
   defp refresh_counts(socket) do
     uuid = socket.assigns.catalogue_uuid
     mode = view_mode_to_atom(socket.assigns.view_mode)
+    items_tab_deleted? = socket.assigns.view_mode == "deleted" and socket.assigns.tab == "items"
 
-    assign(socket,
-      deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
-      active_item_count: Catalogue.item_count_for_catalogue(uuid),
-      deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
-      active_category_count: Catalogue.category_count_for_catalogue(uuid),
-      deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid),
-      category_counts: Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode),
-      uncategorized_total: Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
-    )
+    deleted_items =
+      if items_tab_deleted?,
+        do: Catalogue.list_deleted_items_for_catalogue(uuid),
+        else: socket.assigns[:deleted_items] || []
+
+    socket =
+      assign(socket,
+        deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
+        active_item_count: Catalogue.item_count_for_catalogue(uuid),
+        deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
+        active_category_count: Catalogue.category_count_for_catalogue(uuid),
+        deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid),
+        category_counts: Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode),
+        uncategorized_total: Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode),
+        deleted_items: deleted_items
+      )
+
+    maybe_auto_flip_to_active(socket)
+  end
+
+  # Per-tab auto-flip: Items tab uses deleted_item_count, Categories tab
+  # uses deleted_category_count. Without tab awareness the user would
+  # land in an empty Deleted view of one tab while the other tab still
+  # had deleted entries (since `deleted_count` is the combined total).
+  defp maybe_auto_flip_to_active(socket) do
+    relevant_count =
+      case socket.assigns.tab do
+        "categories" -> socket.assigns.deleted_category_count
+        _ -> socket.assigns.deleted_item_count
+      end
+
+    if relevant_count == 0 and socket.assigns.view_mode == "deleted" do
+      socket
+      |> assign(:view_mode, "active")
+      |> reset_and_load()
+    else
+      socket
+    end
   end
 
   # PubSub-driven refresh. Updates counts, the catalogue struct, and the
@@ -683,34 +836,27 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # where this catalogue itself was deleted (caller redirects to index).
   defp refresh_in_place(socket) do
     uuid = socket.assigns.catalogue_uuid
-
     catalogue = Catalogue.fetch_catalogue!(uuid)
-    deleted_count = Catalogue.deleted_count_for_catalogue(uuid)
-
-    view_mode =
-      if deleted_count == 0 and socket.assigns.view_mode == "deleted",
-        do: "active",
-        else: socket.assigns.view_mode
-
-    mode = view_mode_to_atom(view_mode)
+    mode = view_mode_to_atom(socket.assigns.view_mode)
     tree = Catalogue.list_category_tree(uuid, mode: mode)
     category_list = Enum.map(tree, fn {cat, _depth} -> cat end)
     category_depths = Map.new(tree, fn {cat, depth} -> {cat.uuid, depth} end)
 
-    assign(socket,
+    socket
+    |> assign(
       page_title: catalogue.name,
       catalogue: catalogue,
-      view_mode: view_mode,
       category_list: category_list,
       category_depths: category_depths,
       category_counts: Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode),
       uncategorized_total: Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode),
-      deleted_count: deleted_count,
+      deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
       active_item_count: Catalogue.item_count_for_catalogue(uuid),
       deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
       active_category_count: Catalogue.category_count_for_catalogue(uuid),
       deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid)
     )
+    |> maybe_auto_flip_to_active()
   end
 
   # Loads one batch (up to `@per_page` items) based on the current
@@ -1303,17 +1449,17 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-        <div :if={is_nil(@search_results) and not @search_loading and @loaded_cards == [] and not @has_more and not @loading and @view_mode == "deleted"} class="card bg-base-100 shadow">
+        <div :if={is_nil(@search_results) and not @search_loading and @deleted_items == [] and @view_mode == "deleted"} class="card bg-base-100 shadow">
           <div class="card-body items-center text-center py-12">
             <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No deleted items.")}</p>
           </div>
         </div>
 
-        <%!-- Streamed cards (one per category, one for uncategorized).
+        <%!-- Active view: streamed cards (one per category + Uncategorized).
              Category DnD lives on the Categories tab — Items tab is
              read-only structure so admins focus on item-level edits. --%>
         <div
-          :if={is_nil(@search_results) and not @search_loading and @loaded_cards != []}
+          :if={is_nil(@search_results) and not @search_loading and @view_mode == "active" and @loaded_cards != []}
           id="catalogue-detail-cards"
           class="flex flex-col gap-6"
         >
@@ -1334,9 +1480,30 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           <% end %>
         </div>
 
-        <%!-- Infinite-scroll sentinel --%>
+        <%!-- Deleted view: flat list ordered by deletion date. No
+             category grouping — the boss wants a recency-ordered audit
+             list, not a tree. --%>
         <div
-          :if={is_nil(@search_results) and not @search_loading and @has_more}
+          :if={is_nil(@search_results) and not @search_loading and @view_mode == "deleted" and @deleted_items != []}
+          id="catalogue-detail-deleted-items"
+        >
+          <.item_table
+            items={@deleted_items}
+            columns={[:name, :sku, :unit, :status]}
+            on_restore="restore_item"
+            on_permanent_delete="show_delete_confirm"
+            permanent_delete_type="item"
+            cards={true}
+            show_toggle={false}
+            storage_key="catalogue-detail-items"
+            id="catalogue-deleted-items"
+          />
+        </div>
+
+        <%!-- Infinite-scroll sentinel (active view only — deleted view
+             is a one-shot 500-row list and doesn't paginate yet). --%>
+        <div
+          :if={is_nil(@search_results) and not @search_loading and @view_mode == "active" and @has_more}
           id="detail-load-more-sentinel"
           phx-hook="InfiniteScroll"
           data-cursor={"#{@cursor.phase}-#{@cursor.category_index}-#{@cursor.item_offset}"}
@@ -1347,7 +1514,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </div>
         </div>
 
-          <div :if={is_nil(@search_results) and not @search_loading and not @has_more and @loaded_cards != []} class="text-center text-xs text-base-content/40 py-2">
+          <div :if={is_nil(@search_results) and not @search_loading and @view_mode == "active" and not @has_more and @loaded_cards != []} class="text-center text-xs text-base-content/40 py-2">
             {Gettext.gettext(PhoenixKitWeb.Gettext, "All items loaded")}
           </div>
         </div>
@@ -1453,6 +1620,137 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         danger={true}
       />
 
+      <%!-- "What about the items?" modal — opens when the operator
+           clicks Delete on a category that still has active items in
+           its V103 subtree. The boss's rule: deleting the category
+           shouldn't drag the items down with it; the operator picks
+           a destination first. --%>
+      <.confirm_modal
+        :if={@trash_modal}
+        show={true}
+        on_confirm="confirm_trash_category"
+        on_cancel="cancel_trash_category"
+        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete category — what about the items?")}
+        title_icon="hero-folder-minus"
+        confirm_text={
+          if @trash_modal[:disposition] == :cascade,
+            do: Gettext.gettext(PhoenixKitWeb.Gettext, "Delete category and items"),
+            else: Gettext.gettext(PhoenixKitWeb.Gettext, "Move items and delete category")
+        }
+        confirm_disabled={
+          @trash_modal[:disposition] == :move_to and is_nil(@trash_modal[:target_uuid])
+        }
+        danger={true}
+      >
+        <p class="text-sm text-base-content/70">
+          <strong>{@trash_modal[:category].name}</strong>
+          {Gettext.gettext(
+            PhoenixKitWeb.Gettext,
+            "and its subtree contain %{count} active items. Choose where they should go before the category is deleted.",
+            count: @trash_modal[:item_count]
+          )}
+        </p>
+
+        <div class="space-y-3 mt-4">
+          <%!-- Option 1: uncategorize (no further input needed) --%>
+          <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer hover:bg-base-200/50">
+            <input
+              type="radio"
+              name="trash_disposition"
+              value="uncategorize"
+              checked={@trash_modal[:disposition] == :uncategorize}
+              phx-click="set_trash_disposition"
+              phx-value-disposition="uncategorize"
+              class="radio radio-sm radio-primary mt-0.5"
+            />
+            <div class="flex-1 min-w-0">
+              <p class="font-medium text-sm">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Make items uncategorized")}
+              </p>
+              <p class="text-xs text-base-content/60">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "Items stay in this catalogue but are no longer attached to any category."
+                )}
+              </p>
+            </div>
+          </label>
+
+          <%!-- Option 2: move to another category in the same catalogue.
+               Only meaningful when there's a sibling/elsewhere to move to;
+               we still render the radio when the list is empty so the UI
+               is symmetric, but the dropdown shows an empty-state hint. --%>
+          <label class="flex items-start gap-3 p-3 rounded-lg border border-base-300 cursor-pointer hover:bg-base-200/50">
+            <input
+              type="radio"
+              name="trash_disposition"
+              value="move_to"
+              checked={@trash_modal[:disposition] == :move_to}
+              phx-click="set_trash_disposition"
+              phx-value-disposition="move_to"
+              class="radio radio-sm radio-primary mt-0.5"
+            />
+            <div class="flex-1 min-w-0">
+              <p class="font-medium text-sm">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move items to another category")}
+              </p>
+              <p class="text-xs text-base-content/60 mb-2">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "Pick a target category in this catalogue. The category being deleted and its subtree are excluded."
+                )}
+              </p>
+              <%= if @trash_modal[:targets] == [] do %>
+                <p class="text-xs text-warning">
+                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No other categories available — use Uncategorized instead.")}
+                </p>
+              <% else %>
+                <select
+                  name="category_uuid"
+                  phx-change="select_trash_target"
+                  disabled={@trash_modal[:disposition] != :move_to}
+                  class="select select-sm select-bordered w-full"
+                >
+                  <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}</option>
+                  <%= for {cat, depth} <- @trash_modal[:targets] do %>
+                    <option value={cat.uuid} selected={@trash_modal[:target_uuid] == cat.uuid}>
+                      {String.duplicate("— ", depth)}{cat.name}
+                    </option>
+                  <% end %>
+                </select>
+              <% end %>
+            </div>
+          </label>
+
+          <%!-- Option 3: cascade — items follow the category to the
+               Deleted view. Soft-delete, restorable. The "I want everything
+               gone" path; not the default since the boss specifically
+               disliked this being implicit. --%>
+          <label class="flex items-start gap-3 p-3 rounded-lg border border-error/30 cursor-pointer hover:bg-error/5">
+            <input
+              type="radio"
+              name="trash_disposition"
+              value="cascade"
+              checked={@trash_modal[:disposition] == :cascade}
+              phx-click="set_trash_disposition"
+              phx-value-disposition="cascade"
+              class="radio radio-sm radio-error mt-0.5"
+            />
+            <div class="flex-1 min-w-0">
+              <p class="font-medium text-sm text-error">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete items along with the category")}
+              </p>
+              <p class="text-xs text-base-content/60">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "Items move to the Deleted view alongside the category. Both can be restored later."
+                )}
+              </p>
+            </div>
+          </label>
+        </div>
+      </.confirm_modal>
+
       <.live_component
         :if={@pdf_search_item}
         module={PdfSearchModal}
@@ -1546,7 +1844,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
             </.link>
             <button
-              phx-click="trash_category"
+              phx-click="request_trash_category"
               phx-value-uuid={@card.category.uuid}
               phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
               class="btn btn-ghost btn-xs text-error"
@@ -1569,7 +1867,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               phx-click="show_delete_confirm"
               phx-value-uuid={@card.category.uuid}
               phx-value-type="category"
-              class="btn btn-ghost btn-xs text-error"
+              class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-error/30 bg-error/10 hover:bg-error/20 text-error text-xs font-medium transition-colors cursor-pointer"
             >
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
             </button>
@@ -1709,7 +2007,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               {@category.name}
             </span>
             <span :if={@category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
-            <span class="badge badge-ghost badge-sm">{@count} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
+            <%!-- Item count only for active categories. Once a category
+                 is deleted, its items are managed separately (Items tab
+                 Deleted view) — the count here would be confusing under
+                 the "separate status" rule. --%>
+            <span :if={@category.status == "active"} class="badge badge-ghost badge-sm">{@count} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
           </div>
 
           <%!-- Active mode: Edit + Delete --%>
@@ -1718,7 +2020,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
             </.link>
             <button
-              phx-click="trash_category"
+              phx-click="request_trash_category"
               phx-value-uuid={@category.uuid}
               phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
               class="btn btn-ghost btn-xs text-error"
@@ -1741,7 +2043,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               phx-click="show_delete_confirm"
               phx-value-uuid={@category.uuid}
               phx-value-type="category"
-              class="btn btn-ghost btn-xs text-error"
+              class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-error/30 bg-error/10 hover:bg-error/20 text-error text-xs font-medium transition-colors cursor-pointer"
             >
               {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
             </button>

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -682,19 +682,24 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     {:noreply, assign(socket, :confirm_delete, nil)}
   end
 
-  def handle_event("reorder_categories", %{"ordered_ids" => ordered_ids}, socket)
+  def handle_event("reorder_categories", %{"ordered_ids" => ordered_ids} = params, socket)
       when is_list(ordered_ids) do
-    apply_category_reorder(socket, ordered_ids)
+    apply_category_reorder(socket, ordered_ids, params["moved_id"])
   end
 
-  # Cross-category drop: SortableJS sent `moved_id` plus the source
-  # category in `from*` keys alongside the destination's scope. We move
-  # the item, then reorder the destination to match the visual order
-  # the user dropped it into. The source's remaining order is preserved
-  # implicitly — its position values stay valid since they're per-scope.
+  # Cross-category drop: SortableJS sent the source category in `from*`
+  # keys alongside the destination's scope. We move the item, then
+  # reorder the destination to match the visual order the user dropped
+  # it into. The source's remaining order is preserved implicitly —
+  # its position values stay valid since they're per-scope.
+  #
+  # Pattern-matches on `fromCatalogueUuid` (only present on cross-
+  # container drops) rather than `moved_id` (now sent for every drop
+  # so the LV can flash the moved row regardless).
   def handle_event(
         "reorder_items",
-        %{"ordered_ids" => ordered_ids, "moved_id" => moved_id} = params,
+        %{"ordered_ids" => ordered_ids, "moved_id" => moved_id, "fromCatalogueUuid" => _} =
+            params,
         socket
       )
       when is_list(ordered_ids) and is_binary(moved_id) do
@@ -748,11 +753,14 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
            socket
            |> refresh_card_items(from_scope, -1)
            |> refresh_card_items(to_scope, +1)
-           |> refresh_counts()}
+           |> refresh_counts()
+           |> flash_reorder(moved_id, :ok)}
         else
           nil ->
             {:noreply,
-             put_flash(socket, :error, Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found."))}
+             socket
+             |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found."))
+             |> flash_reorder(moved_id, :error)}
 
           {:error, reason} ->
             log_operation_error(socket, "move_item_via_dnd", %{
@@ -767,7 +775,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                :error,
                Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move item.")
              )
-             |> reset_and_load()}
+             |> reset_and_load()
+             |> flash_reorder(moved_id, :error)}
         end
     end
   end
@@ -776,6 +785,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       when is_list(ordered_ids) do
     catalogue_uuid = params["catalogueUuid"]
     category_uuid = blank_to_nil(params["categoryUuid"])
+    moved_id = params["moved_id"]
 
     if catalogue_uuid != socket.assigns.catalogue_uuid do
       {:noreply,
@@ -785,7 +795,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          Gettext.gettext(PhoenixKitWeb.Gettext, "Wrong catalogue scope.")
        )}
     else
-      apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids)
+      apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids, moved_id)
     end
   end
 
@@ -946,7 +956,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     end
   end
 
-  defp apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids) do
+  defp apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids, moved_id) do
     case Catalogue.reorder_items(
            catalogue_uuid,
            category_uuid,
@@ -955,18 +965,33 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          ) do
       :ok ->
         scope = category_uuid || :uncategorized
-        {:noreply, refresh_card_items(socket, scope)}
+
+        {:noreply,
+         socket
+         |> refresh_card_items(scope)
+         |> flash_reorder(moved_id, :ok)}
 
       {:error, reason} ->
         log_operation_error(socket, "reorder_items", %{reason: reason})
 
         {:noreply,
-         put_flash(
-           socket,
+         socket
+         |> put_flash(
            :error,
            Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to reorder items.")
-         )}
+         )
+         |> reset_and_load()
+         |> flash_reorder(moved_id, :error)}
     end
+  end
+
+  # Pushes the `sortable:flash` event the SortableGrid hook listens for.
+  # `moved_id` may be nil if a stale client missed the JS-side update;
+  # we no-op in that case so the success/error flash isn't required.
+  defp flash_reorder(socket, nil, _status), do: socket
+
+  defp flash_reorder(socket, moved_id, status) when is_binary(moved_id) do
+    push_event(socket, "sortable:flash", %{uuid: moved_id, status: to_string(status)})
   end
 
   # ── Helpers ─────────────────────────────────────────────────────
@@ -1557,7 +1582,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # a half-reordered state. UUIDs whose parent changed are silently
   # kept under their original parent — DnD here is for sibling-only
   # reorder, not reparenting.
-  defp apply_category_reorder(socket, ordered_ids) do
+  defp apply_category_reorder(socket, ordered_ids, moved_id) do
     by_uuid = Map.new(socket.assigns.category_list, fn %Category{} = c -> {c.uuid, c} end)
 
     groups =
@@ -1582,17 +1607,19 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
     case result do
       :ok ->
-        {:noreply, socket}
+        {:noreply, flash_reorder(socket, moved_id, :ok)}
 
       {:error, reason} ->
         log_operation_error(socket, "reorder_categories", %{reason: reason})
 
         {:noreply,
-         put_flash(
-           socket,
+         socket
+         |> put_flash(
            :error,
            Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to reorder categories.")
-         )}
+         )
+         |> reset_and_load()
+         |> flash_reorder(moved_id, :error)}
     end
   end
 

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -644,20 +644,30 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
         </div>
       </.form>
 
-      <%!-- Danger zone — only in edit mode --%>
-      <div :if={@action == :edit} class="card bg-base-100 shadow-lg border border-error/20">
-        <div class="card-body flex flex-row items-center justify-between gap-4">
-          <div>
-            <span class="text-sm font-semibold text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Catalogue")}</span>
-            <p class="text-xs text-base-content/50">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.")}
-            </p>
+      <%!-- Danger zone — collapsed by default to match the integrations
+           page pattern; user clicks to reveal the destructive action. --%>
+      <details :if={@action == :edit} class="card bg-base-100 border-2 border-error/30">
+        <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
+          <.icon name="hero-exclamation-triangle" class="w-4 h-4 text-error" />
+          <h3 class="font-semibold text-error text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Danger Zone")}</h3>
+          <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
+        </summary>
+
+        <div class="card-body pt-0 space-y-4">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Catalogue")}</p>
+              <p class="text-xs text-base-content/60">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.")}
+              </p>
+            </div>
+            <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
+              <.icon name="hero-trash" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+            </button>
           </div>
-          <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
-          </button>
         </div>
-      </div>
+      </details>
 
       <.confirm_modal
         show={@confirm_delete}

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -792,12 +792,13 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           data-sortable-event="reorder_catalogues"
           data-sortable-items=".sortable-item"
           data-sortable-hide-source="false"
+          data-sortable-handle=".pk-drag-handle"
           phx-hook="SortableGrid"
         >
           <.table_default_row :for={catalogue <- @catalogues} class="sortable-item" data-id={catalogue.uuid}>
             <.table_default_cell
               :if={length(@catalogues) > 1}
-              class="cursor-grab active:cursor-grabbing text-base-content/40"
+              class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/40"
             >
               <.icon name="hero-bars-3" class="w-4 h-4" />
             </.table_default_cell>

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -7,6 +7,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
 
   import PhoenixKitWeb.Components.MultilangForm
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
@@ -462,78 +463,102 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         </div>
       </.form>
 
-      <%!-- Move to a different parent — only in edit mode, within the same catalogue --%>
-      <div :if={@action == :edit} class="card bg-base-100 shadow-lg">
-        <div class="card-body flex flex-col gap-3">
-          <h3 class="text-sm font-semibold text-base-content/80">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Parent")}</h3>
-          <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Reparent this category within its catalogue. Its subtree comes along.")}</p>
-          <div class="flex items-end gap-3">
-            <div class="form-control flex-1">
-              <.select
-                name="parent_uuid"
-                id="category-parent-move-target"
-                value={@parent_move_target}
-                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Top level (no parent) —")}
-                options={@parent_options}
-                class="select-sm transition-colors focus-within:select-primary"
-                phx-change="select_parent_move_target"
-              />
+      <%!-- Move actions — collapsed by default to keep destructive +
+           low-frequency actions out of the primary edit flow.
+           Native <details> handles toggle; no JS needed. --%>
+      <details :if={@action == :edit} class="card bg-base-100 shadow-lg">
+        <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
+          <.icon name="hero-arrows-right-left" class="w-4 h-4 text-base-content/60" />
+          <h3 class="font-semibold text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}</h3>
+          <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
+        </summary>
+
+        <div class="card-body pt-0 space-y-6">
+          <%!-- Move to a different parent — within the same catalogue --%>
+          <div class="flex flex-col gap-3">
+            <div>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Parent")}</p>
+              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Reparent this category within its catalogue. Its subtree comes along.")}</p>
             </div>
-            <button
-              type="button"
-              phx-click="move_under_parent"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
-              disabled={@parent_move_target == @category.parent_uuid}
-              class="btn btn-sm btn-outline"
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+            <div class="flex items-end gap-3">
+              <div class="form-control flex-1">
+                <.select
+                  name="parent_uuid"
+                  id="category-parent-move-target"
+                  value={@parent_move_target}
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Top level (no parent) —")}
+                  options={@parent_options}
+                  class="select-sm transition-colors focus-within:select-primary"
+                  phx-change="select_parent_move_target"
+                />
+              </div>
+              <button
+                type="button"
+                phx-click="move_under_parent"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                disabled={@parent_move_target == @category.parent_uuid}
+                class="btn btn-sm btn-outline"
+              >
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+              </button>
+            </div>
+          </div>
+
+          <%!-- Move to another catalogue — only when other catalogues exist --%>
+          <div :if={@other_catalogues != []} class="flex flex-col gap-3">
+            <div>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Catalogue")}</p>
+              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this category and all its items to a different catalogue.")}</p>
+            </div>
+            <div class="flex items-end gap-3">
+              <div class="form-control flex-1">
+                <.select
+                  name="catalogue_uuid"
+                  id="category-move-target"
+                  value={@move_target}
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
+                  options={Enum.map(@other_catalogues, &{&1.name, &1.uuid})}
+                  class="select-sm transition-colors focus-within:select-primary"
+                  phx-change="select_move_target"
+                />
+              </div>
+              <button
+                type="button"
+                phx-click="move_category"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                disabled={is_nil(@move_target)}
+                class="btn btn-sm btn-outline"
+              >
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+              </button>
+            </div>
+          </div>
+        </div>
+      </details>
+
+      <%!-- Danger zone — collapsed by default; matches the integrations
+           page Danger Zone pattern (red border, exclamation-triangle,
+           confirm modal on click). --%>
+      <details :if={@action == :edit} class="card bg-base-100 border-2 border-error/30">
+        <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
+          <.icon name="hero-exclamation-triangle" class="w-4 h-4 text-error" />
+          <h3 class="font-semibold text-error text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Danger Zone")}</h3>
+          <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
+        </summary>
+
+        <div class="card-body pt-0 space-y-4">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Category")}</p>
+              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this category and all its items. This cannot be undone.")}</p>
+            </div>
+            <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
+              <.icon name="hero-trash" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
             </button>
           </div>
         </div>
-      </div>
-
-      <%!-- Move to another catalogue — only in edit mode with other catalogues available --%>
-      <div :if={@action == :edit && @other_catalogues != []} class="card bg-base-100 shadow-lg">
-        <div class="card-body flex flex-col gap-3">
-          <h3 class="text-sm font-semibold text-base-content/80">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Catalogue")}</h3>
-          <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this category and all its items to a different catalogue.")}</p>
-          <div class="flex items-end gap-3">
-            <div class="form-control flex-1">
-              <.select
-                name="catalogue_uuid"
-                id="category-move-target"
-                value={@move_target}
-                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
-                options={Enum.map(@other_catalogues, &{&1.name, &1.uuid})}
-                class="select-sm transition-colors focus-within:select-primary"
-                phx-change="select_move_target"
-              />
-            </div>
-            <button
-              type="button"
-              phx-click="move_category"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
-              disabled={is_nil(@move_target)}
-              class="btn btn-sm btn-outline"
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <%!-- Danger zone — only in edit mode --%>
-      <div :if={@action == :edit} class="card bg-base-100 shadow-lg border border-error/20">
-        <div class="card-body flex flex-row items-center justify-between gap-4">
-          <div>
-            <span class="text-sm font-semibold text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Category")}</span>
-            <p class="text-xs text-base-content/50">{Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this category and all its items. This cannot be undone.")}</p>
-          </div>
-          <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
-          </button>
-        </div>
-      </div>
+      </details>
 
       <.confirm_modal
         show={@confirm_delete_all}

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -1252,7 +1252,21 @@ defmodule PhoenixKitCatalogue.Web.Components do
       >
         <.table_default_row
           :for={item <- @items}
-          class={if @on_reorder, do: "sortable-item group", else: "group"}
+          class={
+            [
+              if(@on_reorder, do: "sortable-item"),
+              "group",
+              # Selected-row tint + left-edge primary accent. 10% bg
+              # alone (the media_browser convention) is too subtle on
+              # zebra-striped tables; the left border makes selection
+              # unambiguous at a glance. `!` overrides daisyUI's table
+              # zebra row bg.
+              selected?(@selected_uuids, item.uuid) &&
+                "!bg-primary/15 border-l-4 border-l-primary"
+            ]
+            |> Enum.reject(&(&1 in [nil, false]))
+            |> Enum.join(" ")
+          }
           data-id={item.uuid}
         >
           <%!-- Combined checkbox + drag handle column. Checkbox is

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -1167,6 +1167,20 @@ defmodule PhoenixKitCatalogue.Web.Components do
       "SortableJS group name; tables sharing a group can exchange items via cross-container drag (e.g. items moving between categories)"
   )
 
+  attr(:selectable, :boolean,
+    default: false,
+    doc:
+      "When true, each row gets a checkbox in the leftmost column (combined with the drag handle when reorderable). The drag handle is hidden until the row is hovered."
+  )
+
+  attr(:selected_uuids, :any, default: nil, doc: "MapSet of selected item UUIDs")
+
+  attr(:on_toggle_select, :string,
+    default: nil,
+    doc:
+      "Event name fired when the user toggles a row's checkbox. The LV handler receives `phx-value-uuid`."
+  )
+
   def item_table(assigns) do
     assigns =
       assigns
@@ -1192,18 +1206,31 @@ defmodule PhoenixKitCatalogue.Web.Components do
       }
     >
       <:card_header :let={item}>
-        <.link
-          :if={@edit_path && item.uuid}
-          navigate={safe_call(@edit_path, item.uuid)}
-          class="font-medium text-sm link link-hover"
-        >
-          {item.name || "—"}
-        </.link>
-        <span :if={!@edit_path || !item.uuid} class="font-medium text-sm">{item.name || "—"}</span>
+        <%!-- Mobile card view: prepend the checkbox so bulk-select works
+             on phone screens too. The desktop table view has its own
+             checkbox column; this keeps the card view symmetric. --%>
+        <div class="flex items-center gap-2">
+          <input
+            :if={@selectable and @on_toggle_select}
+            type="checkbox"
+            class="checkbox checkbox-xs"
+            checked={selected?(@selected_uuids, item.uuid)}
+            phx-click={@on_toggle_select}
+            phx-value-uuid={item.uuid}
+          />
+          <.link
+            :if={@edit_path && item.uuid}
+            navigate={safe_call(@edit_path, item.uuid)}
+            class="font-medium text-sm link link-hover"
+          >
+            {item.name || "—"}
+          </.link>
+          <span :if={!@edit_path || !item.uuid} class="font-medium text-sm">{item.name || "—"}</span>
+        </div>
       </:card_header>
       <.table_default_header>
         <.table_default_row>
-          <.table_default_header_cell :if={@on_reorder} class="w-8"></.table_default_header_cell>
+          <.table_default_header_cell :if={!is_nil(@on_reorder) or @selectable} class="w-10"></.table_default_header_cell>
           <.table_default_header_cell :for={col <- @columns}>
             {column_label(col)}
           </.table_default_header_cell>
@@ -1225,14 +1252,31 @@ defmodule PhoenixKitCatalogue.Web.Components do
       >
         <.table_default_row
           :for={item <- @items}
-          class={if @on_reorder, do: "sortable-item"}
+          class={if @on_reorder, do: "sortable-item group", else: "group"}
           data-id={item.uuid}
         >
-          <.table_default_cell
-            :if={@on_reorder}
-            class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/40"
-          >
-            <.icon name="hero-bars-3" class="w-4 h-4" />
+          <%!-- Combined checkbox + drag handle column. Checkbox is
+               always visible when selectable; drag handle hover-reveals
+               via group-hover so it doesn't compete visually with the
+               checkbox or the row content. --%>
+          <.table_default_cell :if={!is_nil(@on_reorder) or @selectable} class="w-10">
+            <div class="flex items-center gap-1.5">
+              <span
+                :if={@on_reorder}
+                class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/40 opacity-0 group-hover:opacity-100 transition-opacity"
+                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder")}
+              >
+                <.icon name="hero-bars-3" class="w-4 h-4" />
+              </span>
+              <input
+                :if={@selectable and @on_toggle_select}
+                type="checkbox"
+                class="checkbox checkbox-xs"
+                checked={selected?(@selected_uuids, item.uuid)}
+                phx-click={@on_toggle_select}
+                phx-value-uuid={item.uuid}
+              />
+            </div>
           </.table_default_cell>
           <.item_cell
             :for={col <- @columns}
@@ -1277,6 +1321,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
   # hook can pluck them off the container as extra payload. `nil` /
   # blank values become `""`-valued attrs so the parser side can detect
   # "uncategorized" without ambiguity.
+  defp selected?(nil, _uuid), do: false
+  defp selected?(%MapSet{} = set, uuid), do: MapSet.member?(set, uuid)
+  defp selected?(_, _), do: false
+
   defp build_reorder_scope_attrs(scope) when is_map(scope) do
     Enum.flat_map(scope, fn {key, value} ->
       attr_name = "data-sortable-scope-" <> dash_case(to_string(key))
@@ -1343,48 +1391,51 @@ defmodule PhoenixKitCatalogue.Web.Components do
 
   defp card_action_buttons(assigns) do
     ~H"""
+    <%!-- Mobile card view: icon-only buttons (text labels would overflow
+         a 390px card row). `title` carries the label as a native browser
+         tooltip + accessibility name. The card view is desktop-hidden
+         (`md:hidden`) so we don't worry about labelled-button parity. --%>
     <.link
       :if={@edit_path && @item.uuid}
       navigate={safe_call(@edit_path, @item.uuid)}
-      class="btn btn-ghost btn-xs"
+      class="btn btn-ghost btn-xs btn-square"
+      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
+      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
     >
-      <.icon name="hero-pencil" class="w-3.5 h-3.5" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
+      <.icon name="hero-pencil" class="w-4 h-4" />
     </.link>
     <button
       :if={@pdf_search_event && @item.uuid}
       type="button"
       phx-click={@pdf_search_event}
       phx-value-uuid={@item.uuid}
-      class="btn btn-ghost btn-xs"
+      class="btn btn-ghost btn-xs btn-square"
+      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Search PDFs")}
+      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Search PDFs")}
     >
-      <.icon name="hero-document-magnifying-glass" class="w-3.5 h-3.5" /> {Gettext.gettext(
-        PhoenixKitWeb.Gettext,
-        "Search PDFs"
-      )}
+      <.icon name="hero-document-magnifying-glass" class="w-4 h-4" />
     </button>
     <button
       :if={@on_delete}
       phx-click={@on_delete}
       phx-value-uuid={@item.uuid}
       phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
-      class="btn btn-ghost btn-xs text-error"
+      class="btn btn-ghost btn-xs btn-square text-error"
+      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
     >
-      <.icon name="hero-trash" class="w-3.5 h-3.5" /> {Gettext.gettext(
-        PhoenixKitWeb.Gettext,
-        "Delete"
-      )}
+      <.icon name="hero-trash" class="w-4 h-4" />
     </button>
     <button
       :if={@on_restore}
       phx-click={@on_restore}
       phx-value-uuid={@item.uuid}
       phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")}
-      class="btn btn-ghost btn-xs text-success"
+      class="btn btn-ghost btn-xs btn-square text-success"
+      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
     >
-      <.icon name="hero-arrow-path" class="w-3.5 h-3.5" /> {Gettext.gettext(
-        PhoenixKitWeb.Gettext,
-        "Restore"
-      )}
+      <.icon name="hero-arrow-path" class="w-4 h-4" />
     </button>
     <button
       :if={@on_permanent_delete}
@@ -1392,12 +1443,11 @@ defmodule PhoenixKitCatalogue.Web.Components do
       phx-value-uuid={@item.uuid}
       phx-value-type={@permanent_delete_type}
       phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
-      class="btn btn-ghost btn-xs text-error"
+      class="btn btn-ghost btn-xs btn-square text-error"
+      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
     >
-      <.icon name="hero-trash" class="w-3.5 h-3.5" /> {Gettext.gettext(
-        PhoenixKitWeb.Gettext,
-        "Delete Forever"
-      )}
+      <.icon name="hero-trash" class="w-4 h-4" />
     </button>
     """
   end

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -915,6 +915,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
           data-sortable-event={@on_reorder}
           data-sortable-items=".sortable-item"
           data-sortable-hide-source="false"
+          data-sortable-handle={if @on_reorder, do: ".pk-drag-handle"}
           phx-hook={if @on_reorder, do: "SortableGrid"}
         >
           <.catalogue_rule_row
@@ -963,7 +964,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
     >
       <div
         :if={@draggable}
-        class="cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
+        class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
         title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder")}
       >
         <.icon name="hero-bars-3" class="w-4 h-4" />
@@ -1218,6 +1219,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
         data-sortable-items=".sortable-item"
         data-sortable-hide-source="false"
         data-sortable-group={@reorder_group}
+        data-sortable-handle={if @on_reorder, do: ".pk-drag-handle"}
         phx-hook={if @on_reorder, do: "SortableGrid"}
         {@reorder_scope_attrs}
       >
@@ -1228,7 +1230,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
         >
           <.table_default_cell
             :if={@on_reorder}
-            class="cursor-grab active:cursor-grabbing text-base-content/40"
+            class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/40"
           >
             <.icon name="hero-bars-3" class="w-4 h-4" />
           </.table_default_cell>

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -1289,84 +1289,95 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         </div>
       </.form>
 
-      <%!-- Move — standard items move to a category anywhere; smart
-           items move across smart catalogues (no category). Each card
-           only renders when its own target list is non-empty so we
-           never show an empty-dropdown dead end. --%>
-      <div
-        :if={@action == :edit && @catalogue_kind != "smart" && @all_categories != []}
+      <%!-- Move — collapsed by default. Standard items move to a
+           category anywhere; smart items move across smart catalogues
+           (no category). Each block only renders when its own target
+           list is non-empty so we never show an empty-dropdown dead
+           end; the outer <details> only renders when at least one
+           branch is available. --%>
+      <details
+        :if={
+          @action == :edit &&
+            ((@catalogue_kind != "smart" && @all_categories != []) ||
+               (@catalogue_kind == "smart" && @smart_move_targets != []))
+        }
         class="card bg-base-100 shadow-lg"
       >
-        <div class="card-body flex flex-col gap-3">
-          <h3 class="text-sm font-semibold text-base-content/80">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Category")}
-          </h3>
-          <p class="text-xs text-base-content/50">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item to a category in any catalogue.")}
-          </p>
-          <div class="flex items-end gap-3">
-            <div class="form-control flex-1">
-              <.select
-                name="category_uuid"
-                id="item-move-category"
-                value={@move_target}
-                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}
-                options={Enum.map(@all_categories, &{&1.name, &1.uuid})}
-                class="select-sm transition-colors focus-within:select-primary"
-                phx-change="select_move_target"
-              />
-            </div>
-            <button
-              type="button"
-              phx-click="move_item"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
-              disabled={is_nil(@move_target)}
-              class="btn btn-sm btn-outline"
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
-            </button>
-          </div>
-        </div>
-      </div>
+        <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
+          <.icon name="hero-arrows-right-left" class="w-4 h-4 text-base-content/60" />
+          <h3 class="font-semibold text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}</h3>
+          <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
+        </summary>
 
-      <div
-        :if={@action == :edit && @catalogue_kind == "smart" && @smart_move_targets != []}
-        class="card bg-base-100 shadow-lg"
-      >
-        <div class="card-body flex flex-col gap-3">
-          <h3 class="text-sm font-semibold text-base-content/80">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Smart Catalogue")}
-          </h3>
-          <p class="text-xs text-base-content/50">
-            {Gettext.gettext(
-              PhoenixKitWeb.Gettext,
-              "Move this item into a different smart catalogue. Its catalogue rules stay attached."
-            )}
-          </p>
-          <div class="flex items-end gap-3">
-            <div class="form-control flex-1">
-              <.select
-                name="catalogue_uuid"
-                id="item-move-smart-catalogue"
-                value={@move_target}
-                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
-                options={Enum.map(@smart_move_targets, &{&1.name, &1.uuid})}
-                class="select-sm transition-colors focus-within:select-primary"
-                phx-change="select_move_target"
-              />
+        <div class="card-body pt-0 space-y-6">
+          <%!-- Standard items: move to any category --%>
+          <div :if={@catalogue_kind != "smart" && @all_categories != []} class="flex flex-col gap-3">
+            <div>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Category")}</p>
+              <p class="text-xs text-base-content/60">
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item to a category in any catalogue.")}
+              </p>
             </div>
-            <button
-              type="button"
-              phx-click="move_item"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
-              disabled={is_nil(@move_target)}
-              class="btn btn-sm btn-outline"
-            >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
-            </button>
+            <div class="flex items-end gap-3">
+              <div class="form-control flex-1">
+                <.select
+                  name="category_uuid"
+                  id="item-move-category"
+                  value={@move_target}
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}
+                  options={Enum.map(@all_categories, &{&1.name, &1.uuid})}
+                  class="select-sm transition-colors focus-within:select-primary"
+                  phx-change="select_move_target"
+                />
+              </div>
+              <button
+                type="button"
+                phx-click="move_item"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                disabled={is_nil(@move_target)}
+                class="btn btn-sm btn-outline"
+              >
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+              </button>
+            </div>
+          </div>
+
+          <%!-- Smart items: move to a different smart catalogue --%>
+          <div :if={@catalogue_kind == "smart" && @smart_move_targets != []} class="flex flex-col gap-3">
+            <div>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Smart Catalogue")}</p>
+              <p class="text-xs text-base-content/60">
+                {Gettext.gettext(
+                  PhoenixKitWeb.Gettext,
+                  "Move this item into a different smart catalogue. Its catalogue rules stay attached."
+                )}
+              </p>
+            </div>
+            <div class="flex items-end gap-3">
+              <div class="form-control flex-1">
+                <.select
+                  name="catalogue_uuid"
+                  id="item-move-smart-catalogue"
+                  value={@move_target}
+                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
+                  options={Enum.map(@smart_move_targets, &{&1.name, &1.uuid})}
+                  class="select-sm transition-colors focus-within:select-primary"
+                  phx-change="select_move_target"
+                />
+              </div>
+              <button
+                type="button"
+                phx-click="move_item"
+                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                disabled={is_nil(@move_target)}
+                class="btn btn-sm btn-outline"
+              >
+                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </details>
     </div>
     """
   end

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -3709,4 +3709,317 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Enum.map(ancestors, & &1.name) == ["Root", "Mid"]
     end
   end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Bulk actions (admin selection toolbar)
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "bulk_trash_items/2" do
+    test "flips status to deleted for the given uuids" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      b = create_item(%{name: "B", catalogue_uuid: cat.uuid})
+      c = create_item(%{name: "C", catalogue_uuid: cat.uuid})
+
+      assert {2, nil} = Catalogue.bulk_trash_items([a.uuid, b.uuid], [])
+
+      assert Catalogue.get_item(a.uuid).status == "deleted"
+      assert Catalogue.get_item(b.uuid).status == "deleted"
+      assert Catalogue.get_item(c.uuid).status == "active"
+    end
+
+    test "empty list is a no-op" do
+      assert {0, nil} = Catalogue.bulk_trash_items([], [])
+    end
+
+    test "skips already-deleted items in the count" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      Catalogue.trash_item(a)
+
+      assert {0, nil} = Catalogue.bulk_trash_items([a.uuid], [])
+    end
+  end
+
+  describe "bulk_restore_items/2" do
+    test "restores items in place when parent category is active" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      a = create_item(%{name: "A", category_uuid: category.uuid})
+      Catalogue.trash_item(a)
+
+      assert {1, nil} = Catalogue.bulk_restore_items([a.uuid], [])
+      restored = Catalogue.get_item(a.uuid)
+      assert restored.status == "active"
+      assert restored.category_uuid == category.uuid
+    end
+
+    test "uncategorizes items whose parent category is deleted" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      a = create_item(%{name: "A", category_uuid: category.uuid})
+
+      Catalogue.trash_category(category, items: :cascade)
+
+      assert {1, nil} = Catalogue.bulk_restore_items([a.uuid], [])
+      restored = Catalogue.get_item(a.uuid)
+      assert restored.status == "active"
+      # Parent category was deleted — bulk restore detaches the item
+      # so it surfaces in the catalogue's Uncategorized bucket without
+      # auto-reviving the category structure.
+      assert restored.category_uuid == nil
+      assert restored.catalogue_uuid == cat.uuid
+    end
+
+    test "refuses items whose parent catalogue is deleted" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      Catalogue.trash_catalogue(cat)
+
+      # Item is filtered out by the parent-catalogue-deleted guard.
+      assert {0, nil} = Catalogue.bulk_restore_items([a.uuid], [])
+      assert Catalogue.get_item(a.uuid).status == "deleted"
+    end
+  end
+
+  describe "bulk_permanently_delete_items/2" do
+    test "hard-deletes the rows" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      b = create_item(%{name: "B", catalogue_uuid: cat.uuid})
+
+      assert {2, nil} = Catalogue.bulk_permanently_delete_items([a.uuid, b.uuid], [])
+
+      assert is_nil(Catalogue.get_item(a.uuid))
+      assert is_nil(Catalogue.get_item(b.uuid))
+    end
+  end
+
+  describe "bulk_move_items_to_category/3" do
+    test "refuses without a :catalogue_uuid scope opt" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+
+      # Required guard — a caller that forgets the scope opt gets a
+      # clear refusal rather than a silent cross-catalogue write.
+      assert {:error, :missing_catalogue_scope} =
+               Catalogue.bulk_move_items_to_category([a.uuid], nil, [])
+    end
+
+    test "rejects when an item belongs to a different catalogue than the scope" do
+      cat_a = create_catalogue()
+      cat_b = create_catalogue()
+      foreign = create_item(%{name: "Foreign", catalogue_uuid: cat_b.uuid})
+
+      assert {:error, :wrong_catalogue_scope} =
+               Catalogue.bulk_move_items_to_category(
+                 [foreign.uuid],
+                 nil,
+                 catalogue_uuid: cat_a.uuid
+               )
+
+      # Item untouched — still in its original catalogue.
+      assert Catalogue.get_item(foreign.uuid).catalogue_uuid == cat_b.uuid
+    end
+
+    test "rejects when target category lives in a different catalogue than the scope" do
+      cat_a = create_catalogue()
+      cat_b = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat_a.uuid})
+      foreign_target = create_category(cat_b)
+
+      assert {:error, :wrong_catalogue_scope} =
+               Catalogue.bulk_move_items_to_category(
+                 [a.uuid],
+                 foreign_target.uuid,
+                 catalogue_uuid: cat_a.uuid
+               )
+
+      # Item untouched — still in its original catalogue.
+      assert Catalogue.get_item(a.uuid).catalogue_uuid == cat_a.uuid
+    end
+
+    test "rejects when target category does not exist" do
+      cat = create_catalogue()
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      bogus = "00000000-0000-0000-0000-000000000000"
+
+      assert {:error, :category_not_found} =
+               Catalogue.bulk_move_items_to_category(
+                 [a.uuid],
+                 bogus,
+                 catalogue_uuid: cat.uuid
+               )
+    end
+
+    test "moves all items into the target category" do
+      cat = create_catalogue()
+      target = create_category(cat, %{name: "Target"})
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      b = create_item(%{name: "B", catalogue_uuid: cat.uuid})
+
+      assert {:ok, 2} =
+               Catalogue.bulk_move_items_to_category(
+                 [a.uuid, b.uuid],
+                 target.uuid,
+                 catalogue_uuid: cat.uuid
+               )
+
+      assert Catalogue.get_item(a.uuid).category_uuid == target.uuid
+      assert Catalogue.get_item(b.uuid).category_uuid == target.uuid
+    end
+
+    test "uncategorizes when target_uuid is nil" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      a = create_item(%{name: "A", category_uuid: category.uuid})
+
+      assert {:ok, 1} =
+               Catalogue.bulk_move_items_to_category(
+                 [a.uuid],
+                 nil,
+                 catalogue_uuid: cat.uuid
+               )
+
+      moved = Catalogue.get_item(a.uuid)
+      assert moved.category_uuid == nil
+      assert moved.catalogue_uuid == cat.uuid
+    end
+  end
+
+  describe "bulk_trash_categories/3" do
+    test ":cascade soft-deletes categories + their items" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      item = create_item(%{name: "Item", category_uuid: category.uuid})
+
+      assert {:ok, %{categories: 1}} =
+               Catalogue.bulk_trash_categories([category.uuid], :cascade, [])
+
+      assert Catalogue.get_category(category.uuid).status == "deleted"
+      assert Catalogue.get_item(item.uuid).status == "deleted"
+    end
+
+    test ":uncategorize keeps items active and detaches them from the category" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      item = create_item(%{name: "Item", category_uuid: category.uuid})
+
+      assert {:ok, %{categories: 1}} =
+               Catalogue.bulk_trash_categories([category.uuid], :uncategorize, [])
+
+      assert Catalogue.get_category(category.uuid).status == "deleted"
+      survived = Catalogue.get_item(item.uuid)
+      assert survived.status == "active"
+      assert survived.category_uuid == nil
+    end
+
+    test "{:move_to, target_uuid} reparents items to the target before trashing" do
+      cat = create_catalogue()
+      source = create_category(cat, %{name: "Source"})
+      target = create_category(cat, %{name: "Target"})
+      item = create_item(%{name: "Item", category_uuid: source.uuid})
+
+      assert {:ok, %{categories: 1}} =
+               Catalogue.bulk_trash_categories([source.uuid], {:move_to, target.uuid}, [])
+
+      assert Catalogue.get_category(source.uuid).status == "deleted"
+      moved = Catalogue.get_item(item.uuid)
+      assert moved.status == "active"
+      assert moved.category_uuid == target.uuid
+    end
+
+    test "skips already-deleted categories in the count" do
+      cat = create_catalogue()
+      a = create_category(cat, %{name: "A"})
+      b = create_category(cat, %{name: "B"})
+      Catalogue.trash_category(b)
+
+      assert {:ok, %{categories: 1}} =
+               Catalogue.bulk_trash_categories([a.uuid, b.uuid], :uncategorize, [])
+    end
+
+    test "empty list is a no-op" do
+      assert {:ok, %{categories: 0, items_handled: 0}} =
+               Catalogue.bulk_trash_categories([], :cascade, [])
+    end
+  end
+
+  describe "list_move_target_categories/1" do
+    test "excludes the category itself" do
+      cat = create_catalogue()
+      a = create_category(cat, %{name: "A"})
+
+      targets = Catalogue.list_move_target_categories(a)
+      uuids = Enum.map(targets, fn {c, _depth} -> c.uuid end)
+
+      refute a.uuid in uuids
+    end
+
+    test "excludes the category's V103 subtree" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root"})
+      child = create_category(cat, %{name: "Child", parent_uuid: root.uuid})
+      grandchild = create_category(cat, %{name: "GC", parent_uuid: child.uuid})
+      sibling = create_category(cat, %{name: "Sibling"})
+
+      targets = Catalogue.list_move_target_categories(root)
+      uuids = Enum.map(targets, fn {c, _depth} -> c.uuid end)
+
+      refute root.uuid in uuids
+      refute child.uuid in uuids
+      refute grandchild.uuid in uuids
+      assert sibling.uuid in uuids
+    end
+  end
+
+  describe "active_item_count_in_subtree/1" do
+    test "counts items in the category and every V103 descendant" do
+      cat = create_catalogue()
+      root = create_category(cat, %{name: "Root"})
+      child = create_category(cat, %{name: "Child", parent_uuid: root.uuid})
+
+      _ = create_item(%{name: "RootItem", category_uuid: root.uuid})
+      _ = create_item(%{name: "ChildItem", category_uuid: child.uuid})
+      deleted = create_item(%{name: "Deleted", category_uuid: child.uuid})
+      Catalogue.trash_item(deleted)
+
+      assert Catalogue.active_item_count_in_subtree(root.uuid) == 2
+    end
+  end
+
+  describe "list_deleted_items_for_catalogue/2" do
+    test "returns only deleted items in this catalogue, newest first" do
+      cat = create_catalogue()
+      cat_other = create_catalogue()
+
+      a = create_item(%{name: "A", catalogue_uuid: cat.uuid})
+      b = create_item(%{name: "B", catalogue_uuid: cat.uuid})
+      foreign = create_item(%{name: "F", catalogue_uuid: cat_other.uuid})
+
+      Catalogue.trash_item(a)
+      Process.sleep(1100)
+      Catalogue.trash_item(b)
+      Catalogue.trash_item(foreign)
+
+      uuids =
+        cat.uuid
+        |> Catalogue.list_deleted_items_for_catalogue()
+        |> Enum.map(& &1.uuid)
+
+      assert uuids == [b.uuid, a.uuid]
+      refute foreign.uuid in uuids
+    end
+
+    test "respects :limit" do
+      cat = create_catalogue()
+
+      for i <- 1..3 do
+        item = create_item(%{name: "Item #{i}", catalogue_uuid: cat.uuid})
+        Catalogue.trash_item(item)
+      end
+
+      assert length(Catalogue.list_deleted_items_for_catalogue(cat.uuid, limit: 2)) == 2
+    end
+  end
 end

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -620,22 +620,24 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Catalogue.get_item(item.uuid).status == "deleted"
     end
 
-    test "restore_category restores ancestors upward and subtree downward" do
+    test "restore_category only flips the target's status (no cascades)" do
       cat = create_catalogue()
       root = create_category(cat, %{name: "Root"})
       mid = create_category(cat, %{name: "Mid", parent_uuid: root.uuid})
       leaf = create_category(cat, %{name: "Leaf", parent_uuid: mid.uuid})
       item = create_item(%{name: "Thing", category_uuid: leaf.uuid})
 
-      {:ok, _} = Catalogue.trash_category(root)
+      {:ok, _} = Catalogue.trash_category(root, items: :cascade)
 
-      # Restore from the deepest node; ancestors + subtree should come back.
+      # Restore the deepest node — only `leaf` flips back. Ancestors,
+      # descendants, and items keep their (deleted) status. The boss's
+      # rule: each entity's status is its own; restore doesn't ripple.
       assert {:ok, _} = Catalogue.restore_category(Catalogue.get_category(leaf.uuid))
 
-      assert Catalogue.get_category(root.uuid).status == "active"
-      assert Catalogue.get_category(mid.uuid).status == "active"
       assert Catalogue.get_category(leaf.uuid).status == "active"
-      assert Catalogue.get_item(item.uuid).status == "active"
+      assert Catalogue.get_category(root.uuid).status == "deleted"
+      assert Catalogue.get_category(mid.uuid).status == "deleted"
+      assert Catalogue.get_item(item.uuid).status == "deleted"
     end
 
     test "permanently_delete_category hard-deletes the subtree" do
@@ -718,19 +720,23 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert Catalogue.get_item(item.uuid).status == "deleted"
     end
 
-    test "restore_category cascades to items and restores parent catalogue" do
+    test "restore_category refuses when parent catalogue is deleted" do
       cat = create_catalogue()
       category = create_category(cat)
       item = create_item(%{name: "Item", category_uuid: category.uuid})
       Catalogue.trash_catalogue(cat)
 
-      # Restore the category — should also restore catalogue (upward) and items (downward)
+      # Restoring the category alone is no longer allowed when the
+      # catalogue itself is deleted — the operator must restore the
+      # catalogue first. The previous auto-revive surprised operators
+      # who only meant to undo a category-level trash.
       category = Catalogue.get_category(category.uuid)
-      {:ok, _} = Catalogue.restore_category(category)
+      assert {:error, :parent_catalogue_deleted} = Catalogue.restore_category(category)
 
-      assert Catalogue.get_catalogue(cat.uuid).status == "active"
-      assert Catalogue.get_category(category.uuid).status == "active"
-      assert Catalogue.get_item(item.uuid).status == "active"
+      # State unchanged.
+      assert Catalogue.get_catalogue(cat.uuid).status == "deleted"
+      assert Catalogue.get_category(category.uuid).status == "deleted"
+      assert Catalogue.get_item(item.uuid).status == "deleted"
     end
 
     test "permanently_delete_category removes category and items" do
@@ -1013,38 +1019,43 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert restored.status == "active"
     end
 
-    test "restore_item/1 cascades upward to deleted parent category" do
+    test "restore_item/1 detaches from a deleted parent category (uncategorizes)" do
       cat = create_catalogue()
       category = create_category(cat)
       item = create_item(%{name: "Item", category_uuid: category.uuid})
 
-      Catalogue.trash_category(category)
+      # Trash via :cascade so the item shares the category's deleted state.
+      Catalogue.trash_category(category, items: :cascade)
       assert Catalogue.get_category(category.uuid).status == "deleted"
       assert Catalogue.get_item(item.uuid).status == "deleted"
 
       item = Catalogue.get_item(item.uuid)
-      {:ok, _} = Catalogue.restore_item(item)
+      {:ok, restored} = Catalogue.restore_item(item)
 
-      assert Catalogue.get_category(category.uuid).status == "active"
-      assert Catalogue.get_item(item.uuid).status == "active"
+      # New behaviour: the item resurfaces as Uncategorized in the same
+      # catalogue. The category stays deleted — restoring an item no
+      # longer auto-revives the category structure.
+      assert restored.status == "active"
+      assert restored.category_uuid == nil
+      assert restored.catalogue_uuid == cat.uuid
+      assert Catalogue.get_category(category.uuid).status == "deleted"
     end
 
-    test "restore_item/1 cascades upward to deleted parent catalogue" do
+    test "restore_item/1 refuses when parent catalogue is deleted" do
       cat = create_catalogue()
       category = create_category(cat)
       item = create_item(%{name: "Item", category_uuid: category.uuid})
 
       Catalogue.trash_catalogue(cat)
       assert Catalogue.get_catalogue(cat.uuid).status == "deleted"
-      assert Catalogue.get_category(category.uuid).status == "deleted"
       assert Catalogue.get_item(item.uuid).status == "deleted"
 
       item = Catalogue.get_item(item.uuid)
-      {:ok, _} = Catalogue.restore_item(item)
+      assert {:error, :parent_catalogue_deleted} = Catalogue.restore_item(item)
 
-      assert Catalogue.get_catalogue(cat.uuid).status == "active"
-      assert Catalogue.get_category(category.uuid).status == "active"
-      assert Catalogue.get_item(item.uuid).status == "active"
+      # Nothing was changed — caller must restore the catalogue first.
+      assert Catalogue.get_catalogue(cat.uuid).status == "deleted"
+      assert Catalogue.get_item(item.uuid).status == "deleted"
     end
 
     test "permanently_delete_item/1 removes from DB" do

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -60,6 +60,11 @@ defmodule PhoenixKitCatalogue.ErrorsTest do
       assert Errors.message(:csv_empty) == "CSV file is empty."
     end
 
+    test "parent_catalogue_deleted" do
+      assert Errors.message(:parent_catalogue_deleted) ==
+               "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
+    end
+
     # `:pdf_invalid_format` and `:pdf_extraction_failed` removed
     # 2026-05-06 (Phase 2 sweep) — neither had a caller. The PDF
     # library upload pipeline rejects non-PDF MIME at the LV's

--- a/test/web/catalogue_detail_branches_test.exs
+++ b/test/web/catalogue_detail_branches_test.exs
@@ -93,12 +93,15 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailBranchesTest do
   end
 
   describe "trash_category / restore_category happy path" do
-    test "trash_category soft-deletes + restore reverses",
+    test "request_trash_category trashes empty category directly + restore reverses",
          %{conn: conn, catalogue: cat} do
       cat_obj = fixture_category(cat, %{name: "TrashCat"})
       {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
 
-      render_click(view, "trash_category", %{"uuid" => cat_obj.uuid})
+      # `request_trash_category` (the renamed event) trashes directly
+      # when the subtree has no active items; otherwise it would open
+      # the item-disposition modal first.
+      render_click(view, "request_trash_category", %{"uuid" => cat_obj.uuid})
       assert Catalogue.get_category(cat_obj.uuid).status == "deleted"
 
       render_click(view, "switch_view", %{"mode" => "deleted"})
@@ -138,26 +141,196 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailBranchesTest do
     end
   end
 
-  describe "move_category_up / move_category_down" do
-    test "swaps positions when adjacent siblings exist",
+  # `move_category_up` / `move_category_down` events were removed
+  # when category reorder switched to drag-only via the SortableGrid
+  # hook. The drag path is exercised end-to-end by
+  # `apply_category_reorder/3` in the parent LV; tests for it would
+  # need to drive the SortableGrid hook from a browser, which is out
+  # of scope for the fixture-driven LV-test stack here.
+
+  # ─────────────────────────────────────────────────────────────────
+  # Bulk selection + actions (added 2026-05-09)
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "bulk item selection + actions" do
+    test "toggle_select_item flips an item in/out of the selection set",
          %{conn: conn, catalogue: cat} do
-      a = fixture_category(cat, %{name: "A"})
-      b = fixture_category(cat, %{name: "B"})
+      category = fixture_category(cat)
+      item = fixture_item(%{name: "I", category_uuid: category.uuid})
 
       {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
 
-      # Move B up — A and B swap. The LV doesn't crash on the no-op
-      # case either.
-      render_click(view, "move_category_up", %{"uuid" => b.uuid})
-      render_click(view, "move_category_down", %{"uuid" => a.uuid})
+      render_click(view, "toggle_select_item", %{"uuid" => item.uuid})
+      assert MapSet.member?(:sys.get_state(view.pid).socket.assigns.selected_items, item.uuid)
+
+      render_click(view, "toggle_select_item", %{"uuid" => item.uuid})
+      refute MapSet.member?(:sys.get_state(view.pid).socket.assigns.selected_items, item.uuid)
+    end
+
+    test "request_bulk_delete_items + confirm_bulk_action soft-deletes the selection",
+         %{conn: conn, catalogue: cat} do
+      category = fixture_category(cat)
+      a = fixture_item(%{name: "A", category_uuid: category.uuid})
+      b = fixture_item(%{name: "B", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+      render_click(view, "toggle_select_item", %{"uuid" => a.uuid})
+      render_click(view, "toggle_select_item", %{"uuid" => b.uuid})
+
+      render_click(view, "request_bulk_delete_items", %{})
+
+      assert :sys.get_state(view.pid).socket.assigns.bulk_confirm == %{
+               kind: :items,
+               mode: :trash,
+               count: 2
+             }
+
+      render_click(view, "confirm_bulk_action", %{})
+
+      assert Catalogue.get_item(a.uuid).status == "deleted"
+      assert Catalogue.get_item(b.uuid).status == "deleted"
+      assert MapSet.size(:sys.get_state(view.pid).socket.assigns.selected_items) == 0
+    end
+
+    test "request_bulk_move_items opens the move modal with same-catalogue targets",
+         %{conn: conn, catalogue: cat} do
+      cat_a = fixture_category(cat, %{name: "Cat A"})
+      _cat_b = fixture_category(cat, %{name: "Cat B"})
+      item = fixture_item(%{name: "I", category_uuid: cat_a.uuid})
+
+      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+      render_click(view, "toggle_select_item", %{"uuid" => item.uuid})
+
+      render_click(view, "request_bulk_move_items", %{})
+
+      modal = :sys.get_state(view.pid).socket.assigns.bulk_move_modal
+      assert modal.count == 1
+      assert modal.disposition == :uncategorize
+      target_uuids = Enum.map(modal.targets, fn {c, _depth} -> c.uuid end)
+      assert cat_a.uuid in target_uuids
+    end
+
+    test "confirm_bulk_move_items uncategorizes the selection",
+         %{conn: conn, catalogue: cat} do
+      category = fixture_category(cat)
+      a = fixture_item(%{name: "A", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+      render_click(view, "toggle_select_item", %{"uuid" => a.uuid})
+      render_click(view, "request_bulk_move_items", %{})
+      render_click(view, "confirm_bulk_move_items", %{})
+
+      assert Catalogue.get_item(a.uuid).category_uuid == nil
+    end
+
+    test "clear_selection drops both selection sets",
+         %{conn: conn, catalogue: cat} do
+      category = fixture_category(cat)
+      item = fixture_item(%{name: "I", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+      render_click(view, "toggle_select_item", %{"uuid" => item.uuid})
+      render_click(view, "toggle_select_category", %{"uuid" => category.uuid})
+
+      render_click(view, "clear_selection", %{})
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.size(assigns.selected_items) == 0
+      assert MapSet.size(assigns.selected_categories) == 0
+    end
+  end
+
+  describe "expand_card per-card pagination" do
+    test "expand_card appends the next slice of items into a single card",
+         %{conn: conn, catalogue: cat} do
+      category = fixture_category(cat)
+      # @per_card is 25; create 30 so a single expand reaches the end.
+      for i <- 1..30 do
+        fixture_item(%{name: "I#{i}", category_uuid: category.uuid})
+      end
+
+      {:ok, view, first_html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+      assert first_html =~ "Show 5 more"
+
+      render_click(view, "expand_card", %{"scope" => category.uuid})
+      :sys.get_state(view.pid)
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      [card] = Enum.filter(assigns.loaded_cards, &(&1.kind == :category))
+      assert length(card.items) == 30
+      assert MapSet.size(assigns.expanding_cards) == 0
+    end
+
+    test "expand_timeout while still expanding restores the button + flashes a retry message",
+         %{conn: conn, catalogue: cat} do
+      category = fixture_category(cat)
+      _ = fixture_item(%{name: "I", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+
+      # Drop the in-flight :apply_expand message so the timeout
+      # branch fires (simulating a stuck mailbox / lost connection).
+      send(view.pid, {:expand_timeout, category.uuid})
+
+      # First mark the scope as expanding so the timeout branch
+      # actually fires.
+      :sys.replace_state(view.pid, fn state ->
+        socket = state.socket
+        new_assigns = Map.put(socket.assigns, :expanding_cards, MapSet.new([category.uuid]))
+        %{state | socket: %{socket | assigns: new_assigns}}
+      end)
+
+      send(view.pid, {:expand_timeout, category.uuid})
+      :sys.get_state(view.pid)
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.size(assigns.expanding_cards) == 0
+    end
+  end
+
+  describe "cross-tab live updates" do
+    test "catalogue_card_refresh from another pid refreshes only the affected scope",
+         %{conn: conn, catalogue: cat} do
+      category = fixture_category(cat)
+      _ = fixture_item(%{name: "Original", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+
+      # Simulate another LV pid broadcasting a card refresh.
+      send(view.pid, {:catalogue_card_refresh, cat.uuid, category.uuid, nil, :ok, self()})
+      :sys.get_state(view.pid)
+
+      # The handler ran (no crash) and the card still renders.
+      html = render(view)
+      assert html =~ "Original"
+    end
+
+    test "catalogue_card_refresh from self() is ignored (no double-render)",
+         %{conn: conn, catalogue: cat} do
+      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
+
+      # Self-broadcast — should be a no-op so the originator doesn't
+      # double-render after their own action.
+      send(view.pid, {:catalogue_card_refresh, cat.uuid, :uncategorized, nil, :ok, view.pid})
+      :sys.get_state(view.pid)
 
       assert Process.alive?(view.pid)
     end
 
-    test "move_category_up on a non-existent uuid is a no-op",
+    test "catalogue_bulk_change schedules the deferred apply",
          %{conn: conn, catalogue: cat} do
+      category = fixture_category(cat)
+      item = fixture_item(%{name: "Bulk", category_uuid: category.uuid})
+
       {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
-      render_click(view, "move_category_up", %{"uuid" => Ecto.UUID.generate()})
+
+      send(view.pid, {:catalogue_bulk_change, cat.uuid, :trashed, [item.uuid], [], self()})
+      :sys.get_state(view.pid)
+
+      # Two-step animation: receiver applied red flash; the deferred
+      # :bulk_change_apply still runs ~800ms later and reset_and_loads.
+      # We don't sleep here — just verify the handler didn't crash and
+      # the LV is still alive.
       assert Process.alive?(view.pid)
     end
   end

--- a/test/web/catalogue_detail_live_test.exs
+++ b/test/web/catalogue_detail_live_test.exs
@@ -63,7 +63,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       assert html =~ "A1"
     end
 
-    test "load_more event advances to the next category", %{conn: conn} do
+    test "every category renders eagerly with its own preview slice", %{conn: conn} do
+      # 2026-05-09: Items tab swapped infinite scroll for per-card
+      # expand (mirrors PdfSearchModal). All categories show on first
+      # render with a 25-item preview + per-card "Show N more" button.
       catalogue = fixture_catalogue()
       cat_a = fixture_category(catalogue, %{name: "First", position: 0})
       cat_b = fixture_category(catalogue, %{name: "Second", position: 1})
@@ -71,25 +74,20 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       fixture_item(%{name: "A only", category_uuid: cat_a.uuid})
       fixture_item(%{name: "B only", category_uuid: cat_b.uuid})
 
-      {:ok, view, html} = live(conn, url(catalogue.uuid))
+      {:ok, _view, html} = live(conn, url(catalogue.uuid))
 
       assert html =~ "First"
       assert html =~ "A only"
-      # The second category hasn't been loaded yet.
-      refute html =~ "Second"
-
-      # Fire the load_more event the sentinel would normally push.
-      html_after = render_click(view, "load_more", %{})
-      assert html_after =~ "Second"
-      assert html_after =~ "B only"
+      assert html =~ "Second"
+      assert html =~ "B only"
     end
 
-    test "paging fills a single large category across multiple load_more calls", %{conn: conn} do
+    test "expand_card loads more items into a single category", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
 
-      # @per_page is 100 — create 150 so two loads are needed.
-      for i <- 1..150 do
+      # @per_card is 25 — create 30 so an expand is needed.
+      for i <- 1..30 do
         fixture_item(%{
           name: "Item #{String.pad_leading("#{i}", 3, "0")}",
           category_uuid: category.uuid
@@ -98,48 +96,52 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
 
       {:ok, view, first_html} = live(conn, url(catalogue.uuid))
 
-      # First batch should contain items 001..100 but not 101.
+      # First render: items 001..025 visible, "Show 5 more" button visible.
       assert first_html =~ "Item 001"
-      assert first_html =~ "Item 100"
-      refute first_html =~ "Item 150"
+      assert first_html =~ "Item 025"
+      refute first_html =~ "Item 030"
+      assert first_html =~ "Show 5 more"
 
-      html_after = render_click(view, "load_more", %{})
-      assert html_after =~ "Item 101"
-      assert html_after =~ "Item 150"
+      # `expand_card` is asynchronous: the event handler defers the
+      # actual fetch via send/2 + a recovery `expand_timeout` so the
+      # button can re-render in its loading state. Drain the LV's
+      # mailbox by issuing any synchronous pull (e.g. another render)
+      # — `:sys.get_state` waits for everything queued before it.
+      render_click(view, "expand_card", %{"scope" => category.uuid})
+      :sys.get_state(view.pid)
+      html_after = render(view)
+
+      assert html_after =~ "Item 026"
+      assert html_after =~ "Item 030"
     end
 
-    test "uncategorized items load as the final card", %{conn: conn} do
+    test "Uncategorized renders eagerly when the catalogue has loose items", %{conn: conn} do
       catalogue = fixture_catalogue()
       cat_a = fixture_category(catalogue, %{name: "Cat A"})
 
       fixture_item(%{name: "In Category", category_uuid: cat_a.uuid})
       fixture_item(%{name: "Loose Item", catalogue_uuid: catalogue.uuid})
 
-      {:ok, view, first_html} = live(conn, url(catalogue.uuid))
+      {:ok, _view, html} = live(conn, url(catalogue.uuid))
 
-      assert first_html =~ "Cat A"
-      assert first_html =~ "In Category"
-      # Uncategorized not loaded on the first batch because the
-      # category was loaded first.
-      refute first_html =~ "Uncategorized"
-
-      html_after = render_click(view, "load_more", %{})
-      assert html_after =~ "Uncategorized"
-      assert html_after =~ "Loose Item"
+      assert html =~ "Cat A"
+      assert html =~ "In Category"
+      assert html =~ "Uncategorized"
+      assert html =~ "Loose Item"
     end
 
     test "category card shows the total item count, not the loaded count", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
 
-      for i <- 1..120 do
+      for i <- 1..30 do
         fixture_item(%{name: "I#{i}", category_uuid: category.uuid})
       end
 
       {:ok, _view, html} = live(conn, url(catalogue.uuid))
 
-      # Badge shows total (120), not the first batch (100)
-      assert html =~ "120"
+      # Badge shows total (30), not the first preview slice (25).
+      assert html =~ "30 items"
     end
   end
 
@@ -205,20 +207,25 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       assert Catalogue.get_item(item.uuid).status == "deleted"
     end
 
-    test "restore_item (in deleted view) removes it from the deleted list", %{conn: conn} do
+    test "restore_item (from the Items tab Deleted view) marks the item active", %{conn: conn} do
+      # After restore, the deleted view auto-flips back to Active because
+      # `deleted_item_count` hits 0 — the restored item ends up visible
+      # in the active stream rather than removed from the page entirely.
+      # The behavioral pin is: the DB row is "active" and the page
+      # doesn't crash.
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
       item = fixture_item(%{name: "Comeback", category_uuid: category.uuid})
       Catalogue.trash_item(item)
 
       {:ok, view, _html} = live(conn, url(catalogue.uuid))
-      # Jump to the deleted tab to see the item
       html = render_click(view, "switch_view", %{"mode" => "deleted"})
       assert html =~ "Comeback"
 
-      html_after = render_click(view, "restore_item", %{"uuid" => item.uuid})
-      refute html_after =~ "Comeback"
+      render_click(view, "restore_item", %{"uuid" => item.uuid})
+
       assert Catalogue.get_item(item.uuid).status == "active"
+      assert Process.alive?(view.pid)
     end
 
     test "delete_item with a bogus uuid doesn't crash and leaves existing items untouched", %{
@@ -255,17 +262,22 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       assert html =~ "Clickable category"
     end
 
-    test "category name is plain text in deleted mode", %{conn: conn} do
+    test "category name renders without an edit link in the Categories tab Deleted view",
+         %{conn: conn} do
+      # Items tab no longer renders trashed categories at all (the
+      # "separate status" rule). The Categories tab Deleted view shows
+      # the category as a plain row with no edit link — restore /
+      # delete-forever buttons replace the per-card actions.
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue, %{name: "Deleted category"})
       Catalogue.trash_category(category)
 
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
+      {:ok, view, _html} = live(conn, url(catalogue.uuid) <> "?tab=categories")
       html = render_click(view, "switch_view", %{"mode" => "deleted"})
 
-      # In deleted mode the h3 renders, not the edit link
-      refute html =~ "/en/admin/catalogue/categories/#{category.uuid}/edit"
       assert html =~ "Deleted category"
+      # No edit link to the deleted category — only Restore + Delete Forever.
+      refute html =~ "/en/admin/catalogue/categories/#{category.uuid}/edit"
     end
 
     test "item name in the card body is a link to the item edit page", %{conn: conn} do
@@ -282,7 +294,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
   end
 
   describe "category mutations" do
-    test "trash_category removes the category card", %{conn: conn} do
+    test "request_trash_category removes the category card when the subtree is empty",
+         %{conn: conn} do
+      # `request_trash_category` (the renamed event) trashes directly
+      # when the subtree has no active items. With items it would
+      # open the disposition modal first; here both fixtures are empty.
       catalogue = fixture_catalogue()
       cat_a = fixture_category(catalogue, %{name: "Trashable", position: 0})
       _cat_b = fixture_category(catalogue, %{name: "Staying", position: 1})
@@ -290,7 +306,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       {:ok, view, html} = live(conn, url(catalogue.uuid))
       assert html =~ "Trashable"
 
-      html_after = render_click(view, "trash_category", %{"uuid" => cat_a.uuid})
+      html_after = render_click(view, "request_trash_category", %{"uuid" => cat_a.uuid})
       refute html_after =~ "Trashable"
       assert html_after =~ "Staying"
     end
@@ -312,27 +328,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       assert html_after =~ "Brought Back"
     end
 
-    test "move_category_up swaps positions", %{conn: conn} do
-      catalogue = fixture_catalogue()
-      first = fixture_category(catalogue, %{name: "First", position: 0})
-      second = fixture_category(catalogue, %{name: "Second", position: 1})
-
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
-      render_click(view, "move_category_up", %{"uuid" => second.uuid})
-
-      assert Catalogue.get_category(first.uuid).position == 1
-      assert Catalogue.get_category(second.uuid).position == 0
-    end
-
-    test "move_category_up on the topmost category is a no-op", %{conn: conn} do
-      catalogue = fixture_catalogue()
-      first = fixture_category(catalogue, %{name: "First", position: 0})
-
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
-      render_click(view, "move_category_up", %{"uuid" => first.uuid})
-
-      assert Catalogue.get_category(first.uuid).position == 0
-    end
+    # `move_category_up` / `move_category_down` events were removed
+    # when category reorder switched to drag-only via the SortableGrid
+    # hook. The new wire is the `reorder_categories` event the hook
+    # pushes; LV-test coverage of drag would need to drive SortableJS
+    # from a browser, out of scope for this fixture-driven stack.
   end
 
   # ─────────────────────────────────────────────────────────────────

--- a/test/web/form_lives_test.exs
+++ b/test/web/form_lives_test.exs
@@ -11,7 +11,11 @@ defmodule PhoenixKitCatalogue.Web.FormLivesTest do
 
   @base "/en/admin/catalogue"
 
-  defp form_selector, do: "form[phx-submit=save]"
+  # The Attachments dropzone (`Attachments.allow_attachment_upload/1`)
+  # also renders a `phx-submit="save"` form, so the loose selector is
+  # ambiguous. Scope to forms with `action="#"` — the canonical shape
+  # of the resource forms in this module.
+  defp form_selector, do: ~s|form[action="#"][phx-submit=save]|
 
   # ─────────────────────────────────────────────────────────────────
   # CatalogueFormLive

--- a/test/web/item_form_live_test.exs
+++ b/test/web/item_form_live_test.exs
@@ -72,7 +72,9 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
 
       html =
         view
-        |> form("form[phx-submit=save]", %{"item" => base_item_params(%{"name" => ""})})
+        |> form("form[action=\"#\"][phx-submit=save]", %{
+          "item" => base_item_params(%{"name" => ""})
+        })
         |> render_change()
 
       # The exact error wording comes from gettext; assert the field is
@@ -86,7 +88,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
 
       html =
         view
-        |> form("form[phx-submit=save]", %{"item" => base_item_params()})
+        |> form("form[action=\"#\"][phx-submit=save]", %{"item" => base_item_params()})
         |> render_change()
 
       assert html =~ "Oak Panel"
@@ -104,7 +106,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
 
       {:error, {:live_redirect, %{to: to}}} =
         view
-        |> form("form[phx-submit=save]", %{"item" => params})
+        |> form("form[action=\"#\"][phx-submit=save]", %{"item" => params})
         |> render_submit()
 
       # After create the LiveView navigates to the catalogue detail.
@@ -123,7 +125,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
 
       {:error, {:live_redirect, _}} =
         view
-        |> form("form[phx-submit=save]", %{
+        |> form("form[action=\"#\"][phx-submit=save]", %{
           "item" => base_item_params(%{"name" => "Loose item", "category_uuid" => ""})
         })
         |> render_submit()
@@ -141,7 +143,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
 
       html =
         view
-        |> form("form[phx-submit=save]", %{
+        |> form("form[action=\"#\"][phx-submit=save]", %{
           "item" => base_item_params(%{"name" => "", "sku" => "user-typed-sku"})
         })
         |> render_submit()
@@ -187,7 +189,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
 
       {:error, {:live_redirect, %{to: to}}} =
         view
-        |> form("form[phx-submit=save]", %{
+        |> form("form[action=\"#\"][phx-submit=save]", %{
           "item" => base_item_params(%{"name" => "New name", "category_uuid" => category.uuid})
         })
         |> render_submit()
@@ -214,7 +216,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
 
       {:error, {:live_redirect, _}} =
         view
-        |> form("form[phx-submit=save]", %{
+        |> form("form[action=\"#\"][phx-submit=save]", %{
           "item" =>
             base_item_params(%{
               "name" => "X",
@@ -322,7 +324,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
       render_change(view, "set_catalogue_rule_value", %{"uuid" => kitchen.uuid, "value" => "10"})
 
       view
-      |> form("form[phx-submit=save]",
+      |> form("form[action=\"#\"][phx-submit=save]",
         item: %{
           "name" => item.name,
           "status" => "active"
@@ -346,7 +348,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
       render_change(view, "set_catalogue_rule_unit", %{"uuid" => kitchen.uuid, "unit" => "flat"})
 
       view
-      |> form("form[phx-submit=save]",
+      |> form("form[action=\"#\"][phx-submit=save]",
         item: %{
           "name" => item.name,
           "status" => "active"
@@ -371,7 +373,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLiveTest do
       render_click(view, "clear_catalogue_rules", %{})
 
       view
-      |> form("form[phx-submit=save]",
+      |> form("form[action=\"#\"][phx-submit=save]",
         item: %{
           "name" => item.name,
           "status" => "active"


### PR DESCRIPTION
## Summary

Ten commits worth of catalogue admin UX work, hardened by a Phase 2 quality sweep at the end. Highlights:

- **Items / Categories tabs** on the detail page with per-tab Active / Deleted counts and a flat recency-ordered Deleted view for items.
- **Decoupled soft-delete** — items and categories now manage their `status` independently. Restoring a category no longer cascades; restoring an item whose parent category is deleted detaches it to Uncategorized; restoring an item whose parent catalogue is deleted is refused.
- **Item-disposition modal** when trashing a category that still has items: Cascade / Uncategorize / Move to (with same-catalogue target picker).
- **Bulk select + actions**: row checkboxes (table + card view) with a sticky action bar — Delete / Restore / Move (items) and Delete (categories, opens disposition modal).
- **Per-card pagination**: replaced the global infinite-scroll cursor with PdfSearchModal-style per-category expand. Every category renders eagerly with a 25-row preview + "Show N more" button per card.
- **DnD polish**: handle-only drag (the SortableGrid `data-sortable-handle` work landed in core), reorder-result flash (green on success, red on failure) on both rows and cards.
- **Cross-tab live updates** via PubSub: reorders, bulk operations, and category position changes broadcast to all open detail pages. Bulk operations get a two-step animation on receivers (red flash on leaving rows → 800ms delay → state refresh → green flash on arriving rows).
- **Selected-row indicator**: 15% primary tint + 4px primary left-edge accent on selected rows; same treatment for cards via the core `:has()` CSS rule.
- **Show-more reliability**: `expand_card` is now deferred (event handler returns immediately, button renders the loading state, the actual fetch runs on the next mailbox tick) with an 8s `:expand_timeout` recovery so a network hiccup mid-click restores the button + flashes a retry message.

## Phase 2 sweep findings (all fixed)

- **BUG-HIGH**: `bulk_move_items_to_category/3` could silently flip an item's `catalogue_uuid` cross-catalogue. The single-item DnD path rejects with "Wrong catalogue scope"; the bulk path didn't validate scope at all. Now requires `:catalogue_uuid` opt + `ensure_items_in_catalogue/2` + `resolve_move_target/2` guards. New error atoms `:wrong_catalogue_scope` / `:missing_catalogue_scope`.
- **BUG-HIGH**: `inspect(reason)` leaked raw Elixir terms in two flash messages. Replaced with gettext-wrapped user messages; raw reason routes to `log_operation_error/3` for engineer visibility.
- **BUG-HIGH**: 6 unwrapped flash strings in bulk handlers — all now wrapped in `Gettext.gettext`.
- **IMPROVEMENT-MEDIUM**: extracted magic 800ms cross-tab delay to `@bulk_change_apply_delay_ms`.

## Test coverage added

- 23 context-fn tests for the new bulk operations (all error paths, including `:missing_catalogue_scope`, `:wrong_catalogue_scope`, `:category_not_found`, plus the parent-deleted uncategorize / catalogue-deleted refusal semantics).
- 11 LV smoke tests for bulk events, per-card expand (`expand_card`, `:expand_timeout`), and cross-tab live (`:catalogue_card_refresh` self-skip + other-pid, `:catalogue_bulk_change` deferred apply).
- Stale LV tests rewritten for the new behavior (per-card expand, `request_trash_category` rename, deleted-mode header refactor, dropzone form selector scoping).

## Test plan

- [ ] `mix format --check-formatted` clean.
- [ ] `mix compile` clean (no warnings).
- [ ] `mix credo --strict` 0 findings on changed files.
- [ ] `mix test` — all web tests pass.
- [ ] In two browser tabs, drag an item — second tab sees the same green flash on the moved row.
- [ ] In two browser tabs, bulk-delete a few items — second tab sees them flash red, then disappear.
- [ ] Open a catalogue with a 100-item category; the card shows 25 items + "Show 75 more"; clicking expands by 25 with a brief loading state.
- [ ] Tick rows / cards — selected ones get a primary tint and left-edge accent.
- [ ] Try to bulk-move items where the target category is in a different catalogue — gets a clear "Items can only be moved within this catalogue." flash, no DB write.