### PR TITLE
Per-module gettext (en/ru/et)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.2.0 - 2026-05-11
+
+### Added
+- **Per-module gettext backend** — `PhoenixKitCatalogue.Gettext` (`lib/phoenix_kit_catalogue/gettext.ex`). The module now owns its translations instead of borrowing `PhoenixKitWeb.Gettext` from the host app.
+- **i18n-aware tab registration** — all 19 `%Tab{}` structs in `admin_tabs/0` carry `gettext_backend: PhoenixKitCatalogue.Gettext` and `gettext_domain: "default"`. Tab labels are now translated at render-time via `Tab.localized_label/1` (requires `phoenix_kit >= 1.7.107`).
+- **Translation files** — `priv/gettext/{en,ru,et}/LC_MESSAGES/default.po` with complete translations for tab labels, page titles, status strings, error messages, flash messages, and UI copy. Russian uses 3 plural forms per CLDR; Estonian uses 2.
+- **Smoke test** — `test/gettext_test.exs` verifies backend compilation, Russian/Estonian tab-label translation, fallback for tabs without a backend, and fallback to msgid for untranslated strings.
+
+### Changed
+- All `Gettext.gettext(PhoenixKitWeb.Gettext, ...)` and `Gettext.ngettext(PhoenixKitWeb.Gettext, ...)` calls replaced with `PhoenixKitCatalogue.Gettext`. Affects 18 files in `lib/`. This is a transparent change for end users — behaviour is identical as long as translations are kept in sync.
+- Version bumped `0.1.17` → `0.2.0` (minor: tab labels are now locale-dependent, which is a visible behaviour change for downstream callers relying on raw English strings from `Tab.label`).
+
+### Notes
+- `{:phoenix_kit, "~> 1.7"}` constraint kept as-is (core is at 1.7.107 locally). A bump to `~> 1.8` is gated on the core hex release; `Tab.gettext_backend` and `Tab.localized_label/1` are already present at 1.7.107.
+
 ## 0.1.17 - 2026-05-09
 
 ### Added

--- a/lib/phoenix_kit_catalogue.ex
+++ b/lib/phoenix_kit_catalogue.ex
@@ -89,7 +89,7 @@ defmodule PhoenixKitCatalogue do
   # ===========================================================================
 
   @impl PhoenixKit.Module
-  def version, do: "0.1.17"
+  def version, do: "0.2.0"
 
   @impl PhoenixKit.Module
   def css_sources, do: [:phoenix_kit_catalogue]
@@ -114,6 +114,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue,
         label: "Catalogue",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-rectangle-stack",
         path: "catalogue",
         priority: 660,
@@ -130,6 +132,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_list,
         label: "Catalogues",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-rectangle-stack",
         path: "catalogue",
         priority: 661,
@@ -153,6 +157,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_manufacturers,
         label: "Manufacturers",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-building-office",
         path: "catalogue/manufacturers",
         priority: 662,
@@ -164,6 +170,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_suppliers,
         label: "Suppliers",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-cube",
         path: "catalogue/suppliers",
         priority: 663,
@@ -176,6 +184,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_import,
         label: "Import",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-arrow-up-tray",
         path: "catalogue/import",
         priority: 664,
@@ -188,6 +198,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_events,
         label: "Events",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-clock",
         path: "catalogue/events",
         priority: 665,
@@ -201,6 +213,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_pdfs,
         label: "PDFs",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-document-text",
         path: "catalogue/pdfs",
         priority: 690,
@@ -216,6 +230,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_pdf_detail,
         label: "PDF",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-document-text",
         path: "catalogue/pdfs/:uuid",
         priority: 691,
@@ -232,6 +248,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_new,
         label: "New Catalogue",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-plus",
         path: "catalogue/new",
         priority: 666,
@@ -244,6 +262,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_manufacturer_new,
         label: "New Manufacturer",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-plus",
         path: "catalogue/manufacturers/new",
         priority: 667,
@@ -256,6 +276,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_manufacturer_edit,
         label: "Edit Manufacturer",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-pencil-square",
         path: "catalogue/manufacturers/:uuid/edit",
         priority: 668,
@@ -268,6 +290,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_supplier_new,
         label: "New Supplier",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-plus",
         path: "catalogue/suppliers/new",
         priority: 669,
@@ -280,6 +304,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_supplier_edit,
         label: "Edit Supplier",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-pencil-square",
         path: "catalogue/suppliers/:uuid/edit",
         priority: 670,
@@ -293,6 +319,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_category_edit,
         label: "Edit Category",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-pencil-square",
         path: "catalogue/categories/:uuid/edit",
         priority: 671,
@@ -306,6 +334,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_item_edit,
         label: "Edit Item",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-pencil-square",
         path: "catalogue/items/:uuid/edit",
         priority: 672,
@@ -319,6 +349,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_detail,
         label: "Catalogue",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-rectangle-stack",
         path: "catalogue/:uuid",
         priority: 673,
@@ -331,6 +363,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_edit,
         label: "Edit Catalogue",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-pencil-square",
         path: "catalogue/:uuid/edit",
         priority: 674,
@@ -343,6 +377,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_category_new,
         label: "New Category",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-plus",
         path: "catalogue/:catalogue_uuid/categories/new",
         priority: 675,
@@ -355,6 +391,8 @@ defmodule PhoenixKitCatalogue do
       %Tab{
         id: :admin_catalogue_item_new,
         label: "New Item",
+        gettext_backend: PhoenixKitCatalogue.Gettext,
+        gettext_domain: "default",
         icon: "hero-plus",
         path: "catalogue/:catalogue_uuid/items/new",
         priority: 676,

--- a/lib/phoenix_kit_catalogue/attachments.ex
+++ b/lib/phoenix_kit_catalogue/attachments.ex
@@ -208,7 +208,7 @@ defmodule PhoenixKitCatalogue.Attachments do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Could not prepare the files folder.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not prepare the files folder.")
          )}
     end
   end
@@ -268,7 +268,7 @@ defmodule PhoenixKitCatalogue.Attachments do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Could not remove file.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not remove file.")
          )}
     end
   end
@@ -443,16 +443,19 @@ defmodule PhoenixKitCatalogue.Attachments do
 
   @doc "Translates LiveView upload error atoms to user-facing text."
   def upload_error_message(:too_large),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "File is too large.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "File is too large.")
 
   def upload_error_message(:not_accepted),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "File type not accepted.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "File type not accepted.")
 
   def upload_error_message(:too_many_files),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Too many files.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Too many files.")
 
   def upload_error_message(other),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Upload error: %{reason}", reason: inspect(other))
+    do:
+      Gettext.gettext(PhoenixKitCatalogue.Gettext, "Upload error: %{reason}",
+        reason: inspect(other)
+      )
 
   # ── Internals ────────────────────────────────────────────────────
 
@@ -589,7 +592,7 @@ defmodule PhoenixKitCatalogue.Attachments do
         put_flash(
           socket,
           :error,
-          Gettext.gettext(PhoenixKitWeb.Gettext, "Selected image could not be loaded.")
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Selected image could not be loaded.")
         )
 
       file ->
@@ -672,7 +675,7 @@ defmodule PhoenixKitCatalogue.Attachments do
     put_flash(
       socket,
       :error,
-      Gettext.gettext(PhoenixKitWeb.Gettext, "Upload failed for %{name}.",
+      Gettext.gettext(PhoenixKitCatalogue.Gettext, "Upload failed for %{name}.",
         name: entry.client_name
       )
     )

--- a/lib/phoenix_kit_catalogue/errors.ex
+++ b/lib/phoenix_kit_catalogue/errors.ex
@@ -69,70 +69,70 @@ defmodule PhoenixKitCatalogue.Errors do
   def message(:would_create_cycle),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Cannot move a category under itself or one of its descendants."
       )
 
   def message(:cross_catalogue),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Target belongs to a different catalogue. Move the category to the target catalogue first."
       )
 
   def message(:parent_not_found),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Parent category not found.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Parent category not found.")
 
   def message(:not_siblings),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Categories must share the same parent to be reordered."
       )
 
   def message(:category_not_found),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category not found.")
 
   def message(:catalogue_not_found),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found.")
 
   def message(:same_catalogue),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Item is already in this catalogue."
       )
 
   def message(:no_user),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "You must be logged in to upload files."
       )
 
   def message(:unsupported),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unsupported file format.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unsupported file format.")
 
   def message(:unsupported_file_format),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Unsupported file format. Please upload .xlsx or .csv."
       )
 
   def message(:not_found),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Not found.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Not found.")
 
   def message(:missing_item_name),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Missing item name.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Missing item name.")
 
   def message(:csv_empty),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "CSV file is empty.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "CSV file is empty.")
 
   def message(:parent_catalogue_deleted),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
       )
 
@@ -140,7 +140,7 @@ defmodule PhoenixKitCatalogue.Errors do
 
   def message({:referenced_by_smart_items, count}) when is_integer(count) do
     Gettext.gettext(
-      PhoenixKitWeb.Gettext,
+      PhoenixKitCatalogue.Gettext,
       "Cannot delete: %{count} smart items still reference this catalogue.",
       count: count
     )
@@ -149,14 +149,14 @@ defmodule PhoenixKitCatalogue.Errors do
   def message({:duplicate_referenced_catalogue, _uuid}),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Each catalogue can only be referenced once per item."
       )
 
   def message({:invalid_price, raw}),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Invalid price: %{raw}",
         raw: truncate(raw)
       )
@@ -164,7 +164,7 @@ defmodule PhoenixKitCatalogue.Errors do
   def message({:invalid_markup, raw}),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Invalid markup: %{raw}",
         raw: truncate(raw)
       )
@@ -172,7 +172,7 @@ defmodule PhoenixKitCatalogue.Errors do
   def message({:sheet_empty, sheet}),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Sheet '%{sheet}' is empty.",
         sheet: to_string(sheet)
       )
@@ -180,19 +180,19 @@ defmodule PhoenixKitCatalogue.Errors do
   def message({:sheet_read_failed, sheet, _raw}),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Failed to read sheet '%{sheet}'.",
         sheet: to_string(sheet)
       )
 
   def message({:xlsx_open_failed, _raw}),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to open XLSX file.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to open XLSX file.")
 
   def message({:xlsx_read_failed, _raw}),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to read XLSX file.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to read XLSX file.")
 
   def message({:csv_parse_failed, _raw}),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to parse CSV file.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to parse CSV file.")
 
   # PDF library error atoms removed 2026-05-06 (Phase 2 sweep) —
   # `:pdf_invalid_format` had no caller (the upload pipeline rejects
@@ -211,7 +211,7 @@ defmodule PhoenixKitCatalogue.Errors do
 
   def message(reason) do
     Gettext.gettext(
-      PhoenixKitWeb.Gettext,
+      PhoenixKitCatalogue.Gettext,
       "Unexpected error: %{reason}",
       reason: inspect(reason)
     )

--- a/lib/phoenix_kit_catalogue/gettext.ex
+++ b/lib/phoenix_kit_catalogue/gettext.ex
@@ -1,0 +1,4 @@
+defmodule PhoenixKitCatalogue.Gettext do
+  @moduledoc "Gettext backend for phoenix_kit_catalogue."
+  use Gettext.Backend, otp_app: :phoenix_kit_catalogue
+end

--- a/lib/phoenix_kit_catalogue/metadata.ex
+++ b/lib/phoenix_kit_catalogue/metadata.ex
@@ -48,30 +48,33 @@ defmodule PhoenixKitCatalogue.Metadata do
   Order here is the order used for the "Add metadata" dropdown.
 
   The `:label` values are translated at call time via
-  `PhoenixKitWeb.Gettext` — do not cache the result across locale
+  `PhoenixKitCatalogue.Gettext` — do not cache the result across locale
   changes. The `:key` is stable (it's the JSONB key) and never
   translated.
   """
   @spec definitions(resource_type()) :: [definition()]
   def definitions(:item) do
     [
-      %{key: "color", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Color")},
-      %{key: "weight", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Weight")},
-      %{key: "width", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Width")},
-      %{key: "height", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Height")},
-      %{key: "depth", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Depth")},
-      %{key: "material", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Material")},
-      %{key: "finish", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Finish")}
+      %{key: "color", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Color")},
+      %{key: "weight", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Weight")},
+      %{key: "width", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Width")},
+      %{key: "height", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Height")},
+      %{key: "depth", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Depth")},
+      %{key: "material", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Material")},
+      %{key: "finish", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Finish")}
     ]
   end
 
   def definitions(:catalogue) do
     [
-      %{key: "brand", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Brand")},
-      %{key: "collection", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Collection")},
-      %{key: "season", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Season")},
-      %{key: "region", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Region")},
-      %{key: "vendor_ref", label: Gettext.gettext(PhoenixKitWeb.Gettext, "Vendor Reference")}
+      %{key: "brand", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Brand")},
+      %{key: "collection", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Collection")},
+      %{key: "season", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Season")},
+      %{key: "region", label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Region")},
+      %{
+        key: "vendor_ref",
+        label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Vendor Reference")
+      }
     ]
   end
 

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -47,7 +47,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   def mount(%{"uuid" => uuid}, _session, socket) do
     socket =
       assign(socket,
-        page_title: Gettext.gettext(PhoenixKitWeb.Gettext, "Loading..."),
+        page_title: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Loading..."),
         catalogue_uuid: uuid,
         catalogue: nil,
         category_list: [],
@@ -94,7 +94,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
           {:ok,
            socket
-           |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found."))
+           |> put_flash(
+             :error,
+             Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found.")
+           )
            |> push_navigate(to: Paths.index())}
       end
     else
@@ -284,7 +287,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
        |> put_flash(
          :error,
          Gettext.gettext(
-           PhoenixKitWeb.Gettext,
+           PhoenixKitCatalogue.Gettext,
            "Loading more items took too long. Please try again."
          )
        )}
@@ -330,7 +333,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
        socket
        |> put_flash(
          :info,
-         Gettext.gettext(PhoenixKitWeb.Gettext, "This catalogue was just deleted.")
+         Gettext.gettext(PhoenixKitCatalogue.Gettext, "This catalogue was just deleted.")
        )
        |> push_navigate(to: Paths.index())}
   end
@@ -432,7 +435,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          {:ok, _} <- Catalogue.trash_item(item, actor_opts(socket)) do
       {:noreply,
        socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item moved to deleted."))
+       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item moved to deleted."))
        |> remove_item_locally(uuid)
        |> refresh_counts()}
     else
@@ -441,7 +444,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item not found.")
          )}
 
       {:error, reason} ->
@@ -455,7 +458,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete item.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete item.")
          )}
     end
   end
@@ -465,7 +468,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          {:ok, _} <- Catalogue.restore_item(item, actor_opts(socket)) do
       {:noreply,
        socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item restored."))
+       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item restored."))
        |> remove_item_locally(uuid)
        |> refresh_counts()}
     else
@@ -474,7 +477,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item not found.")
          )}
 
       {:error, :parent_catalogue_deleted} ->
@@ -491,7 +494,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to restore item.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to restore item.")
          )}
     end
   end
@@ -510,7 +513,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
            |> assign(:confirm_delete, nil)
            |> put_flash(
              :info,
-             Gettext.gettext(PhoenixKitWeb.Gettext, "Item permanently deleted.")
+             Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item permanently deleted.")
            )
            |> remove_item_locally(uuid)
            |> refresh_counts()}
@@ -519,7 +522,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             {:noreply,
              socket
              |> assign(:confirm_delete, nil)
-             |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found."))}
+             |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item not found."))}
 
           {:error, reason} ->
             log_operation_error(socket, "permanently_delete_item", %{
@@ -533,7 +536,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
              |> assign(:confirm_delete, nil)
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete item.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete item.")
              )}
         end
 
@@ -554,7 +557,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category not found.")
          )}
 
       category ->
@@ -783,7 +786,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          {:ok, _} <- Catalogue.restore_category(category, actor_opts(socket)) do
       {:noreply,
        socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Category restored."))
+       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category restored."))
        |> reset_and_load()}
     else
       nil ->
@@ -791,7 +794,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category not found.")
          )}
 
       {:error, :parent_catalogue_deleted} ->
@@ -808,7 +811,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to restore category.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to restore category.")
          )}
     end
   end
@@ -823,7 +826,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
            |> assign(:confirm_delete, nil)
            |> put_flash(
              :info,
-             Gettext.gettext(PhoenixKitWeb.Gettext, "Category permanently deleted.")
+             Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category permanently deleted.")
            )
            |> reset_and_load()}
         else
@@ -833,7 +836,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
              |> assign(:confirm_delete, nil)
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category not found.")
              )}
 
           {:error, reason} ->
@@ -848,7 +851,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
              |> assign(:confirm_delete, nil)
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete category.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete category.")
              )}
         end
 
@@ -892,7 +895,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Wrong catalogue scope.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Wrong catalogue scope.")
          )}
 
       from_catalogue_uuid != to_catalogue_uuid ->
@@ -905,7 +908,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          |> put_flash(
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Items can only be moved within the same catalogue."
            )
          )
@@ -943,7 +946,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           nil ->
             {:noreply,
              socket
-             |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found."))
+             |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item not found."))
              |> flash_reorder(moved_id, :error)}
 
           {:error, reason} ->
@@ -957,7 +960,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
              socket
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move item.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move item.")
              )
              |> reset_and_load()
              |> flash_reorder(moved_id, :error)}
@@ -976,7 +979,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
        put_flash(
          socket,
          :error,
-         Gettext.gettext(PhoenixKitWeb.Gettext, "Wrong catalogue scope.")
+         Gettext.gettext(PhoenixKitCatalogue.Gettext, "Wrong catalogue scope.")
        )}
     else
       apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids, moved_id)
@@ -1028,7 +1031,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> assign(:selected_items, MapSet.new())
     |> put_flash(
       :info,
-      Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted %{count} items.", count: count)
+      Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted %{count} items.", count: count)
     )
     |> reset_and_load()
     |> then(&{:noreply, &1})
@@ -1044,7 +1047,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> assign(:selected_items, MapSet.new())
     |> put_flash(
       :info,
-      Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently deleted %{count} items.", count: count)
+      Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently deleted %{count} items.",
+        count: count
+      )
     )
     |> reset_and_load()
     |> then(&{:noreply, &1})
@@ -1059,7 +1064,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> assign(:selected_items, MapSet.new())
     |> put_flash(
       :info,
-      Gettext.gettext(PhoenixKitWeb.Gettext, "Restored %{count} items.", count: count)
+      Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restored %{count} items.", count: count)
     )
     |> reset_and_load()
     |> then(&{:noreply, &1})
@@ -1082,7 +1087,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         |> assign(:selected_items, MapSet.new())
         |> put_flash(
           :info,
-          Gettext.gettext(PhoenixKitWeb.Gettext, "Moved %{count} items.", count: count)
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Moved %{count} items.", count: count)
         )
         |> reset_and_load()
         |> then(&{:noreply, &1})
@@ -1092,7 +1097,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Target category not found.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Target category not found.")
          )}
 
       {:error, scope_err} when scope_err in [:wrong_catalogue_scope, :missing_catalogue_scope] ->
@@ -1103,7 +1108,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
            socket,
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Items can only be moved within this catalogue."
            )
          )}
@@ -1128,7 +1133,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         |> assign(:selected_categories, MapSet.new())
         |> put_flash(
           :info,
-          Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted %{count} categories.", count: count)
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted %{count} categories.",
+            count: count
+          )
         )
         |> reset_and_load()
         |> then(&{:noreply, &1})
@@ -1140,7 +1147,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete categories.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete categories.")
          )}
     end
   end
@@ -1162,7 +1169,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       |> assign(:selected_categories, MapSet.new())
       |> put_flash(
         :info,
-        Gettext.gettext(PhoenixKitWeb.Gettext, "Restored %{count} categories.", count: ok)
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restored %{count} categories.", count: ok)
       )
       |> reset_and_load()
 
@@ -1176,7 +1183,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          socket,
          :error,
          Gettext.gettext(
-           PhoenixKitWeb.Gettext,
+           PhoenixKitCatalogue.Gettext,
            "Some categories couldn't be restored. The catalogue may be deleted — restore it first."
          )
        )}
@@ -1200,7 +1207,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       {:ok, _} ->
         {:noreply,
          socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Category moved to deleted."))
+         |> put_flash(
+           :info,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category moved to deleted.")
+         )
          |> reset_and_load()}
 
       {:error, reason} ->
@@ -1214,7 +1224,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete category.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete category.")
          )}
     end
   end
@@ -1243,7 +1253,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          socket
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to reorder items.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to reorder items.")
          )
          |> reset_and_load()
          |> flash_reorder(moved_id, :error)}
@@ -1276,7 +1286,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
      |> assign(:confirm_delete, nil)
      |> put_flash(
        :error,
-       Gettext.gettext(PhoenixKitWeb.Gettext, "Unexpected request. Please try again.")
+       Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unexpected request. Please try again.")
      )}
   end
 
@@ -1574,7 +1584,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          |> assign(:search_loading, false)
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Search failed. Please try again.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search failed. Please try again.")
          )}
     end
   end
@@ -1621,7 +1631,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          |> assign(:search_loading, false)
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Search failed. Please try again.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search failed. Please try again.")
          )}
     end
   end
@@ -1818,7 +1828,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          socket
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to reorder categories.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to reorder categories.")
          )
          |> reset_and_load()
          |> flash_reorder(moved_id, :error)}
@@ -1845,13 +1855,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <.admin_page_header back={Paths.index()} title={@catalogue.name}>
           <:actions :if={@view_mode == "active"}>
             <.link navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-outline btn-sm">
-              <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Add Category")}
+              <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
             </.link>
             <.link navigate={Paths.item_new(@catalogue.uuid)} class="btn btn-primary btn-sm">
-              <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Add Item")}
+              <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Item")}
             </.link>
             <.link navigate={Paths.catalogue_edit(@catalogue.uuid)} class="btn btn-ghost btn-sm">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
             </.link>
           </:actions>
         </.admin_page_header>
@@ -1874,7 +1884,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               phx-value-tab="items"
               class={["tab", @tab == "items" && "tab-active"]}
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Items")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items")}
             </button>
             <button
               type="button"
@@ -1883,7 +1893,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               phx-value-tab="categories"
               class={["tab", @tab == "categories" && "tab-active"]}
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Categories")} ({length(@category_list)})
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Categories")} ({length(@category_list)})
             </button>
           </div>
 
@@ -1912,7 +1922,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 )
               ]}
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")} ({if @tab == "categories",
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")} ({if @tab == "categories",
                 do: @active_category_count,
                 else: @active_item_count})
             </button>
@@ -1928,7 +1938,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 )
               ]}
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({if @tab == "categories",
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({if @tab == "categories",
                 do: @deleted_category_count,
                 else: @deleted_item_count})
             </button>
@@ -1938,7 +1948,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <%!-- ── Items tab ────────────────────────────────────────── --%>
         <div :if={@tab == "items"} class="flex flex-col gap-6">
           <%!-- Search (Items tab only — Categories tab has no search yet) --%>
-          <.search_input :if={@view_mode == "active"} query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items by name, description, or SKU...")} />
+          <.search_input :if={@view_mode == "active"} query={@search_query} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items by name, description, or SKU...")} />
 
           <%!-- Combined row: bulk-action contents on the left (when
                items are selected), card/table view toggle on the right.
@@ -1969,7 +1979,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           <div class="flex items-center gap-2">
             <%= if @search_loading and is_nil(@search_results) do %>
               <span class="text-sm text-base-content/60">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Searching for \"%{query}\"...", query: @search_query)}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Searching for \"%{query}\"...", query: @search_query)}
               </span>
             <% else %>
               <.search_results_summary :if={@search_results != nil} count={@search_total} query={@search_query} loaded={length(@search_results)} />
@@ -1977,7 +1987,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <span :if={@search_loading} class="loading loading-spinner loading-xs text-base-content/40"></span>
           </div>
 
-          <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitWeb.Gettext, "No items match your search.")} />
+          <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
 
           <%!-- Stale results are dimmed while a newer query is in flight to
                signal that the list is about to update. --%>
@@ -2014,13 +2024,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <%!-- Empty states --%>
         <div :if={is_nil(@search_results) and not @search_loading and @loaded_cards == [] and @view_mode == "active"} class="card bg-base-100 shadow">
           <div class="card-body items-center text-center py-12">
-            <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No categories or items yet. Add a category or item to get started.")}</p>
+            <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No categories or items yet. Add a category or item to get started.")}</p>
           </div>
         </div>
 
         <div :if={is_nil(@search_results) and not @search_loading and @deleted_items == [] and @view_mode == "deleted"} class="card bg-base-100 shadow">
           <div class="card-body items-center text-center py-12">
-            <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No deleted items.")}</p>
+            <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No deleted items.")}</p>
           </div>
         </div>
 
@@ -2098,11 +2108,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <div class="card-body items-center text-center py-12">
               <p class="text-base-content/60">
                 {if @view_mode == "deleted",
-                  do: Gettext.gettext(PhoenixKitWeb.Gettext, "No deleted categories."),
-                  else: Gettext.gettext(PhoenixKitWeb.Gettext, "No categories yet. Add one to start organizing items.")}
+                  do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No deleted categories."),
+                  else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No categories yet. Add one to start organizing items.")}
               </p>
               <.link :if={@view_mode == "active"} navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-primary btn-sm mt-2">
-                <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitWeb.Gettext, "Add Category")}
+                <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
               </.link>
             </div>
           </div>
@@ -2140,10 +2150,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         show={match?({"item", _}, @confirm_delete)}
         on_confirm="permanently_delete_item"
         on_cancel="cancel_delete"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Item")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently Delete Item")}
         title_icon="hero-trash"
-        messages={[{:warning, Gettext.gettext(PhoenixKitWeb.Gettext, "This item will be permanently deleted. This cannot be undone.")}]}
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+        messages={[{:warning, Gettext.gettext(PhoenixKitCatalogue.Gettext, "This item will be permanently deleted. This cannot be undone.")}]}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
 
@@ -2151,10 +2161,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         show={match?({"category", _}, @confirm_delete)}
         on_confirm="permanently_delete_category"
         on_cancel="cancel_delete"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Category")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently Delete Category")}
         title_icon="hero-trash"
-        messages={[{:warning, Gettext.gettext(PhoenixKitWeb.Gettext, "This category and all its items will be permanently deleted. This cannot be undone.")}]}
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+        messages={[{:warning, Gettext.gettext(PhoenixKitCatalogue.Gettext, "This category and all its items will be permanently deleted. This cannot be undone.")}]}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
 
@@ -2168,12 +2178,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         show={true}
         on_confirm="confirm_trash_category"
         on_cancel="cancel_trash_category"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete category — what about the items?")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete category — what about the items?")}
         title_icon="hero-folder-minus"
         confirm_text={
           if @trash_modal[:disposition] == :cascade,
-            do: Gettext.gettext(PhoenixKitWeb.Gettext, "Delete category and items"),
-            else: Gettext.gettext(PhoenixKitWeb.Gettext, "Move items and delete category")
+            do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete category and items"),
+            else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move items and delete category")
         }
         confirm_disabled={
           @trash_modal[:disposition] == :move_to and is_nil(@trash_modal[:target_uuid])
@@ -2183,7 +2193,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <p class="text-sm text-base-content/70">
           <strong>{@trash_modal[:category].name}</strong>
           {Gettext.gettext(
-            PhoenixKitWeb.Gettext,
+            PhoenixKitCatalogue.Gettext,
             "and its subtree contain %{count} active items. Choose where they should go before the category is deleted.",
             count: @trash_modal[:item_count]
           )}
@@ -2203,11 +2213,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             />
             <div class="flex-1 min-w-0">
               <p class="font-medium text-sm">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Make items uncategorized")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Make items uncategorized")}
               </p>
               <p class="text-xs text-base-content/60">
                 {Gettext.gettext(
-                  PhoenixKitWeb.Gettext,
+                  PhoenixKitCatalogue.Gettext,
                   "Items stay in this catalogue but are no longer attached to any category."
                 )}
               </p>
@@ -2230,17 +2240,17 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             />
             <div class="flex-1 min-w-0">
               <p class="font-medium text-sm">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move items to another category")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move items to another category")}
               </p>
               <p class="text-xs text-base-content/60 mb-2">
                 {Gettext.gettext(
-                  PhoenixKitWeb.Gettext,
+                  PhoenixKitCatalogue.Gettext,
                   "Pick a target category in this catalogue. The category being deleted and its subtree are excluded."
                 )}
               </p>
               <%= if @trash_modal[:targets] == [] do %>
                 <p class="text-xs text-warning">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No other categories available — use Uncategorized instead.")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No other categories available — use Uncategorized instead.")}
                 </p>
               <% else %>
                 <select
@@ -2249,7 +2259,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                   disabled={@trash_modal[:disposition] != :move_to}
                   class="select select-sm select-bordered w-full"
                 >
-                  <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}</option>
+                  <option value="">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "-- Select category --")}</option>
                   <%= for {cat, depth} <- @trash_modal[:targets] do %>
                     <option value={cat.uuid} selected={@trash_modal[:target_uuid] == cat.uuid}>
                       {String.duplicate("— ", depth)}{cat.name}
@@ -2276,11 +2286,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             />
             <div class="flex-1 min-w-0">
               <p class="font-medium text-sm text-error">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete items along with the category")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete items along with the category")}
               </p>
               <p class="text-xs text-base-content/60">
                 {Gettext.gettext(
-                  PhoenixKitWeb.Gettext,
+                  PhoenixKitCatalogue.Gettext,
                   "Items move to the Deleted view alongside the category. Both can be restored later."
                 )}
               </p>
@@ -2299,15 +2309,15 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         on_cancel="cancel_bulk_action"
         title={
           case @bulk_confirm[:mode] do
-            :permanent -> Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently delete selected items?")
-            _ -> Gettext.gettext(PhoenixKitWeb.Gettext, "Delete selected items?")
+            :permanent -> Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently delete selected items?")
+            _ -> Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete selected items?")
           end
         }
         title_icon="hero-trash"
         confirm_text={
           case @bulk_confirm[:mode] do
-            :permanent -> Gettext.gettext(PhoenixKitWeb.Gettext, "Delete forever")
-            _ -> Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")
+            :permanent -> Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete forever")
+            _ -> Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")
           end
         }
         danger={true}
@@ -2316,13 +2326,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             :permanent ->
               [
                 {:warning,
-                 Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} items will be permanently deleted. This cannot be undone.", count: @bulk_confirm[:count])}
+                 Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} items will be permanently deleted. This cannot be undone.", count: @bulk_confirm[:count])}
               ]
 
             _ ->
               [
                 {:warning,
-                 Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} items will be moved to the Deleted view. They can be restored later.", count: @bulk_confirm[:count])}
+                 Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} items will be moved to the Deleted view. They can be restored later.", count: @bulk_confirm[:count])}
               ]
           end
         }
@@ -2336,15 +2346,15 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         show={true}
         on_confirm="confirm_bulk_move_items"
         on_cancel="cancel_bulk_move"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Move selected items")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move selected items")}
         title_icon="hero-arrows-right-left"
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Move items")}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move items")}
         confirm_disabled={
           @bulk_move_modal[:disposition] == :move_to and is_nil(@bulk_move_modal[:target_uuid])
         }
       >
         <p class="text-sm text-base-content/70">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Pick where %{count} items should go.", count: @bulk_move_modal[:count])}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Pick where %{count} items should go.", count: @bulk_move_modal[:count])}
         </p>
 
         <div class="space-y-3 mt-4">
@@ -2360,10 +2370,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             />
             <div class="flex-1 min-w-0">
               <p class="font-medium text-sm">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Make items uncategorized")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Make items uncategorized")}
               </p>
               <p class="text-xs text-base-content/60">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Items keep their catalogue but lose their category.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items keep their catalogue but lose their category.")}
               </p>
             </div>
           </label>
@@ -2380,11 +2390,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             />
             <div class="flex-1 min-w-0">
               <p class="font-medium text-sm">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move items to another category")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move items to another category")}
               </p>
               <%= if @bulk_move_modal[:targets] == [] do %>
                 <p class="text-xs text-warning">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No categories available — use Uncategorized instead.")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No categories available — use Uncategorized instead.")}
                 </p>
               <% else %>
                 <select
@@ -2393,7 +2403,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                   disabled={@bulk_move_modal[:disposition] != :move_to}
                   class="select select-sm select-bordered w-full mt-2"
                 >
-                  <option value="">{Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}</option>
+                  <option value="">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "-- Select category --")}</option>
                   <%= for {cat, depth} <- @bulk_move_modal[:targets] do %>
                     <option value={cat.uuid} selected={@bulk_move_modal[:target_uuid] == cat.uuid}>
                       {String.duplicate("— ", depth)}{cat.name}
@@ -2491,12 +2501,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               :if={@view_mode == "active" and @card.category.status == "active"}
               navigate={Paths.category_edit(@card.category.uuid)}
               class="text-base-content/40 hover:text-primary"
-              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit category")}
+              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit category")}
             >
               <.icon name="hero-pencil" class="w-4 h-4" />
             </.link>
             <span :if={@card.category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
-            <span class="badge badge-ghost badge-sm">{@total} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
+            <span class="badge badge-ghost badge-sm">{@total} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}</span>
           </div>
 
           <%!-- Active mode: no per-card buttons. The Items tab is
@@ -2508,10 +2518,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <button
               phx-click="restore_category"
               phx-value-uuid={@card.category.uuid}
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")}
+              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
               class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
             </button>
             <button
               phx-click="show_delete_confirm"
@@ -2519,7 +2529,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               phx-value-type="category"
               class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-error/30 bg-error/10 hover:bg-error/20 text-error text-xs font-medium transition-colors cursor-pointer"
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
             </button>
           </div>
         </div>
@@ -2564,10 +2574,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             >
               <%= if @expanding do %>
                 <span class="loading loading-spinner loading-xs"></span>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Loading…")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Loading…")}
               <% else %>
                 <.icon name="hero-chevron-down" class="w-3 h-3" />
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Show %{n} more", n: @total - @loaded)}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Show %{n} more", n: @total - @loaded)}
               <% end %>
             </button>
           </div>
@@ -2590,7 +2600,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         </div>
 
         <p :if={@card.items == [] and @view_mode == "active"} class="text-sm text-base-content/40 text-center py-4">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "No items in this category.")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items in this category.")}
         </p>
       </div>
     </div>
@@ -2604,8 +2614,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     <div class="card bg-base-100 shadow">
       <div class="card-body">
         <div :if={@category_total > 0} class="flex items-center gap-2">
-          <h3 class="card-title text-lg text-base-content/70">{Gettext.gettext(PhoenixKitWeb.Gettext, "Uncategorized")}</h3>
-          <span class="badge badge-ghost badge-sm">{@uncategorized_total} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
+          <h3 class="card-title text-lg text-base-content/70">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Uncategorized")}</h3>
+          <span class="badge badge-ghost badge-sm">{@uncategorized_total} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}</span>
         </div>
 
         <div class={if @category_total > 0, do: "mt-2", else: ""}>
@@ -2642,10 +2652,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             >
               <%= if @expanding do %>
                 <span class="loading loading-spinner loading-xs"></span>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Loading…")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Loading…")}
               <% else %>
                 <.icon name="hero-chevron-down" class="w-3 h-3" />
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Show %{n} more", n: @uncategorized_total - @loaded)}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Show %{n} more", n: @uncategorized_total - @loaded)}
               <% end %>
             </button>
           </div>
@@ -2671,30 +2681,30 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     ~H"""
     <div class="flex flex-wrap items-center gap-3 grow">
       <span class="text-sm font-medium">
-        {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} selected", count: @count)}
+        {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} selected", count: @count)}
       </span>
       <div class="flex items-center gap-2">
         <%= if @view_mode == "active" do %>
           <button phx-click="request_bulk_move_items" class="btn btn-sm btn-outline">
             <.icon name="hero-arrows-right-left" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
           </button>
           <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
             <.icon name="hero-trash" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
           </button>
         <% else %>
           <button phx-click="request_bulk_restore_items" class="btn btn-sm btn-outline btn-success">
             <.icon name="hero-arrow-path" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
           </button>
           <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
             <.icon name="hero-trash" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete forever")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete forever")}
           </button>
         <% end %>
         <button phx-click="clear_selection" class="btn btn-sm btn-ghost">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
         </button>
       </div>
     </div>
@@ -2708,22 +2718,22 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     ~H"""
     <div class="sticky top-[72px] z-40 -mx-1 px-3 py-2 rounded-lg bg-base-100/95 border border-primary/40 shadow-md backdrop-blur flex flex-wrap items-center gap-3">
       <span class="text-sm font-medium">
-        {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} selected", count: @count)}
+        {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} selected", count: @count)}
       </span>
       <div class="flex items-center gap-2 ml-auto">
         <%= if @view_mode == "active" do %>
           <button phx-click="request_bulk_delete_categories" class="btn btn-sm btn-outline btn-error">
             <.icon name="hero-trash" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
           </button>
         <% else %>
           <button phx-click="request_bulk_restore_categories" class="btn btn-sm btn-outline btn-success">
             <.icon name="hero-arrow-path" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
           </button>
         <% end %>
         <button phx-click="clear_selection" class="btn btn-sm btn-ghost">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
         </button>
       </div>
     </div>
@@ -2764,7 +2774,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               <span
                 :if={@sibling_count > 1}
                 class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 opacity-0 group-hover:opacity-100 transition-opacity"
-                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder (among siblings)")}
+                title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to reorder (among siblings)")}
               >
                 <.icon name="hero-bars-3" class="w-4 h-4" />
               </span>
@@ -2798,7 +2808,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               :if={@view_mode == "active" and @category.status == "active"}
               navigate={Paths.category_edit(@category.uuid)}
               class="text-base-content/40 hover:text-primary"
-              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit category")}
+              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit category")}
             >
               <.icon name="hero-pencil" class="w-4 h-4" />
             </.link>
@@ -2808,7 +2818,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                  is deleted, its items are managed separately (Items tab
                  Deleted view) — the count here would be confusing under
                  the "separate status" rule. --%>
-            <span :if={@category.status == "active"} class="badge badge-ghost badge-sm">{@count} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}</span>
+            <span :if={@category.status == "active"} class="badge badge-ghost badge-sm">{@count} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}</span>
           </div>
 
           <%!-- Deleted mode: Restore + Permanent Delete (per-row; bulk
@@ -2818,10 +2828,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <button
               phx-click="restore_category"
               phx-value-uuid={@category.uuid}
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")}
+              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
               class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
             </button>
             <button
               phx-click="show_delete_confirm"
@@ -2829,7 +2839,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
               phx-value-type="category"
               class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-error/30 bg-error/10 hover:bg-error/20 text-error text-xs font-medium transition-colors cursor-pointer"
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
             </button>
           </div>
         </div>

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -56,7 +56,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     if is_nil(catalogue) and action == :edit do
       {:ok,
        socket
-       |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found."))
+       |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found."))
        |> push_navigate(to: Paths.index())}
     else
       {:ok,
@@ -64,8 +64,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
        |> assign(
          page_title:
            if(action == :new,
-             do: Gettext.gettext(PhoenixKitWeb.Gettext, "New Catalogue"),
-             else: Gettext.gettext(PhoenixKitWeb.Gettext, "Edit %{name}", name: catalogue.name)
+             do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Catalogue"),
+             else:
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit %{name}", name: catalogue.name)
            ),
          action: action,
          catalogue: catalogue,
@@ -197,7 +198,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
          |> put_flash(
            :info,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Catalogue and all its contents permanently deleted."
            )
          )
@@ -209,7 +210,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
          |> assign(:confirm_delete, false)
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete catalogue.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete catalogue.")
          )}
     end
   end
@@ -249,7 +250,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
 
         {:noreply,
          socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue created."))
+         |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue created."))
          |> push_navigate(to: Paths.catalogue_detail(catalogue.uuid))}
 
       {:error, changeset} ->
@@ -262,7 +263,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       {:ok, catalogue} ->
         {:noreply,
          socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue updated."))
+         |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue updated."))
          |> push_navigate(to: Paths.catalogue_detail(catalogue.uuid))}
 
       {:error, changeset} ->
@@ -296,7 +297,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       />
 
       <%!-- Header --%>
-      <.admin_page_header back={Paths.index()} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update catalogue details and settings.")} />
+      <.admin_page_header back={Paths.index()} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update catalogue details and settings.")} />
 
       <%!-- Tab strip — each panel stays in the DOM (toggled by `hidden`)
            so the multilang wrapper + any user input don't lose state
@@ -309,7 +310,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
           class={"tab #{if @current_tab == :details, do: "tab-active"}"}
         >
           <.icon name="hero-document-text" class="w-4 h-4 mr-1" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Details")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Details")}
         </button>
         <button
           type="button"
@@ -318,7 +319,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
           class={"tab #{if @current_tab == :metadata, do: "tab-active"}"}
         >
           <.icon name="hero-tag" class="w-4 h-4 mr-1" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Metadata")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Metadata")}
           <span :if={@meta_state.attached != []} class="badge badge-sm badge-ghost ml-2">
             {length(@meta_state.attached)}
           </span>
@@ -330,7 +331,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
           class={"tab #{if @current_tab == :files, do: "tab-active"}"}
         >
           <.icon name="hero-paper-clip" class="w-4 h-4 mr-1" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Files")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Files")}
           <span :if={@files_state.files != []} class="badge badge-sm badge-ghost ml-2">
             {length(@files_state.files)}
           </span>
@@ -378,8 +379,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                 current_lang={@current_lang}
                 primary_language={@primary_language}
                 lang_data={@lang_data}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Kitchen Furniture")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Kitchen Furniture")}
                 required
                 class="w-full"
               />
@@ -393,9 +394,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                 current_lang={@current_lang}
                 primary_language={@primary_language}
                 lang_data={@lang_data}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")}
                 type="textarea"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Brief description of what this catalogue contains...")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Brief description of what this catalogue contains...")}
                 class="w-full"
               />
             </div>
@@ -407,18 +408,18 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
             <div class="form-control">
               <.select
                 field={@form[:kind]}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Kind")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Kind")}
                 class="transition-colors focus-within:select-primary"
                 options={[
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Standard — items priced directly"), "standard"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Smart — items reference other catalogues"), "smart"}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Standard — items priced directly"), "standard"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Smart — items reference other catalogues"), "smart"}
                 ]}
               />
               <span class="label-text-alt text-base-content/50 mt-1">
                 <%= if Ecto.Changeset.get_field(@changeset, :kind) == "smart" do %>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Smart catalogues hold items like \"Delivery\" whose cost is a per-catalogue %/flat rule picked from other catalogues. Items here reference other catalogues instead of carrying a base price of their own.")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Smart catalogues hold items like \"Delivery\" whose cost is a per-catalogue %/flat rule picked from other catalogues. Items here reference other catalogues instead of carrying a base price of their own.")}
                 <% else %>
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Standard catalogues hold items priced directly — each item has its own base price, markup, and discount. This is the normal flow for materials, products, or anything with a fixed price tag.")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Standard catalogues hold items priced directly — each item has its own base price, markup, and discount. This is the normal flow for materials, products, or anything with a fixed price tag.")}
                 <% end %>
               </span>
             </div>
@@ -427,13 +428,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
               <.input
                 field={@form[:markup_percentage]}
                 type="number"
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Percentage")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Markup Percentage")}
                 step="0.01"
                 min="0"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 15.0")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., 15.0")}
               />
               <span class="label-text-alt text-base-content/50 mt-1">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Applied to all item base prices to calculate sale prices. Leave blank for no markup.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Applied to all item base prices to calculate sale prices. Leave blank for no markup.")}
               </span>
             </div>
 
@@ -441,29 +442,29 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
               <.input
                 field={@form[:discount_percentage]}
                 type="number"
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Discount Percentage")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Discount Percentage")}
                 step="0.01"
                 min="0"
                 max="100"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 10.0")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., 10.0")}
               />
               <span class="label-text-alt text-base-content/50 mt-1">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Applied on top of the sale price to compute the final price. 0..100. Individual items can override this.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Applied on top of the sale price to compute the final price. 0..100. Individual items can override this.")}
               </span>
             </div>
 
             <div class="form-control">
               <.select
                 field={@form[:status]}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
                 class="transition-colors focus-within:select-primary"
                 options={[
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived"), "archived"}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Archived"), "archived"}
                 ]}
               />
               <span class="label-text-alt text-base-content/50 mt-1">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Archived catalogues are hidden from active views.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Archived catalogues are hidden from active views.")}
               </span>
             </div>
           </div>
@@ -478,7 +479,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
             resource_type={:catalogue}
             state={@meta_state}
             id_prefix="catalogue"
-            description={Gettext.gettext(PhoenixKitWeb.Gettext, "Attach any metadata fields that apply to this catalogue. Blank values are dropped on save.")}
+            description={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Attach any metadata fields that apply to this catalogue. Blank values are dropped on save.")}
           />
         </div>
 
@@ -487,7 +488,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
           <.featured_image_card
             featured_image_uuid={@featured_image_uuid}
             featured_image_file={@featured_image_file}
-            subtitle={Gettext.gettext(PhoenixKitWeb.Gettext, "Shown on catalogue listings and detail views.")}
+            subtitle={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Shown on catalogue listings and detail views.")}
           />
 
           <div class="card bg-base-100 shadow-lg">
@@ -495,13 +496,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
               <div class="flex flex-col gap-0.5">
                 <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
                   <.icon name="hero-paper-clip" class="w-4 h-4" />
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Attached Files")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Attached Files")}
                   <span :if={@files_state.files != []} class="badge badge-sm badge-ghost ml-1">
                     {length(@files_state.files)}
                   </span>
                 </h2>
                 <p class="text-xs text-base-content/50">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Brochures, spec sheets, datasheets. Any file type is accepted.")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Brochures, spec sheets, datasheets. Any file type is accepted.")}
                 </p>
               </div>
 
@@ -512,8 +513,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
               >
                 <.icon name="hero-cloud-arrow-up" class="w-8 h-8 text-base-content/40" />
                 <div class="text-sm text-base-content/60">
-                  <span class="font-medium text-primary">{Gettext.gettext(PhoenixKitWeb.Gettext, "Click to upload")}</span>
-                  <span>{Gettext.gettext(PhoenixKitWeb.Gettext, " or drag & drop")}</span>
+                  <span class="font-medium text-primary">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Click to upload")}</span>
+                  <span>{Gettext.gettext(PhoenixKitCatalogue.Gettext, " or drag & drop")}</span>
                 </div>
                 <.live_file_input upload={@uploads.attachment_files} class="hidden" />
               </label>
@@ -539,7 +540,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                     phx-click="cancel_upload"
                     phx-value-ref={entry.ref}
                     class="btn btn-ghost btn-xs btn-square"
-                    title={Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}
                   >
                     <.icon name="hero-x-mark" class="w-4 h-4" />
                   </button>
@@ -557,7 +558,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                 <div class="flex flex-col items-center gap-2 py-10 text-center border border-dashed border-base-300 rounded-md">
                   <.icon name="hero-paper-clip" class="w-8 h-8 text-base-content/30" />
                   <p class="text-sm text-base-content/50">
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "No files attached yet.")}
+                    {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No files attached yet.")}
                   </p>
                 </div>
               <% else %>
@@ -585,7 +586,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                         target="_blank"
                         rel="noopener"
                         class="shrink-0 flex items-center justify-center w-14 h-14 rounded bg-base-200 border border-base-300 text-base-content/60"
-                        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Download")}
+                        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Download")}
                       >
                         <.icon name={Attachments.file_icon(file)} class="w-6 h-6" />
                       </a>
@@ -602,10 +603,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
                       type="button"
                       phx-click="remove_file"
                       phx-value-uuid={file.uuid}
-                      phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Removing...")}
-                      data-confirm={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove this file from the catalogue? If it's not attached to any other resource, it will be moved to trash (admins can restore).")}
+                      phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Removing...")}
+                      data-confirm={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Remove this file from the catalogue? If it's not attached to any other resource, it will be moved to trash (admins can restore).")}
                       class="btn btn-ghost btn-xs btn-square"
-                      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove from catalogue")}
+                      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Remove from catalogue")}
                     >
                       <.icon name="hero-x-mark" class="w-4 h-4" />
                     </button>
@@ -622,23 +623,23 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
              the save path. --%>
         <div class="flex justify-end gap-3 pt-2">
           <.link navigate={Paths.index()} class="btn btn-ghost">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}
           </.link>
           <button
             type="submit"
             class="btn btn-primary phx-submit-loading:opacity-75"
             disabled={@uploads.attachment_files.entries != []}
-            phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+            phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Saving...")}
           >
             {cond do
               @uploads.attachment_files.entries != [] ->
-                Gettext.gettext(PhoenixKitWeb.Gettext, "Waiting for uploads...")
+                Gettext.gettext(PhoenixKitCatalogue.Gettext, "Waiting for uploads...")
 
               @action == :new ->
-                Gettext.gettext(PhoenixKitWeb.Gettext, "Create Catalogue")
+                Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create Catalogue")
 
               true ->
-                Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")
+                Gettext.gettext(PhoenixKitCatalogue.Gettext, "Save Changes")
             end}
           </button>
         </div>
@@ -649,21 +650,21 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       <details :if={@action == :edit} class="card bg-base-100 border-2 border-error/30">
         <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
           <.icon name="hero-exclamation-triangle" class="w-4 h-4 text-error" />
-          <h3 class="font-semibold text-error text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Danger Zone")}</h3>
+          <h3 class="font-semibold text-error text-base">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Danger Zone")}</h3>
           <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
         </summary>
 
         <div class="card-body pt-0 space-y-4">
           <div class="flex items-center justify-between gap-4">
             <div>
-              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Catalogue")}</p>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently Delete Catalogue")}</p>
               <p class="text-xs text-base-content/60">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "This will permanently delete this catalogue, all its categories, and all items within them. This cannot be undone.")}
               </p>
             </div>
             <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
               <.icon name="hero-trash" class="w-4 h-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
             </button>
           </div>
         </div>
@@ -673,10 +674,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
         show={@confirm_delete}
         on_confirm="delete_catalogue"
         on_cancel="cancel_delete"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Catalogue")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently Delete Catalogue")}
         title_icon="hero-trash"
-        messages={[{:warning, Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this catalogue, all its categories, and all items within them.")}]}
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+        messages={[{:warning, Gettext.gettext(PhoenixKitCatalogue.Gettext, "This will permanently delete this catalogue, all its categories, and all items within them.")}]}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
     </div>

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -34,7 +34,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
     {:ok,
      assign(socket,
-       page_title: Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue"),
+       page_title: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue"),
        catalogues: [],
        item_counts: %{},
        manufacturers: [],
@@ -91,9 +91,12 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     {:noreply, socket}
   end
 
-  defp tab_title(:index), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogues")
-  defp tab_title(:manufacturers), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturers")
-  defp tab_title(:suppliers), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Suppliers")
+  defp tab_title(:index), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogues")
+
+  defp tab_title(:manufacturers),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturers")
+
+  defp tab_title(:suppliers), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Suppliers")
 
   # Graceful handler for a delete event that fires while `confirm_delete`
   # is nil (e.g. someone pushed the event without first opening the
@@ -109,7 +112,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
      |> assign(:confirm_delete, nil)
      |> put_flash(
        :error,
-       Gettext.gettext(PhoenixKitWeb.Gettext, "Unexpected request. Please try again.")
+       Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unexpected request. Please try again.")
      )}
   end
 
@@ -183,7 +186,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to save the new order.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to save the new order.")
          )}
     end
   end
@@ -193,14 +196,20 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          {:ok, _} <- Catalogue.trash_catalogue(catalogue, actor_opts(socket)) do
       {:noreply,
        socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue moved to deleted."))
+       |> put_flash(
+         :info,
+         Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue moved to deleted.")
+       )
        |> assign(:confirm_delete, nil)
        |> load_data(:index)}
     else
       nil ->
         {:noreply,
          socket
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found."))
+         |> put_flash(
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found.")
+         )
          |> load_data(:index)}
 
       {:error, reason} ->
@@ -214,7 +223,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          socket
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete catalogue.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete catalogue.")
          )
          |> load_data(:index)}
     end
@@ -225,14 +234,17 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          {:ok, _} <- Catalogue.restore_catalogue(catalogue, actor_opts(socket)) do
       {:noreply,
        socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue restored."))
+       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue restored."))
        |> assign(:confirm_delete, nil)
        |> load_data(:index)}
     else
       nil ->
         {:noreply,
          socket
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found."))
+         |> put_flash(
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found.")
+         )
          |> load_data(:index)}
 
       {:error, reason} ->
@@ -246,7 +258,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          socket
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to restore catalogue.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to restore catalogue.")
          )
          |> load_data(:index)}
     end
@@ -266,7 +278,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
            socket
            |> put_flash(
              :info,
-             Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue permanently deleted.")
+             Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue permanently deleted.")
            )
            |> assign(:confirm_delete, nil)
            |> load_data(:index)}
@@ -277,7 +289,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
              |> assign(:confirm_delete, nil)
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue not found.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found.")
              )
              |> load_data(:index)}
 
@@ -293,7 +305,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
              |> assign(:confirm_delete, nil)
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete catalogue.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete catalogue.")
              )
              |> load_data(:index)}
         end
@@ -325,7 +337,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
              socket
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete manufacturer.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete manufacturer.")
              )
              |> assign(:confirm_delete, nil)}
         end
@@ -356,7 +368,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
              socket
              |> put_flash(
                :error,
-               Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete supplier.")
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete supplier.")
              )
              |> assign(:confirm_delete, nil)}
         end
@@ -452,7 +464,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          |> assign(:search_loading, false)
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Search failed. Please try again.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search failed. Please try again.")
          )}
     end
   end
@@ -492,7 +504,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
          |> assign(:search_loading, false)
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Search failed. Please try again.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search failed. Please try again.")
          )}
     end
   end
@@ -537,37 +549,37 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             patch={Paths.index()}
             class={["tab", @active_tab == :index && "tab-active"]}
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogues")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogues")}
           </.link>
           <.link
             patch={Paths.manufacturers()}
             class={["tab", @active_tab == :manufacturers && "tab-active"]}
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturers")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturers")}
           </.link>
           <.link
             patch={Paths.suppliers()}
             class={["tab", @active_tab == :suppliers && "tab-active"]}
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Suppliers")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Suppliers")}
           </.link>
         </div>
 
         <div class="self-end sm:self-auto">
           <.link :if={@active_tab == :index && @catalogue_view_mode == "active"} navigate={Paths.catalogue_new()} class="btn btn-primary btn-sm">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "New Catalogue")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Catalogue")}
           </.link>
           <.link :if={@active_tab == :manufacturers} navigate={Paths.manufacturer_new()} class="btn btn-primary btn-sm">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "New Manufacturer")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Manufacturer")}
           </.link>
           <.link :if={@active_tab == :suppliers} navigate={Paths.supplier_new()} class="btn btn-primary btn-sm">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "New Supplier")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Supplier")}
           </.link>
         </div>
       </div>
 
       <%!-- Global search (only on catalogues tab) --%>
-      <.search_input :if={@active_tab == :index} query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items across all catalogues...")} />
+      <.search_input :if={@active_tab == :index} query={@search_query} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items across all catalogues...")} />
 
       <%!-- Search results (visible when the user has typed a query) --%>
       <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
@@ -575,7 +587,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         <div class="flex items-center gap-2">
           <%= if @search_loading and is_nil(@search_results) do %>
             <span class="text-sm text-base-content/60">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Searching for \"%{query}\"...", query: @search_query)}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Searching for \"%{query}\"...", query: @search_query)}
             </span>
           <% else %>
             <.search_results_summary :if={@search_results != nil} count={@search_total} query={@search_query} loaded={length(@search_results)} />
@@ -583,7 +595,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <span :if={@search_loading} class="loading loading-spinner loading-xs text-base-content/40"></span>
         </div>
 
-        <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitWeb.Gettext, "No items match your search.")} />
+        <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
 
         <%!-- Stale results are dimmed while a newer query is in flight to
              signal that the list is about to update. --%>
@@ -629,7 +641,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
               )
             ]}
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")}
           </button>
           <button
             type="button"
@@ -643,7 +655,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
               )
             ]}
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")} ({@deleted_catalogue_count})
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({@deleted_catalogue_count})
           </button>
         </div>
 
@@ -662,10 +674,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         show={match?({"catalogue", _}, @confirm_delete)}
         on_confirm="permanently_delete_catalogue"
         on_cancel="cancel_delete"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Catalogue")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently Delete Catalogue")}
         title_icon="hero-trash"
-        messages={[{:warning, Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this catalogue, all its categories, and all items. This cannot be undone.")}]}
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+        messages={[{:warning, Gettext.gettext(PhoenixKitCatalogue.Gettext, "This will permanently delete this catalogue, all its categories, and all items. This cannot be undone.")}]}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
 
@@ -673,10 +685,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         show={match?({"manufacturer", _}, @confirm_delete)}
         on_confirm="delete_manufacturer"
         on_cancel="cancel_delete"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Manufacturer")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Manufacturer")}
         title_icon="hero-trash"
-        messages={[{:warning, Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this manufacturer. Items referencing it will lose the association.")}]}
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+        messages={[{:warning, Gettext.gettext(PhoenixKitCatalogue.Gettext, "This will permanently delete this manufacturer. Items referencing it will lose the association.")}]}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
         danger={true}
       />
 
@@ -684,10 +696,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         show={match?({"supplier", _}, @confirm_delete)}
         on_confirm="delete_supplier"
         on_cancel="cancel_delete"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Supplier")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Supplier")}
         title_icon="hero-trash"
-        messages={[{:warning, Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this supplier. Manufacturer links will be removed.")}]}
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+        messages={[{:warning, Gettext.gettext(PhoenixKitCatalogue.Gettext, "This will permanently delete this supplier. Manufacturer links will be removed.")}]}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
         danger={true}
       />
     </div>
@@ -728,15 +740,15 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     fn c ->
       [
         %{
-          label: Gettext.gettext(PhoenixKitWeb.Gettext, "Items"),
+          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items"),
           value: Map.get(item_counts, c.uuid, 0)
         },
         %{
-          label: Gettext.gettext(PhoenixKitWeb.Gettext, "Status"),
+          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"),
           value: status_label(c.status)
         },
         %{
-          label: Gettext.gettext(PhoenixKitWeb.Gettext, "Updated"),
+          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated"),
           value: Calendar.strftime(c.updated_at, "%Y-%m-%d %H:%M")
         }
       ]
@@ -747,11 +759,11 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     fn c ->
       [
         %{
-          label: Gettext.gettext(PhoenixKitWeb.Gettext, "Status"),
+          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"),
           value: status_label(c.status)
         },
         %{
-          label: Gettext.gettext(PhoenixKitWeb.Gettext, "Updated"),
+          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated"),
           value: Calendar.strftime(c.updated_at, "%Y-%m-%d %H:%M")
         }
       ]
@@ -763,7 +775,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     <div :if={@catalogues == []} class="card bg-base-100 shadow">
       <div class="card-body items-center text-center py-12">
         <p class="text-base-content/60">
-          {if @view_mode == "deleted", do: Gettext.gettext(PhoenixKitWeb.Gettext, "No deleted catalogues."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "No catalogues yet.")}
+          {if @view_mode == "deleted", do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No deleted catalogues."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No catalogues yet.")}
         </p>
       </div>
     </div>
@@ -779,11 +791,11 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         <.table_default_header>
           <.table_default_row>
             <.table_default_header_cell :if={length(@catalogues) > 1} class="w-8"></.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}</.table_default_header_cell>
-            <.table_default_header_cell :if={@view_mode == "active"} class="text-right">{Gettext.gettext(PhoenixKitWeb.Gettext, "Items")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Updated")}</.table_default_header_cell>
-            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitWeb.Gettext, "Actions")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</.table_default_header_cell>
+            <.table_default_header_cell :if={@view_mode == "active"} class="text-right">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated")}</.table_default_header_cell>
+            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</.table_default_header_cell>
           </.table_default_row>
         </.table_default_header>
         <tbody
@@ -818,18 +830,18 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             <%!-- Active mode actions --%>
             <.table_default_cell :if={@view_mode == "active"} class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"cat-menu-#{catalogue.uuid}"}>
-                <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label={Gettext.gettext(PhoenixKitWeb.Gettext, "View")} />
-                <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} variant="secondary" />
+                <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")} />
+                <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} variant="secondary" />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
+                <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
             <%!-- Deleted mode actions --%>
             <.table_default_cell :if={@view_mode == "deleted"} class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"cat-del-menu-#{catalogue.uuid}"}>
-                <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")} variant="success" />
+                <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")} variant="error" />
+                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
           </.table_default_row>
@@ -839,13 +851,13 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <span :if={@view_mode == "deleted"} class="font-medium text-sm text-base-content/50">{catalogue.name}</span>
         </:card_header>
         <:card_actions :let={catalogue} :if={@view_mode == "active"}>
-          <.link navigate={Paths.catalogue_detail(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitWeb.Gettext, "View")}</.link>
-          <.link navigate={Paths.catalogue_edit(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}</.link>
-          <button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")} class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}</button>
+          <.link navigate={Paths.catalogue_detail(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")}</.link>
+          <.link navigate={Paths.catalogue_edit(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}</.link>
+          <button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}</button>
         </:card_actions>
         <:card_actions :let={catalogue} :if={@view_mode == "deleted"}>
-          <button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")} class="btn btn-ghost btn-xs text-success">{Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}</button>
-          <button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}</button>
+          <button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} class="btn btn-ghost btn-xs text-success">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}</button>
+          <button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}</button>
         </:card_actions>
       </.table_default>
     </div>
@@ -856,7 +868,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     ~H"""
     <div :if={@manufacturers == []} class="card bg-base-100 shadow">
       <div class="card-body items-center text-center py-12">
-        <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No manufacturers yet.")}</p>
+        <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No manufacturers yet.")}</p>
       </div>
     </div>
 
@@ -865,16 +877,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         variant="zebra" size="sm" toggleable={true}
         id="manufacturers-list" items={@manufacturers}
         card_fields={fn m -> [
-          %{label: Gettext.gettext(PhoenixKitWeb.Gettext, "Website"), value: m.website || "—"},
-          %{label: Gettext.gettext(PhoenixKitWeb.Gettext, "Status"), value: status_label(m.status)}
+          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website"), value: m.website || "—"},
+          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"), value: status_label(m.status)}
         ] end}
       >
         <.table_default_header>
           <.table_default_row>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</.table_default_header_cell>
-            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitWeb.Gettext, "Actions")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</.table_default_header_cell>
+            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</.table_default_header_cell>
           </.table_default_row>
         </.table_default_header>
         <.table_default_body>
@@ -888,9 +900,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             <.table_default_cell><.status_badge status={m.status} size={:sm} /></.table_default_cell>
             <.table_default_cell class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"mfg-menu-#{m.uuid}"}>
-                <.table_row_menu_link navigate={Paths.manufacturer_edit(m.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} />
+                <.table_row_menu_link navigate={Paths.manufacturer_edit(m.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
+                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
           </.table_default_row>
@@ -899,8 +911,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <.link navigate={Paths.manufacturer_edit(m.uuid)} class="font-medium text-sm link link-hover">{m.name}</.link>
         </:card_header>
         <:card_actions :let={m}>
-          <.link navigate={Paths.manufacturer_edit(m.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}</.link>
-          <button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}</button>
+          <.link navigate={Paths.manufacturer_edit(m.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}</.link>
+          <button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}</button>
         </:card_actions>
       </.table_default>
     </div>
@@ -911,7 +923,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     ~H"""
     <div :if={@suppliers == []} class="card bg-base-100 shadow">
       <div class="card-body items-center text-center py-12">
-        <p class="text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "No suppliers yet.")}</p>
+        <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No suppliers yet.")}</p>
       </div>
     </div>
 
@@ -920,16 +932,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         variant="zebra" size="sm" toggleable={true}
         id="suppliers-list" items={@suppliers}
         card_fields={fn s -> [
-          %{label: Gettext.gettext(PhoenixKitWeb.Gettext, "Website"), value: s.website || "—"},
-          %{label: Gettext.gettext(PhoenixKitWeb.Gettext, "Status"), value: status_label(s.status)}
+          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website"), value: s.website || "—"},
+          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"), value: status_label(s.status)}
         ] end}
       >
         <.table_default_header>
           <.table_default_row>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</.table_default_header_cell>
-            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitWeb.Gettext, "Actions")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website")}</.table_default_header_cell>
+            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</.table_default_header_cell>
+            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</.table_default_header_cell>
           </.table_default_row>
         </.table_default_header>
         <.table_default_body>
@@ -943,9 +955,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             <.table_default_cell><.status_badge status={s.status} size={:sm} /></.table_default_cell>
             <.table_default_cell class="text-right whitespace-nowrap">
               <.table_row_menu mode="auto" id={"supplier-menu-#{s.uuid}"}>
-                <.table_row_menu_link navigate={Paths.supplier_edit(s.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")} variant="secondary" />
+                <.table_row_menu_link navigate={Paths.supplier_edit(s.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} variant="secondary" />
                 <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" icon="hero-trash" label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")} variant="error" />
+                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
               </.table_row_menu>
             </.table_default_cell>
           </.table_default_row>
@@ -954,8 +966,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <.link navigate={Paths.supplier_edit(s.uuid)} class="font-medium text-sm link link-hover">{s.name}</.link>
         </:card_header>
         <:card_actions :let={s}>
-          <.link navigate={Paths.supplier_edit(s.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}</.link>
-          <button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}</button>
+          <.link navigate={Paths.supplier_edit(s.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}</.link>
+          <button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}</button>
         </:card_actions>
       </.table_default>
     </div>

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -54,7 +54,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
     if is_nil(category) and action == :edit do
       {:ok,
        socket
-       |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Category not found."))
+       |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category not found."))
        |> push_navigate(to: Paths.index())}
     else
       mount_category_form(socket, action, category, changeset, catalogue_uuid)
@@ -77,8 +77,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
      |> assign(
        page_title:
          if(action == :new,
-           do: Gettext.gettext(PhoenixKitWeb.Gettext, "New Category"),
-           else: Gettext.gettext(PhoenixKitWeb.Gettext, "Edit %{name}", name: category.name)
+           do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Category"),
+           else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit %{name}", name: category.name)
          ),
        action: action,
        category: category,
@@ -187,7 +187,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
          |> put_flash(
            :info,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Category and all its items permanently deleted."
            )
          )
@@ -199,7 +199,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
          |> assign(:confirm_delete_all, false)
          |> put_flash(
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to delete category.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete category.")
          )}
     end
   end
@@ -223,7 +223,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
            socket
            |> put_flash(
              :info,
-             Gettext.gettext(PhoenixKitWeb.Gettext, "Category moved to another catalogue.")
+             Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category moved to another catalogue.")
            )
            |> push_navigate(to: Paths.catalogue_detail(target))}
 
@@ -232,7 +232,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
            put_flash(
              socket,
              :error,
-             Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move category.")
+             Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move category.")
            )}
       end
     else
@@ -256,7 +256,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
          |> assign(:parent_options, parent_options_for(:edit, updated, updated.catalogue_uuid))
          |> put_flash(
            :info,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Category moved.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category moved.")
          )}
 
       {:error, :would_create_cycle} ->
@@ -265,7 +265,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
            socket,
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Cannot move a category under itself or one of its descendants."
            )
          )}
@@ -276,7 +276,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
            socket,
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Parent must live in the same catalogue."
            )
          )}
@@ -286,7 +286,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move category.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move category.")
          )}
     end
   end
@@ -325,7 +325,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
 
         {:noreply,
          socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Category created."))
+         |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category created."))
          |> push_navigate(to: Paths.catalogue_detail(socket.assigns.catalogue_uuid))}
 
       {:error, changeset} ->
@@ -338,7 +338,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       {:ok, _} ->
         {:noreply,
          socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Category updated."))
+         |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category updated."))
          |> push_navigate(to: Paths.catalogue_detail(socket.assigns.catalogue_uuid))}
 
       {:error, changeset} ->
@@ -371,7 +371,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       />
 
       <%!-- Header --%>
-      <.admin_page_header back={Paths.catalogue_detail(@catalogue_uuid)} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Add a new category to organize items within this catalogue."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update category details and ordering.")} />
+      <.admin_page_header back={Paths.catalogue_detail(@catalogue_uuid)} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new category to organize items within this catalogue."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update category details and ordering.")} />
 
       <%!-- Featured image — opens the scoped picker. Uuid stored on
            `category.data["featured_image_uuid"]`. The folder is lazily
@@ -380,7 +380,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       <.featured_image_card
         featured_image_uuid={@featured_image_uuid}
         featured_image_file={@featured_image_file}
-        subtitle={Gettext.gettext(PhoenixKitWeb.Gettext, "Shown on catalogue listings and category landing pages.")}
+        subtitle={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Shown on catalogue listings and category landing pages.")}
       />
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
@@ -408,7 +408,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
                 field_name="name" form_prefix="category" changeset={@changeset}
                 schema_field={:name} multilang_enabled={@multilang_enabled}
                 current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Cabinet Frames")}
+                lang_data={@lang_data} label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Cabinet Frames")}
                 required class="w-full"
               />
 
@@ -416,8 +416,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
                 field_name="description" form_prefix="category" changeset={@changeset}
                 schema_field={:description} multilang_enabled={@multilang_enabled}
                 current_lang={@current_lang} primary_language={@primary_language}
-                lang_data={@lang_data} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")} type="textarea"
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "What kinds of items belong in this category...")}
+                lang_data={@lang_data} label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")} type="textarea"
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "What kinds of items belong in this category...")}
                 class="w-full"
               />
             </div>
@@ -429,35 +429,35 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
             <div :if={@action == :new} class="form-control">
               <.select
                 field={@form[:parent_uuid]}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Parent category")}
-                prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Top level (no parent) —")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Parent category")}
+                prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "— Top level (no parent) —")}
                 options={@parent_options}
                 class="transition-colors focus-within:select-primary"
               />
-              <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Pick a parent to nest this category inside, or leave blank to keep it at the top level. You can move it later.")}</span>
+              <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Pick a parent to nest this category inside, or leave blank to keep it at the top level. You can move it later.")}</span>
             </div>
 
             <div class="form-control">
               <.input
                 field={@form[:position]}
                 type="number"
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Position")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Position")}
                 class="w-28"
                 min="0"
               />
-              <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Lower numbers appear first. You can also reorder from the catalogue detail page.")}</span>
+              <span class="label-text-alt text-base-content/50 mt-1">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Lower numbers appear first. You can also reorder from the catalogue detail page.")}</span>
             </div>
 
             <%!-- Actions --%>
             <div class="divider my-0"></div>
 
             <div class="flex justify-end gap-3">
-              <.link navigate={Paths.catalogue_detail(@catalogue_uuid)} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
+              <.link navigate={Paths.catalogue_detail(@catalogue_uuid)} class="btn btn-ghost">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}</.link>
               <button
                 type="submit"
                 class="btn btn-primary phx-submit-loading:opacity-75"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
-              >{if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Category"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}</button>
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Saving...")}
+              >{if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create Category"), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Save Changes")}</button>
             </div>
           </div>
         </div>
@@ -469,7 +469,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       <details :if={@action == :edit} class="card bg-base-100 shadow-lg">
         <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
           <.icon name="hero-arrows-right-left" class="w-4 h-4 text-base-content/60" />
-          <h3 class="font-semibold text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}</h3>
+          <h3 class="font-semibold text-base">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}</h3>
           <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
         </summary>
 
@@ -477,8 +477,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
           <%!-- Move to a different parent — within the same catalogue --%>
           <div class="flex flex-col gap-3">
             <div>
-              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Parent")}</p>
-              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Reparent this category within its catalogue. Its subtree comes along.")}</p>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to Another Parent")}</p>
+              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Reparent this category within its catalogue. Its subtree comes along.")}</p>
             </div>
             <div class="flex items-end gap-3">
               <div class="form-control flex-1">
@@ -486,7 +486,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
                   name="parent_uuid"
                   id="category-parent-move-target"
                   value={@parent_move_target}
-                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Top level (no parent) —")}
+                  prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "— Top level (no parent) —")}
                   options={@parent_options}
                   class="select-sm transition-colors focus-within:select-primary"
                   phx-change="select_parent_move_target"
@@ -495,11 +495,11 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
               <button
                 type="button"
                 phx-click="move_under_parent"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Moving...")}
                 disabled={@parent_move_target == @category.parent_uuid}
                 class="btn btn-sm btn-outline"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
               </button>
             </div>
           </div>
@@ -507,8 +507,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
           <%!-- Move to another catalogue — only when other catalogues exist --%>
           <div :if={@other_catalogues != []} class="flex flex-col gap-3">
             <div>
-              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Catalogue")}</p>
-              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move this category and all its items to a different catalogue.")}</p>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to Another Catalogue")}</p>
+              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move this category and all its items to a different catalogue.")}</p>
             </div>
             <div class="flex items-end gap-3">
               <div class="form-control flex-1">
@@ -516,7 +516,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
                   name="catalogue_uuid"
                   id="category-move-target"
                   value={@move_target}
-                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
+                  prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "-- Select catalogue --")}
                   options={Enum.map(@other_catalogues, &{&1.name, &1.uuid})}
                   class="select-sm transition-colors focus-within:select-primary"
                   phx-change="select_move_target"
@@ -525,11 +525,11 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
               <button
                 type="button"
                 phx-click="move_category"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Moving...")}
                 disabled={is_nil(@move_target)}
                 class="btn btn-sm btn-outline"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
               </button>
             </div>
           </div>
@@ -542,19 +542,19 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       <details :if={@action == :edit} class="card bg-base-100 border-2 border-error/30">
         <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
           <.icon name="hero-exclamation-triangle" class="w-4 h-4 text-error" />
-          <h3 class="font-semibold text-error text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Danger Zone")}</h3>
+          <h3 class="font-semibold text-error text-base">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Danger Zone")}</h3>
           <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
         </summary>
 
         <div class="card-body pt-0 space-y-4">
           <div class="flex items-center justify-between gap-4">
             <div>
-              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Category")}</p>
-              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this category and all its items. This cannot be undone.")}</p>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently Delete Category")}</p>
+              <p class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "This will permanently delete this category and all its items. This cannot be undone.")}</p>
             </div>
             <button phx-click="show_delete_confirm" class="btn btn-outline btn-error btn-sm shrink-0">
               <.icon name="hero-trash" class="w-4 h-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
             </button>
           </div>
         </div>
@@ -564,10 +564,10 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         show={@confirm_delete_all}
         on_confirm="delete_category"
         on_cancel="cancel_delete"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Permanently Delete Category")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently Delete Category")}
         title_icon="hero-trash"
-        messages={[{:warning, Gettext.gettext(PhoenixKitWeb.Gettext, "This will permanently delete this category and all its items.")}]}
-        confirm_text={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+        messages={[{:warning, Gettext.gettext(PhoenixKitCatalogue.Gettext, "This will permanently delete this category and all its items.")}]}
+        confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
     </div>

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -52,7 +52,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
       />
 
       <%!-- Search bar --%>
-      <.search_input query={@search_query} placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Search items...")} />
+      <.search_input query={@search_query} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items...")} />
   """
 
   use Phoenix.Component
@@ -118,7 +118,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
     assigns =
       assign_new(assigns, :subtitle_text, fn ->
         assigns[:subtitle] ||
-          Gettext.gettext(PhoenixKitWeb.Gettext, "Shown on listings and detail views.")
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Shown on listings and detail views.")
       end)
 
     ~H"""
@@ -127,7 +127,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
         <div class="flex items-center justify-between">
           <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
             <.icon name="hero-photo" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Featured Image")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Featured Image")}
           </h2>
           <span class="text-xs text-base-content/50">{@subtitle_text}</span>
         </div>
@@ -139,7 +139,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
               target="_blank"
               rel="noopener"
               class="shrink-0"
-              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Open original")}
+              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Open original")}
             >
               <img
                 src={URLSigner.signed_url(@featured_image_uuid, "thumbnail")}
@@ -161,15 +161,15 @@ defmodule PhoenixKitCatalogue.Web.Components do
                 phx-click="open_featured_image_picker"
                 class="btn btn-sm btn-outline"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Change")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Change")}
               </button>
               <button
                 type="button"
                 phx-click="clear_featured_image"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Removing...")}
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Removing...")}
                 class="btn btn-sm btn-ghost"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Remove")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Remove")}
               </button>
             </div>
           </div>
@@ -178,7 +178,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
             <div class="flex items-center gap-3 text-base-content/60">
               <.icon name="hero-photo" class="w-6 h-6" />
               <span class="text-sm">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "No featured image set.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No featured image set.")}
               </span>
             </div>
             <button
@@ -187,7 +187,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
               class="btn btn-sm btn-primary"
             >
               <.icon name="hero-plus" class="w-4 h-4 mr-1" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Set featured image")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Set featured image")}
             </button>
           </div>
         <% end %>
@@ -242,12 +242,12 @@ defmodule PhoenixKitCatalogue.Web.Components do
     assigns =
       assigns
       |> assign_new(:title_text, fn ->
-        assigns[:title] || Gettext.gettext(PhoenixKitWeb.Gettext, "Metadata")
+        assigns[:title] || Gettext.gettext(PhoenixKitCatalogue.Gettext, "Metadata")
       end)
       |> assign_new(:description_text, fn ->
         assigns[:description] ||
           Gettext.gettext(
-            PhoenixKitWeb.Gettext,
+            PhoenixKitCatalogue.Gettext,
             "Attach any metadata fields that apply. Blank values are dropped on save."
           )
       end)
@@ -266,7 +266,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
         <.icon name="hero-information-circle" class="w-5 h-5 shrink-0" />
         <span class="text-sm">
           {Gettext.gettext(
-            PhoenixKitWeb.Gettext,
+            PhoenixKitCatalogue.Gettext,
             "No metadata attached yet. Pick a field below to add one."
           )}
         </span>
@@ -290,8 +290,8 @@ defmodule PhoenixKitCatalogue.Web.Components do
             id={"#{@id_prefix}-metadata-add-#{length(@state.attached)}"}
             name="key"
             value={nil}
-            label={Gettext.gettext(PhoenixKitWeb.Gettext, "Add metadata")}
-            prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "— Pick a field —")}
+            label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add metadata")}
+            prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "— Pick a field —")}
             options={metadata_add_options(@resource_type, @state)}
             class="select-sm transition-colors focus-within:select-primary"
             phx-change="add_meta_field"
@@ -340,9 +340,9 @@ defmodule PhoenixKitCatalogue.Web.Components do
       type="button"
       phx-click="remove_meta_field"
       phx-value-key={@def_.key}
-      phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Removing...")}
+      phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Removing...")}
       class="btn btn-ghost btn-sm btn-square text-error"
-      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove")}
+      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Remove")}
     >
       <.icon name="hero-x-mark" class="w-4 h-4" />
     </button>
@@ -357,7 +357,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
       <div class="mb-2 flex items-center gap-2 text-sm">
         <span class="font-mono">{@key}</span>
         <span class="badge badge-warning badge-sm">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Legacy")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Legacy")}
         </span>
       </div>
       <.input
@@ -373,9 +373,9 @@ defmodule PhoenixKitCatalogue.Web.Components do
       type="button"
       phx-click="remove_meta_field"
       phx-value-key={@key}
-      phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Removing...")}
+      phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Removing...")}
       class="btn btn-ghost btn-sm btn-square text-error"
-      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove")}
+      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Remove")}
     >
       <.icon name="hero-x-mark" class="w-4 h-4" />
     </button>
@@ -408,13 +408,16 @@ defmodule PhoenixKitCatalogue.Web.Components do
   # would pin English casing on a value the gettext extractor can't
   # see, so we leave it raw and rely on a future status enum addition
   # to surface the missing literal here.
-  defp status_label("active"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Active")
-  defp status_label("inactive"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")
-  defp status_label("archived"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Archived")
-  defp status_label("deleted"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")
-  defp status_label("discontinued"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued")
+  defp status_label("active"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")
+  defp status_label("inactive"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive")
+  defp status_label("archived"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Archived")
+  defp status_label("deleted"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")
+
+  defp status_label("discontinued"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Discontinued")
+
   defp status_label(other) when is_binary(other), do: other
-  defp status_label(_), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unknown")
+  defp status_label(_), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unknown")
 
   defp size_class(:xs), do: "badge-xs"
   defp size_class(:sm), do: "badge-sm"
@@ -454,7 +457,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
   def search_input(assigns) do
     placeholder =
       assigns.placeholder ||
-        Gettext.gettext(PhoenixKitWeb.Gettext, "Search...")
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search...")
 
     assigns = assign(assigns, :placeholder, placeholder)
 
@@ -507,7 +510,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
     <span class="text-sm text-base-content/60">
       <%= if is_integer(@loaded) and @loaded < @count do %>
         {Gettext.gettext(
-          PhoenixKitWeb.Gettext,
+          PhoenixKitCatalogue.Gettext,
           "Showing %{loaded} of %{count} results for \"%{query}\"",
           loaded: @loaded,
           count: @count,
@@ -515,7 +518,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
         )}
       <% else %>
         {Gettext.ngettext(
-          PhoenixKitWeb.Gettext,
+          PhoenixKitCatalogue.Gettext,
           "%{count} result for \"%{query}\"",
           "%{count} results for \"%{query}\"",
           @count, count: @count, query: @query)}
@@ -594,7 +597,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
           type="button"
           data-view-action="card"
           class="btn btn-sm join-item"
-          title={Gettext.gettext(PhoenixKitWeb.Gettext, "Card view")}
+          title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Card view")}
         >
           <.icon name="hero-squares-2x2" class="w-4 h-4" />
         </button>
@@ -602,7 +605,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
           type="button"
           data-view-action="table"
           class="btn btn-sm join-item"
-          title={Gettext.gettext(PhoenixKitWeb.Gettext, "Table view")}
+          title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Table view")}
         >
           <.icon name="hero-bars-3-bottom-left" class="w-4 h-4" />
         </button>
@@ -701,7 +704,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
       <summary class="collapse-title min-h-0 py-3 pr-10 text-sm font-medium cursor-pointer">
         <span class="inline-flex items-center gap-2">
           <.icon name="hero-funnel" class="w-4 h-4" />
-          <span>{Gettext.gettext(PhoenixKitWeb.Gettext, "Scope")}</span>
+          <span>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Scope")}</span>
           <span class="text-base-content/60 font-normal">
             {scope_summary_text(@has_catalogues, @has_categories, @cat_count, @cat_categories_count)}
           </span>
@@ -712,7 +715,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
           <section :if={@has_catalogues}>
             <div class="flex items-center justify-between mb-2">
               <span class="label-text font-medium">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogues")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogues")}
               </span>
               <button
                 :if={@cat_count > 0}
@@ -720,7 +723,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
                 phx-click={@on_clear_catalogues}
                 class="btn btn-ghost btn-xs"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
               </button>
             </div>
             <ul class="max-h-60 overflow-y-auto pr-1 space-y-1">
@@ -741,7 +744,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
           <section :if={@has_categories}>
             <div class="flex items-center justify-between mb-2">
               <span class="label-text font-medium">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Categories")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Categories")}
               </span>
               <button
                 :if={@cat_categories_count > 0}
@@ -749,7 +752,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
                 phx-click={@on_clear_categories}
                 class="btn btn-ghost btn-xs"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
               </button>
             </div>
             <ul class="max-h-60 overflow-y-auto pr-1 space-y-1">
@@ -787,11 +790,11 @@ defmodule PhoenixKitCatalogue.Web.Components do
     end
   end
 
-  defp catalogue_summary(0), do: Gettext.gettext(PhoenixKitWeb.Gettext, "all catalogues")
+  defp catalogue_summary(0), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "all catalogues")
 
   defp catalogue_summary(n) do
     Gettext.ngettext(
-      PhoenixKitWeb.Gettext,
+      PhoenixKitCatalogue.Gettext,
       "%{count} catalogue",
       "%{count} catalogues",
       n,
@@ -799,11 +802,11 @@ defmodule PhoenixKitCatalogue.Web.Components do
     )
   end
 
-  defp category_summary(0), do: Gettext.gettext(PhoenixKitWeb.Gettext, "all categories")
+  defp category_summary(0), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "all categories")
 
   defp category_summary(n) do
     Gettext.ngettext(
-      PhoenixKitWeb.Gettext,
+      PhoenixKitCatalogue.Gettext,
       "%{count} category",
       "%{count} categories",
       n,
@@ -892,7 +895,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
     ~H"""
     <div id={@id} class={["space-y-3", @class]}>
       <div :if={@catalogues == []} class="text-sm text-base-content/60 italic">
-        {Gettext.gettext(PhoenixKitWeb.Gettext, "No other catalogues available to reference yet.")}
+        {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No other catalogues available to reference yet.")}
       </div>
       <div :if={@catalogues != []}>
         <div class="flex items-center justify-between mb-2">
@@ -905,7 +908,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
             phx-click={@on_clear}
             class="btn btn-ghost btn-xs"
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear all")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear all")}
           </button>
         </div>
         <div
@@ -965,7 +968,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
       <div
         :if={@draggable}
         class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 select-none"
-        title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder")}
+        title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to reorder")}
       >
         <.icon name="hero-bars-3" class="w-4 h-4" />
       </div>
@@ -1011,14 +1014,14 @@ defmodule PhoenixKitCatalogue.Web.Components do
   defp rules_summary_text(0, total),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "%{total} catalogues available — none selected",
         total: total
       )
 
   defp rules_summary_text(active, total) do
     Gettext.ngettext(
-      PhoenixKitWeb.Gettext,
+      PhoenixKitCatalogue.Gettext,
       "%{active} of %{total} catalogue selected",
       "%{active} of %{total} catalogues selected",
       total,
@@ -1030,7 +1033,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
   defp default_placeholder(%{item_default_value: nil}), do: ""
 
   defp default_placeholder(%{item_default_value: value}) do
-    Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{value}",
+    Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inherit: %{value}",
       value: format_decimal_display(value)
     )
   rescue
@@ -1066,10 +1069,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
   # a no-op translation entry that every locale would translate to "%".
   # "Flat" is a real word and stays translatable.
   defp unit_label("percent"), do: "%"
-  defp unit_label("flat"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Flat")
+  defp unit_label("flat"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Flat")
   defp unit_label(u), do: to_string(u)
 
-  defp kind_label(%{kind: "smart"}), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Smart")
+  defp kind_label(%{kind: "smart"}), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Smart")
   defp kind_label(_), do: nil
 
   # ═══════════════════════════════════════════════════════════════════
@@ -1235,7 +1238,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
             {column_label(col)}
           </.table_default_header_cell>
           <.table_default_header_cell :if={@has_actions} class="text-right">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Actions")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}
           </.table_default_header_cell>
         </.table_default_row>
       </.table_default_header>
@@ -1278,7 +1281,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
               <span
                 :if={@on_reorder}
                 class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/40 opacity-0 group-hover:opacity-100 transition-opacity"
-                title={Gettext.gettext(PhoenixKitWeb.Gettext, "Drag to reorder")}
+                title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to reorder")}
               >
                 <.icon name="hero-bars-3" class="w-4 h-4" />
               </span>
@@ -1413,8 +1416,8 @@ defmodule PhoenixKitCatalogue.Web.Components do
       :if={@edit_path && @item.uuid}
       navigate={safe_call(@edit_path, @item.uuid)}
       class="btn btn-ghost btn-xs btn-square"
-      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
-      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
+      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+      aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
     >
       <.icon name="hero-pencil" class="w-4 h-4" />
     </.link>
@@ -1424,8 +1427,8 @@ defmodule PhoenixKitCatalogue.Web.Components do
       phx-click={@pdf_search_event}
       phx-value-uuid={@item.uuid}
       class="btn btn-ghost btn-xs btn-square"
-      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Search PDFs")}
-      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Search PDFs")}
+      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search PDFs")}
+      aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search PDFs")}
     >
       <.icon name="hero-document-magnifying-glass" class="w-4 h-4" />
     </button>
@@ -1433,10 +1436,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
       :if={@on_delete}
       phx-click={@on_delete}
       phx-value-uuid={@item.uuid}
-      phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
+      phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")}
       class="btn btn-ghost btn-xs btn-square text-error"
-      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
-      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+      aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
     >
       <.icon name="hero-trash" class="w-4 h-4" />
     </button>
@@ -1444,10 +1447,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
       :if={@on_restore}
       phx-click={@on_restore}
       phx-value-uuid={@item.uuid}
-      phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")}
+      phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
       class="btn btn-ghost btn-xs btn-square text-success"
-      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
-      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
+      aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
     >
       <.icon name="hero-arrow-path" class="w-4 h-4" />
     </button>
@@ -1456,10 +1459,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
       phx-click={@on_permanent_delete}
       phx-value-uuid={@item.uuid}
       phx-value-type={@permanent_delete_type}
-      phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
+      phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")}
       class="btn btn-ghost btn-xs btn-square text-error"
-      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
-      aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
+      aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
     >
       <.icon name="hero-trash" class="w-4 h-4" />
     </button>
@@ -1613,14 +1616,14 @@ defmodule PhoenixKitCatalogue.Web.Components do
           :if={@edit_path}
           navigate={safe_call(@edit_path, @item.uuid)}
           icon="hero-pencil"
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Edit")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
         />
         <.table_row_menu_button
           :if={@pdf_search_event}
           phx-click={@pdf_search_event}
           phx-value-uuid={@item.uuid}
           icon="hero-document-magnifying-glass"
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Search PDFs")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search PDFs")}
         />
         <.table_row_menu_divider :if={
           (@edit_path || @pdf_search_event) && (@on_delete || @on_restore)
@@ -1629,18 +1632,18 @@ defmodule PhoenixKitCatalogue.Web.Components do
           :if={@on_delete}
           phx-click={@on_delete}
           phx-value-uuid={@item.uuid}
-          phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
+          phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")}
           icon="hero-trash"
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
           variant="error"
         />
         <.table_row_menu_button
           :if={@on_restore}
           phx-click={@on_restore}
           phx-value-uuid={@item.uuid}
-          phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring...")}
+          phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
           icon="hero-arrow-path"
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
           variant="success"
         />
         <.table_row_menu_divider :if={@on_restore && @on_permanent_delete} />
@@ -1649,9 +1652,9 @@ defmodule PhoenixKitCatalogue.Web.Components do
           phx-click={@on_permanent_delete}
           phx-value-uuid={@item.uuid}
           phx-value-type={@permanent_delete_type}
-          phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting...")}
+          phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")}
           icon="hero-trash"
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Delete Forever")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
           variant="error"
         />
       </.table_row_menu>
@@ -1742,17 +1745,20 @@ defmodule PhoenixKitCatalogue.Web.Components do
       assigns[:pdf_search_event] != nil
   end
 
-  defp column_label(:name), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Name")
-  defp column_label(:sku), do: Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")
-  defp column_label(:base_price), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")
-  defp column_label(:price), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Price")
-  defp column_label(:discount), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Discount")
-  defp column_label(:final_price), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Final Price")
-  defp column_label(:unit), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")
-  defp column_label(:status), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Status")
-  defp column_label(:category), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Category")
-  defp column_label(:catalogue), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue")
-  defp column_label(:manufacturer), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")
+  defp column_label(:name), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")
+  defp column_label(:sku), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "SKU")
+  defp column_label(:base_price), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Base Price")
+  defp column_label(:price), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Price")
+  defp column_label(:discount), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Discount")
+  defp column_label(:final_price), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Final Price")
+  defp column_label(:unit), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unit")
+  defp column_label(:status), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")
+  defp column_label(:category), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category")
+  defp column_label(:catalogue), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue")
+
+  defp column_label(:manufacturer),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturer")
+
   # `column_label` is called with a programmatic atom; falling back to
   # the raw atom name avoids pinning English casing on a value the
   # gettext extractor can't see. Add a literal clause above this one
@@ -1768,12 +1774,12 @@ defmodule PhoenixKitCatalogue.Web.Components do
   end
 
   defp format_unit(nil), do: "—"
-  defp format_unit("piece"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "pc")
-  defp format_unit("set"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "set")
-  defp format_unit("pair"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "pair")
-  defp format_unit("sheet"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "sheet")
-  defp format_unit("m2"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "m²")
-  defp format_unit("running_meter"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "rm")
+  defp format_unit("piece"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "pc")
+  defp format_unit("set"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "set")
+  defp format_unit("pair"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "pair")
+  defp format_unit("sheet"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "sheet")
+  defp format_unit("m2"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "m²")
+  defp format_unit("running_meter"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "rm")
   defp format_unit(other), do: to_string(other)
 
   # Sale-price wrapper: coerces non-Decimal markup at the boundary so

--- a/lib/phoenix_kit_catalogue/web/components/item_picker.ex
+++ b/lib/phoenix_kit_catalogue/web/components/item_picker.ex
@@ -318,7 +318,7 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
       assigns
       |> assign(
         :placeholder_text,
-        assigns[:placeholder] || Gettext.gettext(PhoenixKitWeb.Gettext, "Search items…")
+        assigns[:placeholder] || Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items…")
       )
       |> assign(
         :price_fun,
@@ -359,7 +359,7 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
         phx-click="clear"
         phx-target={@myself}
         class="btn btn-xs btn-ghost absolute right-1 top-1/2 -translate-y-1/2"
-        aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+        aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
       >
         <.icon name="hero-x-mark" class="w-3 h-3" />
       </button>
@@ -411,7 +411,7 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
           aria-disabled="true"
           class="px-3 py-2 text-xs text-base-content/40 italic cursor-default select-none"
         >
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Type to refine search…")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Type to refine search…")}
         </li>
       </ul>
 
@@ -419,7 +419,7 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
         :if={@open and @options == [] and @query != ""}
         class="absolute z-50 mt-1 w-full bg-base-100 border border-base-300 rounded-box shadow-lg px-3 py-2 text-sm text-base-content/50"
       >
-        {Gettext.gettext(PhoenixKitWeb.Gettext, "No items found")}
+        {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items found")}
       </div>
 
       <script :type={Phoenix.LiveView.ColocatedHook} name=".ItemPicker">

--- a/lib/phoenix_kit_catalogue/web/components/pdf_search_modal.ex
+++ b/lib/phoenix_kit_catalogue/web/components/pdf_search_modal.ex
@@ -107,7 +107,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
         expanding: MapSet.new(),
         error:
           Gettext.gettext(
-            PhoenixKitWeb.Gettext,
+            PhoenixKitCatalogue.Gettext,
             "Search is temporarily unavailable. Please try again in a moment."
           ),
         last_item_uuid: item.uuid
@@ -166,7 +166,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
            |> assign(
              :error,
              Gettext.gettext(
-               PhoenixKitWeb.Gettext,
+               PhoenixKitCatalogue.Gettext,
                "Could not load more matches. Please try again."
              )
            )}
@@ -229,11 +229,11 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
             <div class="flex items-start justify-between gap-3">
               <div>
                 <h3 class="font-semibold text-lg">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "PDF search")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF search")}
                 </h3>
                 <p class="text-xs text-base-content/60 mt-1">
                   {Gettext.gettext(
-                    PhoenixKitWeb.Gettext,
+                    PhoenixKitCatalogue.Gettext,
                     "Searched for: %{name}",
                     name: @item.name
                   )}
@@ -244,7 +244,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
                 phx-click="close"
                 phx-target={@myself}
                 class="btn btn-sm btn-ghost btn-circle"
-                aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Close")}
+                aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Close")}
               >
                 ✕
               </button>
@@ -255,7 +255,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
                 <% @loading -> %>
                   <div class="flex items-center gap-2 text-sm text-base-content/60">
                     <span class="loading loading-spinner loading-sm"></span>
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Searching…")}
+                    {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Searching…")}
                   </div>
                 <% @error -> %>
                   <div class="alert alert-error">
@@ -267,7 +267,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
                     <.icon name="hero-magnifying-glass" class="w-10 h-10 mx-auto mb-2 opacity-50" />
                     <p class="text-sm">
                       {Gettext.gettext(
-                        PhoenixKitWeb.Gettext,
+                        PhoenixKitCatalogue.Gettext,
                         "No PDF mentions this item by name."
                       )}
                     </p>
@@ -303,7 +303,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
                               >
                                 <div class="text-xs text-base-content/60">
                                   {Gettext.gettext(
-                                    PhoenixKitWeb.Gettext,
+                                    PhoenixKitCatalogue.Gettext,
                                     "page %{n}",
                                     n: hit.page_number
                                   )}
@@ -327,11 +327,11 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
                               >
                                 <%= if MapSet.member?(@expanding, group.pdf.uuid) do %>
                                   <span class="loading loading-spinner loading-xs"></span>
-                                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Loading…")}
+                                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Loading…")}
                                 <% else %>
                                   <.icon name="hero-chevron-down" class="w-3 h-3" />
                                   {Gettext.gettext(
-                                    PhoenixKitWeb.Gettext,
+                                    PhoenixKitCatalogue.Gettext,
                                     "Show %{n} more",
                                     n: group.total_matches - length(group.hits)
                                   )}
@@ -348,7 +348,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
 
             <div class="modal-action">
               <button type="button" phx-click="close" phx-target={@myself} class="btn btn-sm">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Close")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Close")}
               </button>
             </div>
           </div>
@@ -357,7 +357,7 @@ defmodule PhoenixKitCatalogue.Web.Components.PdfSearchModal do
             phx-click="close"
             phx-target={@myself}
             class="modal-backdrop"
-            aria-label={Gettext.gettext(PhoenixKitWeb.Gettext, "Close modal")}
+            aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Close modal")}
           >
           </button>
         </div>

--- a/lib/phoenix_kit_catalogue/web/events_live.ex
+++ b/lib/phoenix_kit_catalogue/web/events_live.ex
@@ -23,7 +23,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
     {:ok,
      socket
      |> assign(
-       page_title: Gettext.gettext(PhoenixKitWeb.Gettext, "Events"),
+       page_title: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Events"),
        total: 0,
        page: 1,
        has_more: false,
@@ -162,20 +162,22 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   # `resource_types` is built from DB content and may surface unknown
   # types in the future — fall through to capitalize so they still
   # render readably.
-  defp humanize_resource_type("item"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Item")
-  defp humanize_resource_type("category"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Category")
+  defp humanize_resource_type("item"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item")
+
+  defp humanize_resource_type("category"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category")
 
   defp humanize_resource_type("catalogue"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue")
 
   defp humanize_resource_type("manufacturer"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturer")
 
   defp humanize_resource_type("supplier"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Supplier")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Supplier")
 
   defp humanize_resource_type("smart_rule"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Smart rule")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Smart rule")
 
   # Unknown resource types fall back to the raw key. Wrapping in
   # `String.capitalize/1` would pin English casing on a value the
@@ -233,16 +235,16 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
 
     cond do
       diff < 60 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "just now")
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "just now")
 
       diff < 3600 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "%{count}m ago", count: div(diff, 60))
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count}m ago", count: div(diff, 60))
 
       diff < 86_400 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "%{count}h ago", count: div(diff, 3600))
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count}h ago", count: div(diff, 3600))
 
       diff < 604_800 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "%{count}d ago", count: div(diff, 86_400))
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count}d ago", count: div(diff, 86_400))
 
       true ->
         Calendar.strftime(datetime, "%b %d, %Y")
@@ -257,7 +259,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
     <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-4">
       <div class="flex items-center justify-between">
         <div class="text-sm text-base-content/60">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} events", count: @total)}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} events", count: @total)}
         </div>
       </div>
 
@@ -268,9 +270,9 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
             <.select
               name="filter[action]"
               id="events-filter-action"
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Action")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Action")}
               value={@filter_action}
-              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "All Actions")}
+              prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All Actions")}
               options={Enum.map(@action_types, &{&1, &1})}
               class="select-sm"
             />
@@ -280,16 +282,16 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
             <.select
               name="filter[resource_type]"
               id="events-filter-resource"
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Resource")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Resource")}
               value={@filter_resource_type}
-              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "All Types")}
+              prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All Types")}
               options={Enum.map(@resource_types, &{humanize_resource_type(&1), &1})}
               class="select-sm"
             />
           </div>
 
           <button type="button" phx-click="clear_filters" class="btn btn-ghost btn-sm">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Clear")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
           </button>
         </.form>
       </div>
@@ -355,7 +357,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
             <.link
               navigate={Routes.path("/admin/activity/#{entry.uuid}")}
               class="btn btn-ghost btn-xs btn-square"
-              title={Gettext.gettext(PhoenixKitWeb.Gettext, "View details")}
+              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "View details")}
             >
               <.icon name="hero-arrow-top-right-on-square" class="w-3.5 h-3.5" />
             </.link>
@@ -367,7 +369,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
       <%= if @total == 0 and not @loading do %>
         <div class="text-center py-12 text-base-content/60">
           <.icon name="hero-bell-slash" class="w-12 h-12 mx-auto mb-2 opacity-50" />
-          <p>{Gettext.gettext(PhoenixKitWeb.Gettext, "No events recorded yet")}</p>
+          <p>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No events recorded yet")}</p>
         </div>
       <% end %>
 
@@ -382,7 +384,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
 
       <%= if not @has_more and @total > 0 do %>
         <div class="text-center text-xs text-base-content/40 py-2">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "All events loaded")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "All events loaded")}
         </div>
       <% end %>
     </div>

--- a/lib/phoenix_kit_catalogue/web/helpers.ex
+++ b/lib/phoenix_kit_catalogue/web/helpers.ex
@@ -67,13 +67,16 @@ defmodule PhoenixKitCatalogue.Web.Helpers do
   would pin English casing on a value the extractor can't see.
   """
   @spec status_label(String.t() | nil) :: String.t()
-  def status_label("active"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Active")
-  def status_label("inactive"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive")
-  def status_label("archived"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Archived")
-  def status_label("deleted"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Deleted")
-  def status_label("discontinued"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued")
+  def status_label("active"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")
+  def status_label("inactive"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive")
+  def status_label("archived"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Archived")
+  def status_label("deleted"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")
+
+  def status_label("discontinued"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Discontinued")
+
   def status_label(other) when is_binary(other), do: other
-  def status_label(_), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unknown")
+  def status_label(_), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unknown")
 
   @doc """
   Logs a failed LV mutation in two places at once:
@@ -263,14 +266,17 @@ defmodule PhoenixKitCatalogue.Web.Helpers do
 
   @doc "Translated label for an extraction status."
   @spec pdf_status_label(String.t()) :: String.t()
-  def pdf_status_label("pending"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Pending")
-  def pdf_status_label("extracting"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Extracting")
-  def pdf_status_label("extracted"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Extracted")
+  def pdf_status_label("pending"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Pending")
+
+  def pdf_status_label("extracting"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Extracting")
+
+  def pdf_status_label("extracted"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Extracted")
 
   def pdf_status_label("scanned_no_text"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Scanned (no text)")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Scanned (no text)")
 
-  def pdf_status_label("failed"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Failed")
+  def pdf_status_label("failed"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed")
   def pdf_status_label(other), do: other
 
   @doc "Human-readable byte size with B / KB / MB / GB suffixes."
@@ -299,21 +305,21 @@ defmodule PhoenixKitCatalogue.Web.Helpers do
 
     cond do
       diff < 60 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "just now")
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "just now")
 
       diff < 3600 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "%{n}m ago", n: div(diff, 60))
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{n}m ago", n: div(diff, 60))
 
       diff < 86_400 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "%{n}h ago", n: div(diff, 3600))
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{n}h ago", n: div(diff, 3600))
 
       diff < 604_800 ->
-        Gettext.gettext(PhoenixKitWeb.Gettext, "%{n}d ago", n: div(diff, 86_400))
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{n}d ago", n: div(diff, 86_400))
 
       true ->
         Calendar.strftime(
           datetime,
-          Gettext.gettext(PhoenixKitWeb.Gettext, "%b %d, %Y")
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "%b %d, %Y")
         )
     end
   end

--- a/lib/phoenix_kit_catalogue/web/import_live.ex
+++ b/lib/phoenix_kit_catalogue/web/import_live.ex
@@ -63,7 +63,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     {:ok,
      socket
      |> assign(
-       page_title: Gettext.gettext(PhoenixKitWeb.Gettext, "Import"),
+       page_title: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import"),
        step: :upload,
        catalogues: catalogues,
        catalogue_item_counts: catalogue_item_counts,
@@ -178,7 +178,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
        put_flash(
          socket,
          :error,
-         Gettext.gettext(PhoenixKitWeb.Gettext, "Please select a catalogue first.")
+         Gettext.gettext(PhoenixKitCatalogue.Gettext, "Please select a catalogue first.")
        )}
     else
       continue_or_parse(socket)
@@ -283,7 +283,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
            socket,
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "You must map at least one column to 'Item Name'. Scroll down to the column mapping section and pick the column that holds item names."
            )
          )}
@@ -298,7 +298,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
          |> put_flash(
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Please give the new category a name before continuing."
            )
          )}
@@ -313,7 +313,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
          |> put_flash(
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Please give the new manufacturer a name before continuing."
            )
          )}
@@ -328,7 +328,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
          |> put_flash(
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Please give the new supplier a name before continuing."
            )
          )}
@@ -535,7 +535,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
          put_flash(
            socket,
            :info,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Still uploading — please wait a moment.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Still uploading — please wait a moment.")
          )}
 
       socket.assigns.uploads.import_file.entries == [] ->
@@ -543,7 +543,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Please upload a file.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Please upload a file.")
          )}
 
       true ->
@@ -567,7 +567,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Please upload a file.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Please upload a file.")
          )}
     end
   end
@@ -920,7 +920,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
             {:error,
              Gettext.gettext(
-               PhoenixKitWeb.Gettext,
+               PhoenixKitCatalogue.Gettext,
                "Could not create the new category. Please check the form and try again."
              ), socket}
         end
@@ -1002,7 +1002,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
             {:error,
              Gettext.gettext(
-               PhoenixKitWeb.Gettext,
+               PhoenixKitCatalogue.Gettext,
                "Could not create the new manufacturer. Please check the form and try again."
              ), socket}
         end
@@ -1036,7 +1036,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
             {:error,
              Gettext.gettext(
-               PhoenixKitWeb.Gettext,
+               PhoenixKitCatalogue.Gettext,
                "Could not create the new supplier. Please check the form and try again."
              ), socket}
         end
@@ -1168,13 +1168,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-6">
       <%!-- Step indicator --%>
       <div class="flex items-center justify-center gap-2 text-sm">
-        <.step_badge step={:upload} current={@step} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Upload")} />
+        <.step_badge step={:upload} current={@step} label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Upload")} />
         <.icon name="hero-chevron-right" class="w-4 h-4 text-base-content/30" />
-        <.step_badge step={:map} current={@step} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Map")} />
+        <.step_badge step={:map} current={@step} label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Map")} />
         <.icon name="hero-chevron-right" class="w-4 h-4 text-base-content/30" />
-        <.step_badge step={:confirm} current={@step} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Confirm")} />
+        <.step_badge step={:confirm} current={@step} label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Confirm")} />
         <.icon name="hero-chevron-right" class="w-4 h-4 text-base-content/30" />
-        <.step_badge step={:importing} current={@step} label={Gettext.gettext(PhoenixKitWeb.Gettext, "Import")} />
+        <.step_badge step={:importing} current={@step} label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import")} />
       </div>
 
       <%!-- Step content --%>
@@ -1241,7 +1241,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           <%= if available == [] do %>
             <p class="text-xs text-warning bg-warning/10 border border-warning/30 rounded-lg px-3 py-2">
               {Gettext.gettext(
-                PhoenixKitWeb.Gettext,
+                PhoenixKitCatalogue.Gettext,
                 "All columns are already mapped. Free one up by setting it to '— Skip —' in the column mapping section below, or by switching another picker (Category, Manufacturer, or Supplier) out of 'Use a column' mode."
               )}
             </p>
@@ -1260,7 +1260,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
               name={@column_field}
               id={"#{@form_id}-column"}
               value={selected_col}
-              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
+              prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Select a column...")}
               options={Enum.map(available, &{&1.header, &1.column_index})}
               class="select-sm"
             />
@@ -1304,7 +1304,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       <div class="flex flex-col gap-4">
         <div class="form-control">
           <span class="label-text font-semibold mb-2">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Name")} *
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")} *
           </span>
           <input
             type="text"
@@ -1321,7 +1321,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
         <div class="form-control">
           <span class="label-text font-semibold mb-2">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")}
           </span>
           <textarea
             name={"#{@form_prefix}[description]"}
@@ -1332,7 +1332,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
         <div class="form-control">
           <span class="label-text font-semibold mb-2">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website")}
           </span>
           <input
             type="url"
@@ -1411,8 +1411,8 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           current_lang={@current_lang}
           primary_language={@primary_language}
           lang_data={@lang_data}
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}
-          placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Cabinet Frames")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}
+          placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Cabinet Frames")}
           required
           class="w-full"
         />
@@ -1426,10 +1426,10 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           current_lang={@current_lang}
           primary_language={@primary_language}
           lang_data={@lang_data}
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")}
           placeholder={
             Gettext.gettext(
-              PhoenixKitWeb.Gettext,
+              PhoenixKitCatalogue.Gettext,
               "What kinds of items belong in this category..."
             )
           }
@@ -1440,7 +1440,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
       <div class="form-control mt-6">
         <span class="label-text font-semibold mb-2">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Position")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Position")}
         </span>
         <input
           type="number"
@@ -1451,7 +1451,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         />
         <span class="label-text-alt text-base-content/50 mt-1">
           {Gettext.gettext(
-            PhoenixKitWeb.Gettext,
+            PhoenixKitCatalogue.Gettext,
             "Lower numbers appear first."
           )}
         </span>
@@ -1495,7 +1495,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       <div class="card-body gap-6">
         <h2 class="card-title">
           <.icon name="hero-arrow-up-tray" class="w-5 h-5" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Import Items")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import Items")}
         </h2>
 
         <%!-- Upload form (catalogue + file in one form) --%>
@@ -1503,13 +1503,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           <%!-- Catalogue selector --%>
           <div class="form-control w-full max-w-md">
             <span class="block mb-2 text-sm font-medium">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Target Catalogue")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Target Catalogue")}
             </span>
             <.select
               name="catalogue"
               id="upload-catalogue"
               value={@selected_catalogue && @selected_catalogue.uuid}
-              prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Select a catalogue...")}
+              prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Select a catalogue...")}
               options={
                 Enum.map(
                   @catalogues,
@@ -1518,9 +1518,9 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
               }
             />
             <p :if={@catalogues == []} class="text-sm text-base-content/50 mt-1">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "No catalogues yet.")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No catalogues yet.")}
               <.link navigate={Paths.catalogue_new()} class="link link-primary">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Create one first")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create one first")}
               </.link>
             </p>
           </div>
@@ -1530,23 +1530,23 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             <.icon name="hero-document-check" class="w-5 h-5 text-success" />
             <div class="flex-1">
               <p class="font-medium text-sm">{@filename}</p>
-              <p class="text-xs text-base-content/60">{@row_count} {Gettext.gettext(PhoenixKitWeb.Gettext, "rows")} — {length(@headers)} {Gettext.gettext(PhoenixKitWeb.Gettext, "columns")}</p>
+              <p class="text-xs text-base-content/60">{@row_count} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "rows")} — {length(@headers)} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "columns")}</p>
             </div>
             <button
               type="button"
               phx-click="clear_file"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Clearing...")}
+              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clearing...")}
               class="btn btn-xs btn-ghost text-base-content/50"
             >
               <.icon name="hero-x-mark" class="w-4 h-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Replace")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Replace")}
             </button>
           </div>
 
           <%!-- File upload with drag-and-drop (only when no file parsed yet) --%>
           <div :if={@filename == nil} class="form-control">
             <label class="block mb-2 text-sm font-medium">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "File")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "File")}
             </label>
             <div
               class="border-2 border-dashed border-base-300 rounded-lg p-8 text-center transition-colors cursor-pointer hover:border-primary hover:bg-primary/5"
@@ -1557,10 +1557,10 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                   <.icon name="hero-cloud-arrow-up" class="w-8 h-8 text-primary" />
                   <div>
                     <p class="font-semibold text-base-content">
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Drag file here or click to browse")}
+                      {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag file here or click to browse")}
                     </p>
                     <p class="text-sm text-base-content/70 mt-1">
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Supports .xlsx and .csv files (max 10MB)")}
+                      {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Supports .xlsx and .csv files (max 10MB)")}
                     </p>
                   </div>
                 </div>
@@ -1613,14 +1613,14 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           >
             <%= cond do %>
               <% @filename -> %>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Continue")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Continue")}
                 <.icon name="hero-arrow-right" class="w-4 h-4" />
               <% upload_in_progress? -> %>
                 <span class="loading loading-spinner loading-xs"></span>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Uploading...")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Uploading...")}
               <% true -> %>
                 <.icon name="hero-arrow-up-tray" class="w-4 h-4" />
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Upload & Parse")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Upload & Parse")}
             <% end %>
           </button>
         </form>
@@ -1649,7 +1649,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       <div class="card-body gap-6">
         <h2 class="card-title">
           <.icon name="hero-arrows-right-left" class="w-5 h-5" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Map Columns")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Map Columns")}
         </h2>
 
         <div class="flex flex-wrap items-center gap-3 text-sm text-base-content/60">
@@ -1657,13 +1657,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             <.icon name="hero-document-text" class="w-4 h-4 inline" />
             {@filename}
           </span>
-          <span class="badge badge-ghost badge-sm">{@row_count} {Gettext.gettext(PhoenixKitWeb.Gettext, "rows")}</span>
+          <span class="badge badge-ghost badge-sm">{@row_count} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "rows")}</span>
           <span :if={@selected_catalogue} class="badge badge-primary badge-sm badge-outline">{@selected_catalogue.name}</span>
         </div>
 
         <%!-- Sheet selector --%>
         <form :if={length(@sheets) > 1} id="sheet-form" phx-change="select_sheet" class="flex items-center gap-2">
-          <span class="text-sm font-medium">{Gettext.gettext(PhoenixKitWeb.Gettext, "Sheet:")}</span>
+          <span class="text-sm font-medium">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Sheet:")}</span>
           <.select
             name="sheet"
             id="import-sheet"
@@ -1677,14 +1677,14 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <div :if={@multilang_enabled}>
           <div class="flex items-center gap-2 mb-3">
             <.icon name="hero-language" class="w-5 h-5 text-primary" />
-            <h2 class="card-title text-lg m-0">{Gettext.gettext(PhoenixKitWeb.Gettext, "Import Language")}</h2>
+            <h2 class="card-title text-lg m-0">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import Language")}</h2>
           </div>
           <.multilang_tabs multilang_enabled={@multilang_enabled} language_tabs={@language_tabs} current_lang={@current_lang} show_info={false} show_header={false} />
         </div>
 
         <%!-- Category selector --%>
         <div class="form-control w-full max-w-md">
-          <span class="block mb-2 text-sm font-medium">{Gettext.gettext(PhoenixKitWeb.Gettext, "Import Into Category")}</span>
+          <span class="block mb-2 text-sm font-medium">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import Into Category")}</span>
           <form id="category-form" phx-change="select_import_category" class="space-y-3">
             <.select
               name="category_mode"
@@ -1697,9 +1697,9 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
               }
               options={
                 [
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No category — import items without a category"), "none"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — create categories from column values"), "column"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new category — fill in the details below"), "create"}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No category — import items without a category"), "none"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Use a column — create categories from column values"), "column"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new category — fill in the details below"), "create"}
                 ] ++
                   Enum.map(@catalogue_categories, &{&1.name, "existing:#{&1.uuid}"})
               }
@@ -1721,12 +1721,12 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                   checked={@category_match_across_languages}
                   class="checkbox checkbox-xs checkbox-primary"
                 />
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Match across all languages")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Match across all languages")}
                 <span
                   class="tooltip tooltip-right tooltip-info"
                   data-tip={
                     Gettext.gettext(
-                      PhoenixKitWeb.Gettext,
+                      PhoenixKitCatalogue.Gettext,
                       "By default the importer only matches existing categories by their name in the current import language. Turn this on to also match translations in any other language — useful for multilingual catalogues where the same category is named differently in each language."
                     )
                   }
@@ -1736,11 +1736,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
               </label>
 
               <% available_category_cols = available_picker_columns(@column_mappings, :category) %>
-              <span class="block mb-1 text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Which column contains the category names?")}</span>
+              <span class="block mb-1 text-xs text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Which column contains the category names?")}</span>
               <%= if available_category_cols == [] do %>
                 <p class="text-xs text-warning bg-warning/10 border border-warning/30 rounded-lg px-3 py-2">
                   {Gettext.gettext(
-                    PhoenixKitWeb.Gettext,
+                    PhoenixKitCatalogue.Gettext,
                     "All columns are already mapped. Free one up by setting it to '— Skip —' in the column mapping section below, or by switching another picker (Category, Manufacturer, or Supplier) out of 'Use a column' mode."
                   )}
                 </p>
@@ -1753,14 +1753,14 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
                   name="category_column"
                   id="import-category-column"
                   value={selected_category_col}
-                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Select a column...")}
+                  prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Select a column...")}
                   options={Enum.map(available_category_cols, &{&1.header, &1.column_index})}
                   class="select-sm"
                 />
               <% end %>
               <%!-- Show preview of categories that will be created --%>
               <div :if={has_mapping?(@column_mappings, :category)} class="mt-2">
-                <span class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitWeb.Gettext, "Categories that will be created:")}</span>
+                <span class="text-xs text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Categories that will be created:")}</span>
                 <div class="flex flex-wrap gap-1 mt-1">
                   <% cat_mapping = Enum.find(@column_mappings, &(&1.target == :category)) %>
                   <span :for={val <- unique_column_values_from_ets(@ets_table, cat_mapping.column_index)} class="badge badge-secondary badge-outline badge-xs">{val}</span>
@@ -1785,7 +1785,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
 
         <%!-- Manufacturer selector --%>
         <.party_picker
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Set Manufacturer")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Set Manufacturer")}
           form_id="manufacturer-form"
           on_change="select_import_manufacturer"
           mode_field="manufacturer_mode"
@@ -1796,11 +1796,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           column_mappings={@column_mappings}
           ets_table={@ets_table}
           target={:manufacturer}
-          none_label={Gettext.gettext(PhoenixKitWeb.Gettext, "No manufacturer — items imported without a maker")}
-          column_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — create or match manufacturers from column values")}
-          create_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new manufacturer — fill in the details below")}
-          column_picker_prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Which column contains the manufacturer names?")}
-          preview_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturers that will be created or matched:")}
+          none_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No manufacturer — items imported without a maker")}
+          column_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Use a column — create or match manufacturers from column values")}
+          create_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new manufacturer — fill in the details below")}
+          column_picker_prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Which column contains the manufacturer names?")}
+          preview_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturers that will be created or matched:")}
         />
 
         <.new_party_form
@@ -1809,12 +1809,12 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           form_prefix="manufacturer"
           on_change="validate_new_manufacturer"
           changeset={@new_manufacturer_changeset}
-          name_placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Blum")}
+          name_placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Blum")}
         />
 
         <%!-- Supplier selector --%>
         <.party_picker
-          label={Gettext.gettext(PhoenixKitWeb.Gettext, "Link to Supplier")}
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Link to Supplier")}
           form_id="supplier-form"
           on_change="select_import_supplier"
           mode_field="supplier_mode"
@@ -1825,11 +1825,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           column_mappings={@column_mappings}
           ets_table={@ets_table}
           target={:supplier}
-          none_label={Gettext.gettext(PhoenixKitWeb.Gettext, "No supplier — leave manufacturers unlinked")}
-          column_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Use a column — link per-row supplier to row's manufacturer")}
-          create_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Create a new supplier — link to all touched manufacturers")}
-          column_picker_prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "Which column contains the supplier names?")}
-          preview_label={Gettext.gettext(PhoenixKitWeb.Gettext, "Suppliers that will be created or matched:")}
+          none_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No supplier — leave manufacturers unlinked")}
+          column_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Use a column — link per-row supplier to row's manufacturer")}
+          create_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new supplier — link to all touched manufacturers")}
+          column_picker_prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Which column contains the supplier names?")}
+          preview_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Suppliers that will be created or matched:")}
         />
 
         <.new_party_form
@@ -1838,11 +1838,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           form_prefix="supplier"
           on_change="validate_new_supplier"
           changeset={@new_supplier_changeset}
-          name_placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Acme Distributors")}
+          name_placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Acme Distributors")}
         />
 
         <p class="text-sm text-base-content/60">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Choose where each column should be imported to.")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Choose where each column should be imported to.")}
         </p>
 
         <form id="mapping-form" phx-change="mapping_form_change" phx-submit="continue_to_confirm">
@@ -1868,7 +1868,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
               <%!-- Inline unit value mapping (shows when this column is mapped to Unit) --%>
               <div :if={mapping.target == :unit and @unit_values != []} class="mt-3 ml-6 pl-4 border-l-2 border-primary/20">
                 <p class="text-xs text-base-content/60 mb-2">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Map each value to a system unit:")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Map each value to a system unit:")}
                 </p>
                 <div class="grid gap-1.5">
                   <div :for={value <- @unit_values} class="flex items-center gap-2">
@@ -1898,7 +1898,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           <input type="checkbox" id="sample-data-collapse" />
           <div class="collapse-title text-sm font-medium">
             <.icon name="hero-table-cells" class="w-4 h-4 inline" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Sample Data (first 5 rows)")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Sample Data (first 5 rows)")}
           </div>
           <div class="collapse-content overflow-x-auto">
             <table class="table table-sm table-zebra [&_th]:border-r [&_th]:border-base-300 [&_td]:border-r [&_td]:border-base-300 [&_th:last-child]:border-r-0 [&_td:last-child]:border-r-0">
@@ -1921,14 +1921,14 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <div class="flex gap-2">
           <button class="btn btn-ghost btn-sm" phx-click="go_back">
             <.icon name="hero-arrow-left" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Back")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Back")}
           </button>
           <button
             class="btn btn-primary btn-sm"
             phx-click="continue_to_confirm"
-            phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Validating...")}
+            phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Validating...")}
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Continue to Confirm")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Continue to Confirm")}
             <.icon name="hero-arrow-right" class="w-4 h-4" />
           </button>
         </div>
@@ -1945,28 +1945,28 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       <div class="card-body gap-4">
         <h2 class="card-title">
           <.icon name="hero-clipboard-document-check" class="w-5 h-5" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Confirm Import")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Confirm Import")}
         </h2>
 
         <%!-- Stats --%>
         <div class="stats shadow">
           <div class="stat">
-            <div class="stat-title">{Gettext.gettext(PhoenixKitWeb.Gettext, "Items")}</div>
+            <div class="stat-title">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items")}</div>
             <div class="stat-value text-primary">{@import_plan.stats.valid}</div>
           </div>
           <div :if={@import_plan.categories_to_create != []} class="stat">
-            <div class="stat-title">{Gettext.gettext(PhoenixKitWeb.Gettext, "New Categories")}</div>
+            <div class="stat-title">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Categories")}</div>
             <div class="stat-value text-secondary">{length(@import_plan.categories_to_create)}</div>
           </div>
           <div :if={@import_plan.stats.invalid > 0} class="stat">
-            <div class="stat-title">{Gettext.gettext(PhoenixKitWeb.Gettext, "Errors")}</div>
+            <div class="stat-title">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Errors")}</div>
             <div class="stat-value text-error">{@import_plan.stats.invalid}</div>
           </div>
         </div>
 
         <%!-- Categories to create --%>
         <div :if={@import_plan.categories_to_create != []} class="text-sm">
-          <h3 class="font-semibold mb-1">{Gettext.gettext(PhoenixKitWeb.Gettext, "Categories to create:")}</h3>
+          <h3 class="font-semibold mb-1">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Categories to create:")}</h3>
           <div class="flex flex-wrap gap-1">
             <span :for={cat <- @import_plan.categories_to_create} class="badge badge-secondary badge-outline badge-sm">{cat}</span>
           </div>
@@ -1978,12 +1978,12 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             <thead>
               <tr>
                 <th class="bg-base-200">#</th>
-                <th :if={has_mapping?(@column_mappings, :name)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}</th>
-                <th :if={has_mapping?(@column_mappings, :sku)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Article Code")}</th>
-                <th :if={has_mapping?(@column_mappings, :base_price)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Price")}</th>
-                <th :if={has_mapping?(@column_mappings, :markup_percentage)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Markup %")}</th>
-                <th :if={has_mapping?(@column_mappings, :unit)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}</th>
-                <th :if={has_mapping?(@column_mappings, :category)} class="bg-base-200">{Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}</th>
+                <th :if={has_mapping?(@column_mappings, :name)} class="bg-base-200">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</th>
+                <th :if={has_mapping?(@column_mappings, :sku)} class="bg-base-200">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Article Code")}</th>
+                <th :if={has_mapping?(@column_mappings, :base_price)} class="bg-base-200">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Price")}</th>
+                <th :if={has_mapping?(@column_mappings, :markup_percentage)} class="bg-base-200">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Markup %")}</th>
+                <th :if={has_mapping?(@column_mappings, :unit)} class="bg-base-200">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unit")}</th>
+                <th :if={has_mapping?(@column_mappings, :category)} class="bg-base-200">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category")}</th>
               </tr>
             </thead>
             <tbody>
@@ -1999,7 +1999,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
             </tbody>
           </table>
           <p :if={length(@import_plan.items) > 20} class="text-sm text-base-content/50 mt-2">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Showing first 20 of %{count} items.", count: length(@import_plan.items))}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Showing first 20 of %{count} items.", count: length(@import_plan.items))}
           </p>
         </div>
 
@@ -2007,10 +2007,10 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <div :if={@import_plan.errors != []} class="alert alert-warning">
           <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
           <div>
-            <h3 class="font-bold">{Gettext.gettext(PhoenixKitWeb.Gettext, "Rows with errors (will be skipped):")}</h3>
+            <h3 class="font-bold">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Rows with errors (will be skipped):")}</h3>
             <div class="text-sm mt-1">
               <p :for={{row_idx, reason} <- Enum.take(@import_plan.errors, 10)}>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Row %{row}: %{reason}", row: row_idx, reason: translate_error(reason))}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Row %{row}: %{reason}", row: row_idx, reason: translate_error(reason))}
               </p>
             </div>
           </div>
@@ -2022,20 +2022,20 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           <div class="flex-1">
             <div class="text-sm font-medium space-y-1">
               <p :if={@duplicate_row_count > 0}>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} rows in your file are identical duplicates.", count: @duplicate_row_count)}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} rows in your file are identical duplicates.", count: @duplicate_row_count)}
               </p>
               <p :if={@existing_duplicate_count > 0}>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} items already exist in this catalogue with identical data.", count: @existing_duplicate_count)}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} items already exist in this catalogue with identical data.", count: @existing_duplicate_count)}
               </p>
             </div>
             <form id="duplicate-form" phx-change="set_duplicate_mode" class="mt-2 flex flex-col gap-1.5">
               <label class="flex items-center gap-2 cursor-pointer">
                 <input type="radio" name="mode" class="radio radio-sm radio-warning" value="import" checked={@duplicate_mode == :import} />
-                <span class="text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Import all — create everything including duplicates")}</span>
+                <span class="text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import all — create everything including duplicates")}</span>
               </label>
               <label class="flex items-center gap-2 cursor-pointer">
                 <input type="radio" name="mode" class="radio radio-sm radio-warning" value="skip" checked={@duplicate_mode == :skip} />
-                <span class="text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Skip duplicates — only import new, unique items")}</span>
+                <span class="text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Skip duplicates — only import new, unique items")}</span>
               </label>
             </form>
           </div>
@@ -2044,15 +2044,15 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <div class="flex gap-2">
           <button class="btn btn-ghost btn-sm" phx-click="back_to_mapping">
             <.icon name="hero-arrow-left" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Back to Mapping")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Back to Mapping")}
           </button>
           <button
             class="btn btn-primary btn-sm"
             phx-click="execute_import"
-            phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Starting import...")}
+            phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Starting import...")}
           >
             <.icon name="hero-play" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Import %{count} Items", count: @import_plan.stats.valid)}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import %{count} Items", count: @import_plan.stats.valid)}
           </button>
         </div>
       </div>
@@ -2075,11 +2075,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
       <div class="card-body items-center gap-4 py-12">
         <span class="loading loading-spinner loading-lg text-primary"></span>
         <h2 class="text-lg font-semibold">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Importing...")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Importing...")}
         </h2>
         <progress class="progress progress-primary w-full max-w-md" value={@pct} max="100"></progress>
         <p class="text-sm text-base-content/60">
-          {@import_progress} / {@import_total} {Gettext.gettext(PhoenixKitWeb.Gettext, "items")}
+          {@import_progress} / {@import_total} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}
         </p>
       </div>
     </div>
@@ -2096,16 +2096,16 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
           <.icon name="hero-check-circle" class="w-16 h-16" />
         </div>
         <h2 class="text-xl font-bold">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Import Complete")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import Complete")}
         </h2>
 
         <div :if={@import_result} class="stats shadow">
           <div class="stat">
-            <div class="stat-title">{Gettext.gettext(PhoenixKitWeb.Gettext, "Created")}</div>
+            <div class="stat-title">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Created")}</div>
             <div class="stat-value text-success">{@import_result.created}</div>
           </div>
           <div :if={@import_result.categories_created > 0} class="stat">
-            <div class="stat-title">{Gettext.gettext(PhoenixKitWeb.Gettext, "Categories")}</div>
+            <div class="stat-title">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Categories")}</div>
             <div class="stat-value text-secondary">{@import_result.categories_created}</div>
           </div>
         </div>
@@ -2113,7 +2113,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <div :if={@import_result && @import_result.errors != []} class="alert alert-error max-w-md">
           <div class="text-sm">
             <p :for={{row_idx, reason} <- Enum.take(@import_result.errors, 10)}>
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Row %{row}: %{reason}", row: row_idx, reason: translate_error(reason))}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Row %{row}: %{reason}", row: row_idx, reason: translate_error(reason))}
             </p>
           </div>
         </div>
@@ -2121,11 +2121,11 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
         <div class="flex gap-2 mt-4">
           <.link :if={@selected_catalogue} navigate={Paths.catalogue_detail(@selected_catalogue.uuid)} class="btn btn-primary btn-sm">
             <.icon name="hero-eye" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "View Catalogue")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "View Catalogue")}
           </.link>
           <button class="btn btn-ghost btn-sm" phx-click="import_another">
             <.icon name="hero-arrow-path" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Import Another")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Import Another")}
           </button>
         </div>
       </div>
@@ -2144,13 +2144,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     categories = Map.get(category_counts, cat.uuid, 0)
 
     items_label =
-      Gettext.ngettext(PhoenixKitWeb.Gettext, "%{count} item", "%{count} items", items,
+      Gettext.ngettext(PhoenixKitCatalogue.Gettext, "%{count} item", "%{count} items", items,
         count: items
       )
 
     categories_label =
       Gettext.ngettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "%{count} category",
         "%{count} categories",
         categories,
@@ -2160,28 +2160,33 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
     "#{cat.name} · #{categories_label} · #{items_label}"
   end
 
-  defp translate_target("— Skip —"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "— Skip —")
-  defp translate_target("Item Name"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Item Name")
-  defp translate_target("Description"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Description")
+  defp translate_target("— Skip —"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "— Skip —")
+
+  defp translate_target("Item Name"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item Name")
+
+  defp translate_target("Description"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")
 
   defp translate_target("Article Code"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Article Code")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Article Code")
 
-  defp translate_target("Base Price"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")
+  defp translate_target("Base Price"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Base Price")
 
   defp translate_target("Markup Override (%)"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Override (%)")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Markup Override (%)")
 
   defp translate_target("Unit of Measure"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Unit of Measure")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unit of Measure")
 
   defp translate_target("Manufacturer"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturer")
 
-  defp translate_target("Supplier"), do: Gettext.gettext(PhoenixKitWeb.Gettext, "Supplier")
+  defp translate_target("Supplier"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Supplier")
 
   defp translate_target("Create Categories"),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Categories")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create Categories")
 
   defp translate_target(label), do: label
 
@@ -2269,13 +2274,13 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   end
 
   defp error_to_string(:too_large),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "File is too large (max 10MB)")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "File is too large (max 10MB)")
 
   defp error_to_string(:too_many_files),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Only one file allowed")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Only one file allowed")
 
   defp error_to_string(:not_accepted),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "File type not supported. Use .xlsx or .csv")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "File type not supported. Use .xlsx or .csv")
 
   defp error_to_string(err), do: inspect(err)
 

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -47,7 +47,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       {nil, _, _} ->
         {:ok,
          socket
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Item not found."))
+         |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item not found."))
          |> push_navigate(to: Paths.index())}
 
       {item, changeset, catalogue_uuid} ->
@@ -112,8 +112,8 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     |> assign(
       page_title:
         if(action == :new,
-          do: Gettext.gettext(PhoenixKitWeb.Gettext, "New Item"),
-          else: Gettext.gettext(PhoenixKitWeb.Gettext, "Edit %{name}", name: item.name)
+          do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Item"),
+          else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit %{name}", name: item.name)
         ),
       action: action,
       item: item,
@@ -510,7 +510,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       {:ok, item} ->
         {:noreply,
          socket
-         |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item moved."))
+         |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item moved."))
          |> push_navigate(to: redirect_target(socket, item))}
 
       {:error, _} ->
@@ -518,7 +518,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitWeb.Gettext, "Failed to move item.")
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move item.")
          )}
     end
   end
@@ -533,7 +533,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
          :ok <- Attachments.maybe_rename_pending_folder(socket, item) do
       {:noreply,
        socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item created."))
+       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item created."))
        |> push_navigate(to: redirect_target(socket, item))}
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -545,7 +545,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
            socket,
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Each catalogue can only appear once in the rules list."
            )
          )}
@@ -567,7 +567,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
          {:ok, _rules} <- maybe_put_rules(socket, item) do
       {:noreply,
        socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Item updated."))
+       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item updated."))
        |> push_navigate(to: redirect_target(socket, item))}
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -579,7 +579,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
            socket,
            :error,
            Gettext.gettext(
-             PhoenixKitWeb.Gettext,
+             PhoenixKitCatalogue.Gettext,
              "Each catalogue can only appear once in the rules list."
            )
          )}
@@ -674,12 +674,12 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           if @action == :new,
             do:
               Gettext.gettext(
-                PhoenixKitWeb.Gettext,
+                PhoenixKitCatalogue.Gettext,
                 "Add a new product or material to the catalogue."
               ),
             else:
               Gettext.gettext(
-                PhoenixKitWeb.Gettext,
+                PhoenixKitCatalogue.Gettext,
                 "Update item details, pricing, and classification."
               )
         }
@@ -691,18 +691,18 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       <div :if={@action == :edit} class="flex items-center justify-between bg-base-200 rounded-lg p-3 gap-3">
         <div class="text-sm">
           <div class="font-medium">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Find this item in PDFs")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Find this item in PDFs")}
           </div>
           <div class="text-xs text-base-content/60">
             {Gettext.gettext(
-              PhoenixKitWeb.Gettext,
+              PhoenixKitCatalogue.Gettext,
               "Searches the entire PDF library for the item's name across all enabled languages."
             )}
           </div>
         </div>
         <button type="button" phx-click="open_pdf_search" class="btn btn-sm btn-primary">
           <.icon name="hero-magnifying-glass" class="w-4 h-4" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Search PDFs")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search PDFs")}
         </button>
       </div>
 
@@ -720,7 +720,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
         <div>
           <p class="text-sm font-medium">
             {Gettext.gettext(
-              PhoenixKitWeb.Gettext,
+              PhoenixKitCatalogue.Gettext,
               "This item was imported in %{lang}. Please fill in the %{primary} translation and save to set it as the primary language.",
               lang: lang_name(@language_tabs, @item_primary_language),
               primary: lang_name(@language_tabs, @primary_language)
@@ -740,7 +740,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           class={"tab #{if @current_tab == :details, do: "tab-active"}"}
         >
           <.icon name="hero-document-text" class="w-4 h-4 mr-1" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Details")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Details")}
         </button>
         <button
           type="button"
@@ -749,7 +749,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           class={"tab #{if @current_tab == :metadata, do: "tab-active"}"}
         >
           <.icon name="hero-tag" class="w-4 h-4 mr-1" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Metadata")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Metadata")}
           <span :if={@meta_state.attached != []} class="badge badge-sm badge-ghost ml-2">
             {length(@meta_state.attached)}
           </span>
@@ -761,7 +761,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           class={"tab #{if @current_tab == :files, do: "tab-active"}"}
         >
           <.icon name="hero-paper-clip" class="w-4 h-4 mr-1" />
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "Files")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Files")}
         </button>
       </div>
 
@@ -788,7 +788,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           <.featured_image_card
             featured_image_uuid={@featured_image_uuid}
             featured_image_file={@featured_image_file}
-            subtitle={Gettext.gettext(PhoenixKitWeb.Gettext, "Shown in lists and detail views.")}
+            subtitle={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Shown in lists and detail views.")}
           />
         </div>
 
@@ -831,8 +831,8 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 current_lang={@current_lang}
                 primary_language={@primary_language}
                 lang_data={@lang_data}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name")}
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Oak Panel 18mm")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Oak Panel 18mm")}
                 required
                 class="w-full"
               />
@@ -846,11 +846,11 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 current_lang={@current_lang}
                 primary_language={@primary_language}
                 lang_data={@lang_data}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")}
                 type="textarea"
                 placeholder={
                   Gettext.gettext(
-                    PhoenixKitWeb.Gettext,
+                    PhoenixKitCatalogue.Gettext,
                     "Product specifications, dimensions, materials..."
                   )
                 }
@@ -880,62 +880,62 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                     d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
                   />
                 </svg>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Pricing & Identification")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Pricing & Identification")}
               </h2>
 
               <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <.input
                   field={@form[:sku]}
                   type="text"
-                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "SKU")}
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "SKU")}
                   class="font-mono"
-                  placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., KF-001")}
+                  placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., KF-001")}
                 />
                 <div class="form-control">
                   <.input
                     field={@form[:base_price]}
                     type="number"
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Base Price")}
+                    label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Base Price")}
                     step="0.01"
                     min="0"
-                    placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "0.00")}
+                    placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "0.00")}
                   />
                   <span class="label-text-alt text-base-content/50 mt-1">
                     {Gettext.gettext(
-                      PhoenixKitWeb.Gettext,
+                      PhoenixKitCatalogue.Gettext,
                       "Cost/purchase price before catalogue markup."
                     )}
                   </span>
                 </div>
                 <.select
                   field={@form[:unit]}
-                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Unit")}
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unit")}
                   class="transition-colors focus-within:select-primary"
                   options={[
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Piece"), "piece"},
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "m² (square meter)"), "m2"},
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Running meter"), "running_meter"}
+                    {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Piece"), "piece"},
+                    {Gettext.gettext(PhoenixKitCatalogue.Gettext, "m² (square meter)"), "m2"},
+                    {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Running meter"), "running_meter"}
                   ]}
                 />
                 <div class="form-control">
                   <.input
                     field={@form[:markup_percentage]}
                     type="number"
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Markup Override (%)")}
+                    label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Markup Override (%)")}
                     step="0.01"
                     min="0"
                     placeholder={
                       if @catalogue_markup,
                         do:
-                          Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{markup}%",
+                          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inherit: %{markup}%",
                             markup: Decimal.to_string(@catalogue_markup, :normal)
                           ),
-                        else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue markup")
+                        else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inherit catalogue markup")
                     }
                   />
                   <span class="label-text-alt text-base-content/50 mt-1">
                     {Gettext.gettext(
-                      PhoenixKitWeb.Gettext,
+                      PhoenixKitCatalogue.Gettext,
                       "Leave blank to inherit the catalogue's markup. Set (including 0) to override just this item."
                     )}
                   </span>
@@ -944,22 +944,22 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                   <.input
                     field={@form[:discount_percentage]}
                     type="number"
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Discount Override (%)")}
+                    label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Discount Override (%)")}
                     step="0.01"
                     min="0"
                     max="100"
                     placeholder={
                       if @catalogue_discount,
                         do:
-                          Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit: %{discount}%",
+                          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inherit: %{discount}%",
                             discount: Decimal.to_string(@catalogue_discount, :normal)
                           ),
-                        else: Gettext.gettext(PhoenixKitWeb.Gettext, "Inherit catalogue discount")
+                        else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inherit catalogue discount")
                     }
                   />
                   <span class="label-text-alt text-base-content/50 mt-1">
                     {Gettext.gettext(
-                      PhoenixKitWeb.Gettext,
+                      PhoenixKitCatalogue.Gettext,
                       "Leave blank to inherit the catalogue's discount. Set (including 0) to override just this item."
                     )}
                   </span>
@@ -972,11 +972,11 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               <div class="divider my-0"></div>
               <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
                 <.icon name="hero-link" class="w-4 h-4" />
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Catalogue Rules")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue Rules")}
               </h2>
               <p class="text-sm text-base-content/60 -mt-2">
                 {Gettext.gettext(
-                  PhoenixKitWeb.Gettext,
+                  PhoenixKitCatalogue.Gettext,
                   "Pick which catalogues this item applies to and set a value + unit per catalogue. Rows left blank inherit the defaults below."
                 )}
               </p>
@@ -986,14 +986,14 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                   <.input
                     field={@form[:default_value]}
                     type="number"
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Value")}
+                    label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Default Value")}
                     step="0.0001"
                     min="0"
-                    placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., 5")}
+                    placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., 5")}
                   />
                   <span class="label-text-alt text-base-content/50 mt-1">
                     {Gettext.gettext(
-                      PhoenixKitWeb.Gettext,
+                      PhoenixKitCatalogue.Gettext,
                       "Used for any selected catalogue that doesn't have its own value. If no catalogues are selected, this is the item's standalone fee (e.g. $50 flat)."
                     )}
                   </span>
@@ -1001,16 +1001,16 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 <div class="form-control">
                   <.select
                     field={@form[:default_unit]}
-                    label={Gettext.gettext(PhoenixKitWeb.Gettext, "Default Unit")}
+                    label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Default Unit")}
                     class="transition-colors focus-within:select-primary"
                     options={[
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Percent (%)"), "percent"},
-                      {Gettext.gettext(PhoenixKitWeb.Gettext, "Flat amount"), "flat"}
+                      {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Percent (%)"), "percent"},
+                      {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Flat amount"), "flat"}
                     ]}
                   />
                   <span class="label-text-alt text-base-content/50 mt-1">
                     {Gettext.gettext(
-                      PhoenixKitWeb.Gettext,
+                      PhoenixKitCatalogue.Gettext,
                       "Used for any selected catalogue that doesn't have its own unit."
                     )}
                   </span>
@@ -1046,22 +1046,22 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                     d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
                   />
                 </svg>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Classification")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Classification")}
               </h2>
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <.select
                   field={@form[:category_uuid]}
-                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Category")}
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category")}
                   class="transition-colors focus-within:select-primary"
-                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No category --")}
+                  prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "-- No category --")}
                   options={Enum.map(@categories, &{&1.name, &1.uuid})}
                 />
                 <.select
                   field={@form[:manufacturer_uuid]}
-                  label={Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer")}
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturer")}
                   class="transition-colors focus-within:select-primary"
-                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- No manufacturer --")}
+                  prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "-- No manufacturer --")}
                   options={Enum.map(@manufacturers, &{&1.name, &1.uuid})}
                 />
               </div>
@@ -1070,17 +1070,17 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
             <div class="form-control">
               <.select
                 field={@form[:status]}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
                 class="transition-colors focus-within:select-primary"
                 options={[
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Discontinued"), "discontinued"}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive"), "inactive"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Discontinued"), "discontinued"}
                 ]}
               />
               <span class="label-text-alt text-base-content/50 mt-1">
                 {Gettext.gettext(
-                  PhoenixKitWeb.Gettext,
+                  PhoenixKitCatalogue.Gettext,
                   "Discontinued items are kept for reference but hidden from active listings."
                 )}
               </span>
@@ -1100,7 +1100,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
             id_prefix="item"
             description={
               Gettext.gettext(
-                PhoenixKitWeb.Gettext,
+                PhoenixKitCatalogue.Gettext,
                 "Attach any metadata fields that apply to this item. Blank values are dropped on save."
               )
             }
@@ -1118,7 +1118,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               <div class="flex flex-col gap-0.5 min-w-0">
                 <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
                   <.icon name="hero-paper-clip" class="w-4 h-4" />
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Attached Files")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Attached Files")}
                   <span
                     :if={@files_state.files != []}
                     class="badge badge-sm badge-ghost ml-1"
@@ -1128,7 +1128,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                 </h2>
                 <p class="text-xs text-base-content/50">
                   {Gettext.gettext(
-                    PhoenixKitWeb.Gettext,
+                    PhoenixKitCatalogue.Gettext,
                     "Spec sheets, drawings, photos. Any file type is accepted."
                   )}
                 </p>
@@ -1146,9 +1146,9 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               <.icon name="hero-cloud-arrow-up" class="w-8 h-8 text-base-content/40" />
               <div class="text-sm text-base-content/60">
                 <span class="font-medium text-primary">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Click to upload")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Click to upload")}
                 </span>
-                <span>{Gettext.gettext(PhoenixKitWeb.Gettext, " or drag & drop")}</span>
+                <span>{Gettext.gettext(PhoenixKitCatalogue.Gettext, " or drag & drop")}</span>
               </div>
               <.live_file_input upload={@uploads.attachment_files} class="hidden" />
             </label>
@@ -1175,7 +1175,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                   phx-click="cancel_upload"
                   phx-value-ref={entry.ref}
                   class="btn btn-ghost btn-xs btn-square"
-                  title={Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
+                  title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}
                 >
                   <.icon name="hero-x-mark" class="w-4 h-4" />
                 </button>
@@ -1191,7 +1191,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               <div class="flex flex-col items-center gap-2 py-10 text-center border border-dashed border-base-300 rounded-md">
                 <.icon name="hero-paper-clip" class="w-8 h-8 text-base-content/30" />
                 <p class="text-sm text-base-content/50">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "No files attached yet.")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No files attached yet.")}
                 </p>
               </div>
             <% else %>
@@ -1219,7 +1219,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                       target="_blank"
                       rel="noopener"
                       class="shrink-0 flex items-center justify-center w-14 h-14 rounded bg-base-200 border border-base-300 text-base-content/60"
-                      title={Gettext.gettext(PhoenixKitWeb.Gettext, "Download")}
+                      title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Download")}
                     >
                       <.icon name={Attachments.file_icon(file)} class="w-6 h-6" />
                     </a>
@@ -1236,15 +1236,15 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                     type="button"
                     phx-click="remove_file"
                     phx-value-uuid={file.uuid}
-                    phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Removing...")}
+                    phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Removing...")}
                     data-confirm={
                       Gettext.gettext(
-                        PhoenixKitWeb.Gettext,
+                        PhoenixKitCatalogue.Gettext,
                         "Remove this file from the item? If it's not attached to any other item, it will be moved to trash (admins can restore)."
                       )
                     }
                     class="btn btn-ghost btn-xs btn-square"
-                    title={Gettext.gettext(PhoenixKitWeb.Gettext, "Remove from item")}
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Remove from item")}
                   >
                     <.icon name="hero-x-mark" class="w-4 h-4" />
                   </button>
@@ -1267,23 +1267,23 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
             }
             class="btn btn-ghost"
           >
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}
           </.link>
           <button
             type="submit"
             class="btn btn-primary phx-submit-loading:opacity-75"
             disabled={@uploads.attachment_files.entries != []}
-            phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+            phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Saving...")}
           >
             {cond do
               @uploads.attachment_files.entries != [] ->
-                Gettext.gettext(PhoenixKitWeb.Gettext, "Waiting for uploads...")
+                Gettext.gettext(PhoenixKitCatalogue.Gettext, "Waiting for uploads...")
 
               @action == :new ->
-                Gettext.gettext(PhoenixKitWeb.Gettext, "Create Item")
+                Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create Item")
 
               true ->
-                Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")
+                Gettext.gettext(PhoenixKitCatalogue.Gettext, "Save Changes")
             end}
           </button>
         </div>
@@ -1305,7 +1305,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       >
         <summary class="card-body py-3 cursor-pointer flex-row items-center gap-2 select-none">
           <.icon name="hero-arrows-right-left" class="w-4 h-4 text-base-content/60" />
-          <h3 class="font-semibold text-base">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}</h3>
+          <h3 class="font-semibold text-base">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}</h3>
           <.icon name="hero-chevron-down" class="w-4 h-4 ml-auto text-base-content/40" />
         </summary>
 
@@ -1313,9 +1313,9 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           <%!-- Standard items: move to any category --%>
           <div :if={@catalogue_kind != "smart" && @all_categories != []} class="flex flex-col gap-3">
             <div>
-              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Category")}</p>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to Another Category")}</p>
               <p class="text-xs text-base-content/60">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move this item to a category in any catalogue.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move this item to a category in any catalogue.")}
               </p>
             </div>
             <div class="flex items-end gap-3">
@@ -1324,7 +1324,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                   name="category_uuid"
                   id="item-move-category"
                   value={@move_target}
-                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select category --")}
+                  prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "-- Select category --")}
                   options={Enum.map(@all_categories, &{&1.name, &1.uuid})}
                   class="select-sm transition-colors focus-within:select-primary"
                   phx-change="select_move_target"
@@ -1333,11 +1333,11 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               <button
                 type="button"
                 phx-click="move_item"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Moving...")}
                 disabled={is_nil(@move_target)}
                 class="btn btn-sm btn-outline"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
               </button>
             </div>
           </div>
@@ -1345,10 +1345,10 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           <%!-- Smart items: move to a different smart catalogue --%>
           <div :if={@catalogue_kind == "smart" && @smart_move_targets != []} class="flex flex-col gap-3">
             <div>
-              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitWeb.Gettext, "Move to Another Smart Catalogue")}</p>
+              <p class="font-medium text-sm">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to Another Smart Catalogue")}</p>
               <p class="text-xs text-base-content/60">
                 {Gettext.gettext(
-                  PhoenixKitWeb.Gettext,
+                  PhoenixKitCatalogue.Gettext,
                   "Move this item into a different smart catalogue. Its catalogue rules stay attached."
                 )}
               </p>
@@ -1359,7 +1359,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
                   name="catalogue_uuid"
                   id="item-move-smart-catalogue"
                   value={@move_target}
-                  prompt={Gettext.gettext(PhoenixKitWeb.Gettext, "-- Select catalogue --")}
+                  prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "-- Select catalogue --")}
                   options={Enum.map(@smart_move_targets, &{&1.name, &1.uuid})}
                   class="select-sm transition-colors focus-within:select-primary"
                   phx-change="select_move_target"
@@ -1368,11 +1368,11 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
               <button
                 type="button"
                 phx-click="move_item"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Moving...")}
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Moving...")}
                 disabled={is_nil(@move_target)}
                 class="btn btn-sm btn-outline"
               >
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Move")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
               </button>
             </div>
           </div>

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -42,7 +42,10 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
     if is_nil(manufacturer) and action == :edit do
       {:ok,
        socket
-       |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer not found."))
+       |> put_flash(
+         :error,
+         Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturer not found.")
+       )
        |> push_navigate(to: Paths.manufacturers())}
     else
       all_suppliers = Catalogue.list_suppliers(status: "active")
@@ -52,8 +55,11 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
        |> assign(
          page_title:
            if(action == :new,
-             do: Gettext.gettext(PhoenixKitWeb.Gettext, "New Manufacturer"),
-             else: Gettext.gettext(PhoenixKitWeb.Gettext, "Edit %{name}", name: manufacturer.name)
+             do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Manufacturer"),
+             else:
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit %{name}",
+                 name: manufacturer.name
+               )
            ),
          action: action,
          manufacturer: manufacturer,
@@ -110,7 +116,10 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
           {:ok, _} ->
             {:noreply,
              socket
-             |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer created."))
+             |> put_flash(
+               :info,
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturer created.")
+             )
              |> push_navigate(to: Paths.manufacturers())}
 
           {:error, _} ->
@@ -119,7 +128,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
              |> put_flash(
                :warning,
                Gettext.gettext(
-                 PhoenixKitWeb.Gettext,
+                 PhoenixKitCatalogue.Gettext,
                  "Manufacturer created but failed to link some suppliers."
                )
              )
@@ -144,7 +153,10 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
           {:ok, _} ->
             {:noreply,
              socket
-             |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Manufacturer updated."))
+             |> put_flash(
+               :info,
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturer updated.")
+             )
              |> push_navigate(to: Paths.manufacturers())}
 
           {:error, _} ->
@@ -153,7 +165,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
              |> put_flash(
                :warning,
                Gettext.gettext(
-                 PhoenixKitWeb.Gettext,
+                 PhoenixKitCatalogue.Gettext,
                  "Manufacturer updated but failed to sync supplier links."
                )
              )
@@ -173,7 +185,7 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
       <.admin_page_header
         back={Paths.manufacturers()}
         title={@page_title}
-        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Add a new manufacturer to your catalogue system."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update manufacturer details and supplier links.")}
+        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new manufacturer to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update manufacturer details and supplier links.")}
       />
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
@@ -182,16 +194,16 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
             <.input
               field={@form[:name]}
               type="text"
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name *")}
-              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Blum, Hettich")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name *")}
+              placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Blum, Hettich")}
               required
             />
 
             <.textarea
               field={@form[:description]}
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")}
               rows="3"
-              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Brief description of this manufacturer...")}
+              placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Brief description of this manufacturer...")}
             />
 
             <div class="divider my-0"></div>
@@ -199,37 +211,37 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
             <%!-- Contact & web --%>
             <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
               <.icon name="hero-envelope" class="h-4 w-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Contact & Web")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Contact & Web")}
             </h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <.input
                 field={@form[:website]}
                 type="url"
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "https://...")}
               />
               <.input
                 field={@form[:contact_info]}
                 type="text"
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Contact Info")}
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Email or phone")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Contact Info")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Email or phone")}
               />
             </div>
 
             <.input
               field={@form[:logo_url]}
               type="url"
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Logo URL")}
-              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Logo URL")}
+              placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "https://...")}
             />
 
             <.textarea
               field={@form[:notes]}
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Notes")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Notes")}
               rows="2"
               class="min-h-[5rem]"
-              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Internal notes about this manufacturer...")}
+              placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Internal notes about this manufacturer...")}
             />
 
             <div class="divider my-0"></div>
@@ -237,15 +249,15 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
             <div class="form-control">
               <.select
                 field={@form[:status]}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
                 class="transition-colors focus-within:select-primary"
                 options={[
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive"), "inactive"}
                 ]}
               />
               <span class="label-text-alt text-base-content/50 mt-1">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive manufacturers won't appear in item dropdowns.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive manufacturers won't appear in item dropdowns.")}
               </span>
             </div>
 
@@ -255,10 +267,10 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
 
               <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
                 <.icon name="hero-link" class="h-4 w-4" />
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Linked Suppliers")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Linked Suppliers")}
               </h2>
               <p class="text-sm text-base-content/50 -mt-2">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Click to toggle supplier associations.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Click to toggle supplier associations.")}
               </p>
 
               <div class="flex flex-wrap gap-2">
@@ -288,13 +300,13 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
             <div class="divider my-0"></div>
 
             <div class="flex justify-end gap-3">
-              <.link navigate={Paths.manufacturers()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
+              <.link navigate={Paths.manufacturers()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}</.link>
               <button
                 type="submit"
                 class="btn btn-primary phx-submit-loading:opacity-75"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Saving...")}
               >
-                {if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Manufacturer"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}
+                {if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create Manufacturer"), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Save Changes")}
               </button>
             </div>
           </div>

--- a/lib/phoenix_kit_catalogue/web/pdf_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/pdf_detail_live.ex
@@ -34,7 +34,7 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
       nil ->
         {:ok,
          socket
-         |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "PDF not found."))
+         |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF not found."))
          |> push_navigate(to: Paths.pdfs())}
 
       pdf ->
@@ -64,8 +64,8 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
   def handle_event("trash", _params, socket) do
     detail_pdf_action(socket, &Catalogue.trash_pdf/2,
       operation: "trash_pdf",
-      success: Gettext.gettext(PhoenixKitWeb.Gettext, "PDF moved to trash."),
-      failure: Gettext.gettext(PhoenixKitWeb.Gettext, "Could not move the PDF to trash."),
+      success: Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF moved to trash."),
+      failure: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not move the PDF to trash."),
       after_ok: :push_navigate
     )
   end
@@ -74,8 +74,8 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
   def handle_event("restore", _params, socket) do
     detail_pdf_action(socket, &Catalogue.restore_pdf/2,
       operation: "restore_pdf",
-      success: Gettext.gettext(PhoenixKitWeb.Gettext, "PDF restored."),
-      failure: Gettext.gettext(PhoenixKitWeb.Gettext, "Could not restore the PDF."),
+      success: Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF restored."),
+      failure: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not restore the PDF."),
       after_ok: :reload
     )
   end
@@ -84,8 +84,9 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
   def handle_event("permanently_delete", _params, socket) do
     detail_pdf_action(socket, &Catalogue.permanently_delete_pdf/2,
       operation: "permanently_delete_pdf",
-      success: Gettext.gettext(PhoenixKitWeb.Gettext, "PDF permanently deleted."),
-      failure: Gettext.gettext(PhoenixKitWeb.Gettext, "Could not permanently delete the PDF."),
+      success: Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF permanently deleted."),
+      failure:
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not permanently delete the PDF."),
       after_ok: :push_navigate
     )
   end
@@ -156,7 +157,7 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
             <.link
               navigate={Paths.pdfs()}
               class="btn btn-ghost btn-xs"
-              title={Gettext.gettext(PhoenixKitWeb.Gettext, "Back to library")}
+              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Back to library")}
             >
               <.icon name="hero-arrow-left" class="w-4 h-4" />
             </.link>
@@ -165,7 +166,7 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
             </h2>
             <%= if @pdf.status == "trashed" do %>
               <span class="badge badge-sm badge-warning">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Trashed")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Trashed")}
               </span>
             <% end %>
           </div>
@@ -176,7 +177,7 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
             </span>
             <%= if Helpers.pdf_extraction_pages(@pdf) do %>
               <span>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} pages",
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} pages",
                   count: Helpers.pdf_extraction_pages(@pdf)
                 )}
               </span>
@@ -186,9 +187,9 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
             <% end %>
             <%= if Helpers.pdf_extracted_at(@pdf) do %>
               <span>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Extracted")}: {Calendar.strftime(
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Extracted")}: {Calendar.strftime(
                   Helpers.pdf_extracted_at(@pdf),
-                  Gettext.gettext(PhoenixKitWeb.Gettext, "%b %d, %Y %H:%M")
+                  Gettext.gettext(PhoenixKitCatalogue.Gettext, "%b %d, %Y %H:%M")
                 )}
               </span>
             <% end %>
@@ -200,39 +201,39 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
             <button
               type="button"
               phx-click="restore"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring…")}
+              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring…")}
               class="btn btn-ghost btn-sm"
             >
               <.icon name="hero-arrow-uturn-left" class="w-4 h-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Restore")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
             </button>
             <button
               type="button"
               phx-click="permanently_delete"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting…")}
+              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting…")}
               data-confirm={
                 Gettext.gettext(
-                  PhoenixKitWeb.Gettext,
+                  PhoenixKitCatalogue.Gettext,
                   "Permanently delete this PDF? If no other library entry references the same file content, the underlying file will be queued for hard deletion."
                 )
               }
               class="btn btn-ghost btn-sm text-error"
             >
               <.icon name="hero-x-mark" class="w-4 h-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Delete forever")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete forever")}
             </button>
           <% else %>
             <button
               type="button"
               phx-click="trash"
-              phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Trashing…")}
+              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Trashing…")}
               data-confirm={
-                Gettext.gettext(PhoenixKitWeb.Gettext, "Move this PDF to trash?")
+                Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move this PDF to trash?")
               }
               class="btn btn-ghost btn-sm text-error"
             >
               <.icon name="hero-trash" class="w-4 h-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Trash")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Trash")}
             </button>
           <% end %>
         </div>
@@ -243,7 +244,7 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
           <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
           <div>
             <div class="font-semibold">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Extraction failed")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Extraction failed")}
             </div>
             <div class="text-xs opacity-80">{Helpers.pdf_error_message(@pdf)}</div>
           </div>
@@ -255,11 +256,11 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
           <.icon name="hero-photo" class="w-4 h-4" />
           <div>
             <div class="font-semibold">
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "No extractable text")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No extractable text")}
             </div>
             <div class="text-xs opacity-80">
               {Gettext.gettext(
-                PhoenixKitWeb.Gettext,
+                PhoenixKitCatalogue.Gettext,
                 "This PDF appears to be scanned. OCR support is planned for a future iteration."
               )}
             </div>
@@ -272,7 +273,7 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
           <span class="loading loading-spinner loading-sm"></span>
           <div>
             {Gettext.gettext(
-              PhoenixKitWeb.Gettext,
+              PhoenixKitCatalogue.Gettext,
               "Text extraction in progress. This page will refresh automatically when it completes."
             )}
           </div>

--- a/lib/phoenix_kit_catalogue/web/pdf_library_live.ex
+++ b/lib/phoenix_kit_catalogue/web/pdf_library_live.ex
@@ -37,7 +37,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
     {:ok,
      socket
      |> assign(
-       page_title: Gettext.gettext(PhoenixKitWeb.Gettext, "PDFs"),
+       page_title: Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDFs"),
        filter: "active",
        pdfs: Catalogue.list_pdfs(status: "active"),
        upload_error: nil
@@ -73,8 +73,8 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
   def handle_event("trash", %{"uuid" => uuid}, socket) do
     handle_pdf_action(socket, uuid, &Catalogue.trash_pdf/2,
       operation: "trash_pdf",
-      success: Gettext.gettext(PhoenixKitWeb.Gettext, "PDF moved to trash."),
-      failure: Gettext.gettext(PhoenixKitWeb.Gettext, "Could not move the PDF to trash.")
+      success: Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF moved to trash."),
+      failure: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not move the PDF to trash.")
     )
   end
 
@@ -82,8 +82,8 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
   def handle_event("restore", %{"uuid" => uuid}, socket) do
     handle_pdf_action(socket, uuid, &Catalogue.restore_pdf/2,
       operation: "restore_pdf",
-      success: Gettext.gettext(PhoenixKitWeb.Gettext, "PDF restored."),
-      failure: Gettext.gettext(PhoenixKitWeb.Gettext, "Could not restore the PDF.")
+      success: Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF restored."),
+      failure: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not restore the PDF.")
     )
   end
 
@@ -91,8 +91,9 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
   def handle_event("permanently_delete", %{"uuid" => uuid}, socket) do
     handle_pdf_action(socket, uuid, &Catalogue.permanently_delete_pdf/2,
       operation: "permanently_delete_pdf",
-      success: Gettext.gettext(PhoenixKitWeb.Gettext, "PDF permanently deleted."),
-      failure: Gettext.gettext(PhoenixKitWeb.Gettext, "Could not permanently delete the PDF.")
+      success: Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF permanently deleted."),
+      failure:
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "Could not permanently delete the PDF.")
     )
   end
 
@@ -200,14 +201,14 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
   defp format_upload_failure({:storage_failed, _}),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Could not save the uploaded file. Please try again or contact support if it persists."
       )
 
   defp format_upload_failure(_),
     do:
       Gettext.gettext(
-        PhoenixKitWeb.Gettext,
+        PhoenixKitCatalogue.Gettext,
         "Upload failed for an unexpected reason. Please try again."
       )
 
@@ -238,7 +239,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
     <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-6">
       <div class="flex items-center justify-between">
         <h2 class="text-xl font-semibold">
-          {Gettext.gettext(PhoenixKitWeb.Gettext, "PDF library")}
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF library")}
         </h2>
         <div class="flex items-center gap-3">
           <div class="join">
@@ -248,7 +249,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
               phx-value-filter="active"
               class={"join-item btn btn-sm #{if @filter == "active", do: "btn-primary", else: "btn-ghost"}"}
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Active")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")}
             </button>
             <button
               type="button"
@@ -256,11 +257,11 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
               phx-value-filter="trashed"
               class={"join-item btn btn-sm #{if @filter == "trashed", do: "btn-primary", else: "btn-ghost"}"}
             >
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Trash")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Trash")}
             </button>
           </div>
           <div class="text-sm text-base-content/60">
-            {Gettext.gettext(PhoenixKitWeb.Gettext, "%{count} PDFs", count: length(@pdfs))}
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} PDFs", count: length(@pdfs))}
           </div>
         </div>
       </div>
@@ -270,11 +271,11 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
         <div class="bg-base-100 rounded-lg p-4">
           <.file_upload
             upload={@uploads.pdf}
-            label={Gettext.gettext(PhoenixKitWeb.Gettext, "Upload PDF")}
+            label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Upload PDF")}
             icon="hero-document-arrow-up"
             accept_description={
               Gettext.gettext(
-                PhoenixKitWeb.Gettext,
+                PhoenixKitCatalogue.Gettext,
                 "PDF files only. Identical content is deduplicated; same file uploaded again under a new name shares one underlying file + extraction."
               )
             }
@@ -283,7 +284,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
 
           <div class="text-xs text-base-content/60 mt-2 italic">
             {Gettext.gettext(
-              PhoenixKitWeb.Gettext,
+              PhoenixKitCatalogue.Gettext,
               "The progress bar shows the browser → server upload only. Don't refresh until it completes — interrupted uploads are not resumed."
             )}
           </div>
@@ -307,9 +308,9 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
             <.icon name="hero-document-text" class="w-12 h-12 mx-auto mb-2 opacity-50" />
             <p>
               <%= if @filter == "trashed" do %>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Trash is empty.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Trash is empty.")}
               <% else %>
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "No PDFs uploaded yet.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No PDFs uploaded yet.")}
               <% end %>
             </p>
           </div>
@@ -317,19 +318,19 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
           <table class="table table-sm">
             <thead class="text-xs uppercase text-base-content/60">
               <tr>
-                <th>{Gettext.gettext(PhoenixKitWeb.Gettext, "Filename")}</th>
-                <th>{Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}</th>
-                <th>{Gettext.gettext(PhoenixKitWeb.Gettext, "Pages")}</th>
-                <th>{Gettext.gettext(PhoenixKitWeb.Gettext, "Size")}</th>
+                <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Filename")}</th>
+                <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</th>
+                <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Pages")}</th>
+                <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Size")}</th>
                 <th>
                   <%= if @filter == "trashed" do %>
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Trashed")}
+                    {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Trashed")}
                   <% else %>
-                    {Gettext.gettext(PhoenixKitWeb.Gettext, "Uploaded")}
+                    {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Uploaded")}
                   <% end %>
                 </th>
                 <th class="text-right">
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Actions")}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}
                 </th>
               </tr>
             </thead>
@@ -357,7 +358,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
                         type="button"
                         phx-click="restore"
                         phx-value-uuid={pdf.uuid}
-                        phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Restoring…")}
+                        phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring…")}
                         class="btn btn-ghost btn-xs"
                       >
                         <.icon name="hero-arrow-uturn-left" class="w-3.5 h-3.5" />
@@ -366,10 +367,10 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
                         type="button"
                         phx-click="permanently_delete"
                         phx-value-uuid={pdf.uuid}
-                        phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Deleting…")}
+                        phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting…")}
                         data-confirm={
                           Gettext.gettext(
-                            PhoenixKitWeb.Gettext,
+                            PhoenixKitCatalogue.Gettext,
                             "Permanently delete this PDF? If no other library entry references the same file content, the underlying file will be queued for hard deletion."
                           )
                         }
@@ -382,10 +383,10 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
                         type="button"
                         phx-click="trash"
                         phx-value-uuid={pdf.uuid}
-                        phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Trashing…")}
+                        phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Trashing…")}
                         data-confirm={
                           Gettext.gettext(
-                            PhoenixKitWeb.Gettext,
+                            PhoenixKitCatalogue.Gettext,
                             "Move this PDF to trash?"
                           )
                         }
@@ -438,13 +439,13 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
   defp timestamp_for_filter(pdf, _), do: pdf.inserted_at
 
   defp format_upload_error(:too_large),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "File is too large.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "File is too large.")
 
   defp format_upload_error(:not_accepted),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Only PDF files are accepted.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Only PDF files are accepted.")
 
   defp format_upload_error(:too_many_files),
-    do: Gettext.gettext(PhoenixKitWeb.Gettext, "Too many files at once.")
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Too many files at once.")
 
   defp format_upload_error(other), do: inspect(other)
 end

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -42,7 +42,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
     if is_nil(supplier) and action == :edit do
       {:ok,
        socket
-       |> put_flash(:error, Gettext.gettext(PhoenixKitWeb.Gettext, "Supplier not found."))
+       |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Supplier not found."))
        |> push_navigate(to: Paths.suppliers())}
     else
       all_manufacturers = Catalogue.list_manufacturers(status: "active")
@@ -52,8 +52,9 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
        |> assign(
          page_title:
            if(action == :new,
-             do: Gettext.gettext(PhoenixKitWeb.Gettext, "New Supplier"),
-             else: Gettext.gettext(PhoenixKitWeb.Gettext, "Edit %{name}", name: supplier.name)
+             do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Supplier"),
+             else:
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit %{name}", name: supplier.name)
            ),
          action: action,
          supplier: supplier,
@@ -110,7 +111,10 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
           {:ok, _} ->
             {:noreply,
              socket
-             |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Supplier created."))
+             |> put_flash(
+               :info,
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Supplier created.")
+             )
              |> push_navigate(to: Paths.suppliers())}
 
           {:error, _} ->
@@ -119,7 +123,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
              |> put_flash(
                :warning,
                Gettext.gettext(
-                 PhoenixKitWeb.Gettext,
+                 PhoenixKitCatalogue.Gettext,
                  "Supplier created but failed to link some manufacturers."
                )
              )
@@ -144,7 +148,10 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
           {:ok, _} ->
             {:noreply,
              socket
-             |> put_flash(:info, Gettext.gettext(PhoenixKitWeb.Gettext, "Supplier updated."))
+             |> put_flash(
+               :info,
+               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Supplier updated.")
+             )
              |> push_navigate(to: Paths.suppliers())}
 
           {:error, _} ->
@@ -153,7 +160,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
              |> put_flash(
                :warning,
                Gettext.gettext(
-                 PhoenixKitWeb.Gettext,
+                 PhoenixKitCatalogue.Gettext,
                  "Supplier updated but failed to sync manufacturer links."
                )
              )
@@ -173,7 +180,7 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
       <.admin_page_header
         back={Paths.suppliers()}
         title={@page_title}
-        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Add a new supplier to your catalogue system."), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Update supplier details and manufacturer links.")}
+        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new supplier to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update supplier details and manufacturer links.")}
       />
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
@@ -182,16 +189,16 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
             <.input
               field={@form[:name]}
               type="text"
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Name *")}
-              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "e.g., Regional Distributors Inc.")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name *")}
+              placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "e.g., Regional Distributors Inc.")}
               required
             />
 
             <.textarea
               field={@form[:description]}
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Description")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Description")}
               rows="3"
-              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Brief description of this supplier...")}
+              placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Brief description of this supplier...")}
             />
 
             <div class="divider my-0"></div>
@@ -199,30 +206,30 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
             <%!-- Contact & web --%>
             <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
               <.icon name="hero-envelope" class="h-4 w-4" />
-              {Gettext.gettext(PhoenixKitWeb.Gettext, "Contact & Web")}
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Contact & Web")}
             </h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <.input
                 field={@form[:website]}
                 type="url"
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Website")}
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "https://...")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "https://...")}
               />
               <.input
                 field={@form[:contact_info]}
                 type="text"
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Contact Info")}
-                placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Email or phone")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Contact Info")}
+                placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Email or phone")}
               />
             </div>
 
             <.textarea
               field={@form[:notes]}
-              label={Gettext.gettext(PhoenixKitWeb.Gettext, "Notes")}
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Notes")}
               rows="2"
               class="min-h-[5rem]"
-              placeholder={Gettext.gettext(PhoenixKitWeb.Gettext, "Internal notes about this supplier...")}
+              placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Internal notes about this supplier...")}
             />
 
             <div class="divider my-0"></div>
@@ -230,15 +237,15 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
             <div class="form-control">
               <.select
                 field={@form[:status]}
-                label={Gettext.gettext(PhoenixKitWeb.Gettext, "Status")}
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
                 class="transition-colors focus-within:select-primary"
                 options={[
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Active"), "active"},
-                  {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive"), "inactive"}
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active"), "active"},
+                  {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive"), "inactive"}
                 ]}
               />
               <span class="label-text-alt text-base-content/50 mt-1">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Inactive suppliers won't appear in manufacturer linking.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive suppliers won't appear in manufacturer linking.")}
               </span>
             </div>
 
@@ -248,10 +255,10 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
 
               <h2 class="text-base font-semibold text-base-content/80 flex items-center gap-2">
                 <.icon name="hero-link" class="h-4 w-4" />
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Linked Manufacturers")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Linked Manufacturers")}
               </h2>
               <p class="text-sm text-base-content/50 -mt-2">
-                {Gettext.gettext(PhoenixKitWeb.Gettext, "Click to toggle manufacturer associations.")}
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Click to toggle manufacturer associations.")}
               </p>
 
               <div class="flex flex-wrap gap-2">
@@ -281,13 +288,13 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
             <div class="divider my-0"></div>
 
             <div class="flex justify-end gap-3">
-              <.link navigate={Paths.suppliers()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitWeb.Gettext, "Cancel")}</.link>
+              <.link navigate={Paths.suppliers()} class="btn btn-ghost">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}</.link>
               <button
                 type="submit"
                 class="btn btn-primary phx-submit-loading:opacity-75"
-                phx-disable-with={Gettext.gettext(PhoenixKitWeb.Gettext, "Saving...")}
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Saving...")}
               >
-                {if @action == :new, do: Gettext.gettext(PhoenixKitWeb.Gettext, "Create Supplier"), else: Gettext.gettext(PhoenixKitWeb.Gettext, "Save Changes")}
+                {if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create Supplier"), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Save Changes")}
               </button>
             </div>
           </div>

--- a/lib/phoenix_kit_catalogue/workers/pdf_extractor.ex
+++ b/lib/phoenix_kit_catalogue/workers/pdf_extractor.ex
@@ -190,8 +190,7 @@ defmodule PhoenixKitCatalogue.Workers.PdfExtractor do
   rescue
     e in ErlangError ->
       {:error,
-       {:pdftotext_failed, page_number, :enoent,
-        "pdftotext not on PATH: #{Exception.message(e)}"}}
+       {:pdftotext_failed, page_number, :enoent, "pdftotext not on PATH: #{Exception.message(e)}"}}
   end
 
   # Normalize page text:

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKitCatalogue.MixProject do
   use Mix.Project
 
-  @version "0.1.17"
+  @version "0.2.0"
   @source_url "https://github.com/BeamLabEU/phoenix_kit_catalogue"
 
   def project do

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,789 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new translations manually or run "mix gettext.extract" to add
+## stale messages to this file.
+##
+## Run "mix gettext.merge priv/gettext --locale LOCALE" to merge
+## this template with a particular locale's PO file.
+msgid ""
+msgstr ""
+
+## Tab labels
+msgid "Catalogue"
+msgstr ""
+
+msgid "Catalogues"
+msgstr ""
+
+msgid "Manufacturers"
+msgstr ""
+
+msgid "Suppliers"
+msgstr ""
+
+msgid "Import"
+msgstr ""
+
+msgid "Events"
+msgstr ""
+
+msgid "PDFs"
+msgstr ""
+
+msgid "PDF"
+msgstr ""
+
+msgid "New Catalogue"
+msgstr ""
+
+msgid "Edit Catalogue"
+msgstr ""
+
+msgid "New Manufacturer"
+msgstr ""
+
+msgid "Edit Manufacturer"
+msgstr ""
+
+msgid "New Supplier"
+msgstr ""
+
+msgid "Edit Supplier"
+msgstr ""
+
+msgid "New Category"
+msgstr ""
+
+msgid "Edit Category"
+msgstr ""
+
+msgid "New Item"
+msgstr ""
+
+msgid "Edit Item"
+msgstr ""
+
+## Page titles / form headings
+msgid "Edit %{name}"
+msgstr ""
+
+msgid "Create a new product catalogue to organize categories and items."
+msgstr ""
+
+msgid "Update catalogue details and settings."
+msgstr ""
+
+msgid "Add a new manufacturer to your catalogue system."
+msgstr ""
+
+msgid "Update manufacturer details and supplier links."
+msgstr ""
+
+msgid "Add a new supplier to your catalogue system."
+msgstr ""
+
+msgid "Update supplier details and manufacturer links."
+msgstr ""
+
+msgid "Add a new category to organize items within this catalogue."
+msgstr ""
+
+msgid "Update category details and ordering."
+msgstr ""
+
+msgid "Create a new category — fill in the details below"
+msgstr ""
+
+## Status labels
+msgid "Active"
+msgstr ""
+
+msgid "Inactive"
+msgstr ""
+
+msgid "Archived"
+msgstr ""
+
+msgid "Deleted"
+msgstr ""
+
+msgid "Discontinued"
+msgstr ""
+
+msgid "Unknown"
+msgstr ""
+
+## PDF status labels
+msgid "Pending"
+msgstr ""
+
+msgid "Extracting"
+msgstr ""
+
+msgid "Extracted"
+msgstr ""
+
+msgid "Scanned (no text)"
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+## Metadata field labels
+msgid "Color"
+msgstr ""
+
+msgid "Weight"
+msgstr ""
+
+msgid "Width"
+msgstr ""
+
+msgid "Height"
+msgstr ""
+
+msgid "Depth"
+msgstr ""
+
+msgid "Material"
+msgstr ""
+
+msgid "Finish"
+msgstr ""
+
+msgid "Brand"
+msgstr ""
+
+msgid "Collection"
+msgstr ""
+
+msgid "Season"
+msgstr ""
+
+msgid "Region"
+msgstr ""
+
+msgid "Vendor Reference"
+msgstr ""
+
+## Error messages
+msgid "Cannot move a category under itself or one of its descendants."
+msgstr ""
+
+msgid "Target belongs to a different catalogue. Move the category to the target catalogue first."
+msgstr ""
+
+msgid "Parent category not found."
+msgstr ""
+
+msgid "Categories must share the same parent to be reordered."
+msgstr ""
+
+msgid "Category not found."
+msgstr ""
+
+msgid "Catalogue not found."
+msgstr ""
+
+msgid "Item is already in this catalogue."
+msgstr ""
+
+msgid "You must be logged in to upload files."
+msgstr ""
+
+msgid "Unsupported file format."
+msgstr ""
+
+msgid "Unsupported file format. Please upload .xlsx or .csv."
+msgstr ""
+
+msgid "Not found."
+msgstr ""
+
+msgid "Missing item name."
+msgstr ""
+
+msgid "CSV file is empty."
+msgstr ""
+
+msgid "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
+msgstr ""
+
+msgid "Cannot delete: %{count} smart items still reference this catalogue."
+msgstr ""
+
+msgid "Each catalogue can only be referenced once per item."
+msgstr ""
+
+msgid "Invalid price: %{raw}"
+msgstr ""
+
+msgid "Invalid markup: %{raw}"
+msgstr ""
+
+msgid "Sheet '%{sheet}' is empty."
+msgstr ""
+
+msgid "Failed to read sheet '%{sheet}'."
+msgstr ""
+
+msgid "Failed to open XLSX file."
+msgstr ""
+
+msgid "Failed to read XLSX file."
+msgstr ""
+
+msgid "Failed to parse CSV file."
+msgstr ""
+
+msgid "Unexpected error: %{reason}"
+msgstr ""
+
+## Time-ago strings
+msgid "just now"
+msgstr ""
+
+msgid "%{n}m ago"
+msgstr ""
+
+msgid "%{n}h ago"
+msgstr ""
+
+msgid "%{n}d ago"
+msgstr ""
+
+msgid "%b %d, %Y"
+msgstr ""
+
+## Flash messages
+msgid "Catalogue created."
+msgstr ""
+
+msgid "Catalogue updated."
+msgstr ""
+
+msgid "Catalogue moved to deleted."
+msgstr ""
+
+msgid "Catalogue restored."
+msgstr ""
+
+msgid "Catalogue permanently deleted."
+msgstr ""
+
+msgid "Manufacturer created."
+msgstr ""
+
+msgid "Manufacturer not found."
+msgstr ""
+
+msgid "Manufacturer updated."
+msgstr ""
+
+msgid "Supplier created."
+msgstr ""
+
+msgid "Supplier not found."
+msgstr ""
+
+msgid "Supplier updated."
+msgstr ""
+
+msgid "Category created."
+msgstr ""
+
+msgid "Category updated."
+msgstr ""
+
+msgid "Category moved to deleted."
+msgstr ""
+
+msgid "Category restored."
+msgstr ""
+
+msgid "Category permanently deleted."
+msgstr ""
+
+msgid "Category moved."
+msgstr ""
+
+msgid "Category moved to another catalogue."
+msgstr ""
+
+msgid "Item created."
+msgstr ""
+
+msgid "Item updated."
+msgstr ""
+
+msgid "Item moved to deleted."
+msgstr ""
+
+msgid "Item restored."
+msgstr ""
+
+msgid "Item permanently deleted."
+msgstr ""
+
+msgid "Item moved."
+msgstr ""
+
+msgid "Item not found."
+msgstr ""
+
+msgid "Failed to delete catalogue."
+msgstr ""
+
+msgid "Failed to delete category."
+msgstr ""
+
+msgid "Failed to delete categories."
+msgstr ""
+
+msgid "Failed to delete item."
+msgstr ""
+
+msgid "Failed to delete manufacturer."
+msgstr ""
+
+msgid "Failed to delete supplier."
+msgstr ""
+
+msgid "Failed to move category."
+msgstr ""
+
+msgid "Failed to move item."
+msgstr ""
+
+msgid "Failed to reorder categories."
+msgstr ""
+
+msgid "Failed to reorder items."
+msgstr ""
+
+msgid "Failed to restore catalogue."
+msgstr ""
+
+msgid "Failed to restore category."
+msgstr ""
+
+msgid "Failed to restore item."
+msgstr ""
+
+msgid "Failed to save the new order."
+msgstr ""
+
+msgid "PDF moved to trash."
+msgstr ""
+
+msgid "PDF permanently deleted."
+msgstr ""
+
+msgid "PDF restored."
+msgstr ""
+
+msgid "PDF not found."
+msgstr ""
+
+msgid "Could not move the PDF to trash."
+msgstr ""
+
+msgid "Could not permanently delete the PDF."
+msgstr ""
+
+msgid "Could not restore the PDF."
+msgstr ""
+
+## UI strings - general
+msgid "Back"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Save Changes"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Restore"
+msgstr ""
+
+msgid "Delete Forever"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Create Catalogue"
+msgstr ""
+
+msgid "Create Category"
+msgstr ""
+
+msgid "Create Manufacturer"
+msgstr ""
+
+msgid "Create Supplier"
+msgstr ""
+
+msgid "Create Item"
+msgstr ""
+
+msgid "Add Category"
+msgstr ""
+
+msgid "Add Item"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Details"
+msgstr ""
+
+msgid "Metadata"
+msgstr ""
+
+msgid "Files"
+msgstr ""
+
+msgid "Notes"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Search..."
+msgstr ""
+
+msgid "Search items..."
+msgstr ""
+
+msgid "Upload"
+msgstr ""
+
+msgid "Download"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Position"
+msgstr ""
+
+msgid "Confirm"
+msgstr ""
+
+msgid "Loading..."
+msgstr ""
+
+msgid "Saving..."
+msgstr ""
+
+msgid "Deleting..."
+msgstr ""
+
+msgid "Featured Image"
+msgstr ""
+
+msgid "No featured image set."
+msgstr ""
+
+msgid "Change"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
+
+msgid "Set featured image"
+msgstr ""
+
+msgid "Open original"
+msgstr ""
+
+msgid "Add metadata"
+msgstr ""
+
+msgid "— Pick a field —"
+msgstr ""
+
+msgid "Legacy"
+msgstr ""
+
+msgid "Attached Files"
+msgstr ""
+
+msgid "No files attached yet."
+msgstr ""
+
+msgid "Drag file here or click to browse"
+msgstr ""
+
+msgid "Click to upload"
+msgstr ""
+
+msgid "or drag & drop"
+msgstr ""
+
+msgid "File is too large (max 10MB)"
+msgstr ""
+
+msgid "File type not accepted."
+msgstr ""
+
+msgid "Only PDF files are accepted."
+msgstr ""
+
+msgid "Category"
+msgstr ""
+
+msgid "Categories"
+msgstr ""
+
+msgid "Manufacturer"
+msgstr ""
+
+msgid "Supplier"
+msgstr ""
+
+msgid "Item"
+msgstr ""
+
+msgid "Items"
+msgstr ""
+
+msgid "SKU"
+msgstr ""
+
+msgid "Price"
+msgstr ""
+
+msgid "Base Price"
+msgstr ""
+
+msgid "Final Price"
+msgstr ""
+
+msgid "Unit"
+msgstr ""
+
+msgid "Unit of Measure"
+msgstr ""
+
+msgid "Kind"
+msgstr ""
+
+msgid "Smart"
+msgstr ""
+
+msgid "Standard — items priced directly"
+msgstr ""
+
+msgid "Smart — items reference other catalogues"
+msgstr ""
+
+msgid "Markup %"
+msgstr ""
+
+msgid "Discount"
+msgstr ""
+
+msgid "Table view"
+msgstr ""
+
+msgid "Card view"
+msgstr ""
+
+msgid "Clear"
+msgstr ""
+
+msgid "Clear all"
+msgstr ""
+
+msgid "Trash"
+msgstr ""
+
+msgid "Trash is empty."
+msgstr ""
+
+msgid "No catalogues yet."
+msgstr ""
+
+msgid "No categories yet. Add one to start organizing items."
+msgstr ""
+
+msgid "No manufacturers yet."
+msgstr ""
+
+msgid "No suppliers yet."
+msgstr ""
+
+msgid "No items found"
+msgstr ""
+
+msgid "No events recorded yet"
+msgstr ""
+
+msgid "No PDFs uploaded yet."
+msgstr ""
+
+msgid "Upload PDF"
+msgstr ""
+
+msgid "PDF library"
+msgstr ""
+
+msgid "PDF search"
+msgstr ""
+
+msgid "Find this item in PDFs"
+msgstr ""
+
+msgid "Pages"
+msgstr ""
+
+msgid "Import Complete"
+msgstr ""
+
+msgid "Import Another"
+msgstr ""
+
+msgid "Confirm Import"
+msgstr ""
+
+msgid "Back to Mapping"
+msgstr ""
+
+msgid "Import Items"
+msgstr ""
+
+msgid "Map Columns"
+msgstr ""
+
+msgid "All events loaded"
+msgstr ""
+
+msgid "Danger Zone"
+msgstr ""
+
+msgid "Permanently Delete Catalogue"
+msgstr ""
+
+msgid "Permanently Delete Category"
+msgstr ""
+
+msgid "Permanently Delete Item"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Updated"
+msgstr ""
+
+msgid "Uncategorized"
+msgstr ""
+
+msgid "Linked Manufacturers"
+msgstr ""
+
+msgid "Linked Suppliers"
+msgstr ""
+
+msgid "Scope"
+msgstr ""
+
+msgid "Catalogue Rules"
+msgstr ""
+
+msgid "View Catalogue"
+msgstr ""
+
+msgid "View details"
+msgstr ""
+
+msgid "Back to library"
+msgstr ""
+
+msgid "Search PDFs"
+msgstr ""
+
+## Plural forms
+msgid_plural "%{count} items"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} item"
+msgid_plural "%{count} items"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} category"
+msgid_plural "%{count} categories"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} catalogue"
+msgid_plural "%{count} catalogues"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{active} of %{total} catalogue selected"
+msgid_plural "%{active} of %{total} catalogues selected"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} result for \"%{query}\""
+msgid_plural "%{count} results for \"%{query}\""
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} PDFs"
+msgid_plural "%{count} PDFs"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} events"
+msgid_plural "%{count} events"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} pages"
+msgid_plural "%{count} pages"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "%{count} selected"
+msgid_plural "%{count} selected"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Deleted %{count} categories."
+msgstr ""
+
+msgid "Deleted %{count} items."
+msgstr ""
+
+msgid "Restored %{count} categories."
+msgstr ""
+
+msgid "Restored %{count} items."
+msgstr ""
+
+msgid "Moved %{count} items."
+msgstr ""
+
+msgid "Permanently deleted %{count} items."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,780 @@
+## "default" domain translations for en locale.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+## Tab labels
+msgid "Catalogue"
+msgstr "Catalogue"
+
+msgid "Catalogues"
+msgstr "Catalogues"
+
+msgid "Manufacturers"
+msgstr "Manufacturers"
+
+msgid "Suppliers"
+msgstr "Suppliers"
+
+msgid "Import"
+msgstr "Import"
+
+msgid "Events"
+msgstr "Events"
+
+msgid "PDFs"
+msgstr "PDFs"
+
+msgid "PDF"
+msgstr "PDF"
+
+msgid "New Catalogue"
+msgstr "New Catalogue"
+
+msgid "Edit Catalogue"
+msgstr "Edit Catalogue"
+
+msgid "New Manufacturer"
+msgstr "New Manufacturer"
+
+msgid "Edit Manufacturer"
+msgstr "Edit Manufacturer"
+
+msgid "New Supplier"
+msgstr "New Supplier"
+
+msgid "Edit Supplier"
+msgstr "Edit Supplier"
+
+msgid "New Category"
+msgstr "New Category"
+
+msgid "Edit Category"
+msgstr "Edit Category"
+
+msgid "New Item"
+msgstr "New Item"
+
+msgid "Edit Item"
+msgstr "Edit Item"
+
+## Page titles
+msgid "Edit %{name}"
+msgstr "Edit %{name}"
+
+msgid "Create a new product catalogue to organize categories and items."
+msgstr "Create a new product catalogue to organize categories and items."
+
+msgid "Update catalogue details and settings."
+msgstr "Update catalogue details and settings."
+
+msgid "Add a new manufacturer to your catalogue system."
+msgstr "Add a new manufacturer to your catalogue system."
+
+msgid "Update manufacturer details and supplier links."
+msgstr "Update manufacturer details and supplier links."
+
+msgid "Add a new supplier to your catalogue system."
+msgstr "Add a new supplier to your catalogue system."
+
+msgid "Update supplier details and manufacturer links."
+msgstr "Update supplier details and manufacturer links."
+
+msgid "Add a new category to organize items within this catalogue."
+msgstr "Add a new category to organize items within this catalogue."
+
+msgid "Update category details and ordering."
+msgstr "Update category details and ordering."
+
+msgid "Create a new category — fill in the details below"
+msgstr "Create a new category — fill in the details below"
+
+## Status labels
+msgid "Active"
+msgstr "Active"
+
+msgid "Inactive"
+msgstr "Inactive"
+
+msgid "Archived"
+msgstr "Archived"
+
+msgid "Deleted"
+msgstr "Deleted"
+
+msgid "Discontinued"
+msgstr "Discontinued"
+
+msgid "Unknown"
+msgstr "Unknown"
+
+## PDF status labels
+msgid "Pending"
+msgstr "Pending"
+
+msgid "Extracting"
+msgstr "Extracting"
+
+msgid "Extracted"
+msgstr "Extracted"
+
+msgid "Scanned (no text)"
+msgstr "Scanned (no text)"
+
+msgid "Failed"
+msgstr "Failed"
+
+## Metadata field labels
+msgid "Color"
+msgstr "Color"
+
+msgid "Weight"
+msgstr "Weight"
+
+msgid "Width"
+msgstr "Width"
+
+msgid "Height"
+msgstr "Height"
+
+msgid "Depth"
+msgstr "Depth"
+
+msgid "Material"
+msgstr "Material"
+
+msgid "Finish"
+msgstr "Finish"
+
+msgid "Brand"
+msgstr "Brand"
+
+msgid "Collection"
+msgstr "Collection"
+
+msgid "Season"
+msgstr "Season"
+
+msgid "Region"
+msgstr "Region"
+
+msgid "Vendor Reference"
+msgstr "Vendor Reference"
+
+## Error messages
+msgid "Cannot move a category under itself or one of its descendants."
+msgstr "Cannot move a category under itself or one of its descendants."
+
+msgid "Target belongs to a different catalogue. Move the category to the target catalogue first."
+msgstr "Target belongs to a different catalogue. Move the category to the target catalogue first."
+
+msgid "Parent category not found."
+msgstr "Parent category not found."
+
+msgid "Categories must share the same parent to be reordered."
+msgstr "Categories must share the same parent to be reordered."
+
+msgid "Category not found."
+msgstr "Category not found."
+
+msgid "Catalogue not found."
+msgstr "Catalogue not found."
+
+msgid "Item is already in this catalogue."
+msgstr "Item is already in this catalogue."
+
+msgid "You must be logged in to upload files."
+msgstr "You must be logged in to upload files."
+
+msgid "Unsupported file format."
+msgstr "Unsupported file format."
+
+msgid "Unsupported file format. Please upload .xlsx or .csv."
+msgstr "Unsupported file format. Please upload .xlsx or .csv."
+
+msgid "Not found."
+msgstr "Not found."
+
+msgid "Missing item name."
+msgstr "Missing item name."
+
+msgid "CSV file is empty."
+msgstr "CSV file is empty."
+
+msgid "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
+msgstr "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
+
+msgid "Cannot delete: %{count} smart items still reference this catalogue."
+msgstr "Cannot delete: %{count} smart items still reference this catalogue."
+
+msgid "Each catalogue can only be referenced once per item."
+msgstr "Each catalogue can only be referenced once per item."
+
+msgid "Invalid price: %{raw}"
+msgstr "Invalid price: %{raw}"
+
+msgid "Invalid markup: %{raw}"
+msgstr "Invalid markup: %{raw}"
+
+msgid "Sheet '%{sheet}' is empty."
+msgstr "Sheet '%{sheet}' is empty."
+
+msgid "Failed to read sheet '%{sheet}'."
+msgstr "Failed to read sheet '%{sheet}'."
+
+msgid "Failed to open XLSX file."
+msgstr "Failed to open XLSX file."
+
+msgid "Failed to read XLSX file."
+msgstr "Failed to read XLSX file."
+
+msgid "Failed to parse CSV file."
+msgstr "Failed to parse CSV file."
+
+msgid "Unexpected error: %{reason}"
+msgstr "Unexpected error: %{reason}"
+
+## Time-ago strings
+msgid "just now"
+msgstr "just now"
+
+msgid "%{n}m ago"
+msgstr "%{n}m ago"
+
+msgid "%{n}h ago"
+msgstr "%{n}h ago"
+
+msgid "%{n}d ago"
+msgstr "%{n}d ago"
+
+msgid "%b %d, %Y"
+msgstr "%b %d, %Y"
+
+## Flash messages
+msgid "Catalogue created."
+msgstr "Catalogue created."
+
+msgid "Catalogue updated."
+msgstr "Catalogue updated."
+
+msgid "Catalogue moved to deleted."
+msgstr "Catalogue moved to deleted."
+
+msgid "Catalogue restored."
+msgstr "Catalogue restored."
+
+msgid "Catalogue permanently deleted."
+msgstr "Catalogue permanently deleted."
+
+msgid "Manufacturer created."
+msgstr "Manufacturer created."
+
+msgid "Manufacturer not found."
+msgstr "Manufacturer not found."
+
+msgid "Manufacturer updated."
+msgstr "Manufacturer updated."
+
+msgid "Supplier created."
+msgstr "Supplier created."
+
+msgid "Supplier not found."
+msgstr "Supplier not found."
+
+msgid "Supplier updated."
+msgstr "Supplier updated."
+
+msgid "Category created."
+msgstr "Category created."
+
+msgid "Category updated."
+msgstr "Category updated."
+
+msgid "Category moved to deleted."
+msgstr "Category moved to deleted."
+
+msgid "Category restored."
+msgstr "Category restored."
+
+msgid "Category permanently deleted."
+msgstr "Category permanently deleted."
+
+msgid "Category moved."
+msgstr "Category moved."
+
+msgid "Category moved to another catalogue."
+msgstr "Category moved to another catalogue."
+
+msgid "Item created."
+msgstr "Item created."
+
+msgid "Item updated."
+msgstr "Item updated."
+
+msgid "Item moved to deleted."
+msgstr "Item moved to deleted."
+
+msgid "Item restored."
+msgstr "Item restored."
+
+msgid "Item permanently deleted."
+msgstr "Item permanently deleted."
+
+msgid "Item moved."
+msgstr "Item moved."
+
+msgid "Item not found."
+msgstr "Item not found."
+
+msgid "Failed to delete catalogue."
+msgstr "Failed to delete catalogue."
+
+msgid "Failed to delete category."
+msgstr "Failed to delete category."
+
+msgid "Failed to delete categories."
+msgstr "Failed to delete categories."
+
+msgid "Failed to delete item."
+msgstr "Failed to delete item."
+
+msgid "Failed to delete manufacturer."
+msgstr "Failed to delete manufacturer."
+
+msgid "Failed to delete supplier."
+msgstr "Failed to delete supplier."
+
+msgid "Failed to move category."
+msgstr "Failed to move category."
+
+msgid "Failed to move item."
+msgstr "Failed to move item."
+
+msgid "Failed to reorder categories."
+msgstr "Failed to reorder categories."
+
+msgid "Failed to reorder items."
+msgstr "Failed to reorder items."
+
+msgid "Failed to restore catalogue."
+msgstr "Failed to restore catalogue."
+
+msgid "Failed to restore category."
+msgstr "Failed to restore category."
+
+msgid "Failed to restore item."
+msgstr "Failed to restore item."
+
+msgid "Failed to save the new order."
+msgstr "Failed to save the new order."
+
+msgid "PDF moved to trash."
+msgstr "PDF moved to trash."
+
+msgid "PDF permanently deleted."
+msgstr "PDF permanently deleted."
+
+msgid "PDF restored."
+msgstr "PDF restored."
+
+msgid "PDF not found."
+msgstr "PDF not found."
+
+msgid "Could not move the PDF to trash."
+msgstr "Could not move the PDF to trash."
+
+msgid "Could not permanently delete the PDF."
+msgstr "Could not permanently delete the PDF."
+
+msgid "Could not restore the PDF."
+msgstr "Could not restore the PDF."
+
+## UI strings
+msgid "Back"
+msgstr "Back"
+
+msgid "Cancel"
+msgstr "Cancel"
+
+msgid "Save Changes"
+msgstr "Save Changes"
+
+msgid "Delete"
+msgstr "Delete"
+
+msgid "Restore"
+msgstr "Restore"
+
+msgid "Delete Forever"
+msgstr "Delete Forever"
+
+msgid "Edit"
+msgstr "Edit"
+
+msgid "View"
+msgstr "View"
+
+msgid "Create Catalogue"
+msgstr "Create Catalogue"
+
+msgid "Create Category"
+msgstr "Create Category"
+
+msgid "Create Manufacturer"
+msgstr "Create Manufacturer"
+
+msgid "Create Supplier"
+msgstr "Create Supplier"
+
+msgid "Create Item"
+msgstr "Create Item"
+
+msgid "Add Category"
+msgstr "Add Category"
+
+msgid "Add Item"
+msgstr "Add Item"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Description"
+msgstr "Description"
+
+msgid "Status"
+msgstr "Status"
+
+msgid "Details"
+msgstr "Details"
+
+msgid "Metadata"
+msgstr "Metadata"
+
+msgid "Files"
+msgstr "Files"
+
+msgid "Notes"
+msgstr "Notes"
+
+msgid "Actions"
+msgstr "Actions"
+
+msgid "Search..."
+msgstr "Search..."
+
+msgid "Search items..."
+msgstr "Search items..."
+
+msgid "Upload"
+msgstr "Upload"
+
+msgid "Download"
+msgstr "Download"
+
+msgid "Move"
+msgstr "Move"
+
+msgid "Position"
+msgstr "Position"
+
+msgid "Confirm"
+msgstr "Confirm"
+
+msgid "Loading..."
+msgstr "Loading..."
+
+msgid "Saving..."
+msgstr "Saving..."
+
+msgid "Deleting..."
+msgstr "Deleting..."
+
+msgid "Featured Image"
+msgstr "Featured Image"
+
+msgid "No featured image set."
+msgstr "No featured image set."
+
+msgid "Change"
+msgstr "Change"
+
+msgid "Remove"
+msgstr "Remove"
+
+msgid "Set featured image"
+msgstr "Set featured image"
+
+msgid "Open original"
+msgstr "Open original"
+
+msgid "Add metadata"
+msgstr "Add metadata"
+
+msgid "— Pick a field —"
+msgstr "— Pick a field —"
+
+msgid "Legacy"
+msgstr "Legacy"
+
+msgid "Attached Files"
+msgstr "Attached Files"
+
+msgid "No files attached yet."
+msgstr "No files attached yet."
+
+msgid "Drag file here or click to browse"
+msgstr "Drag file here or click to browse"
+
+msgid "Click to upload"
+msgstr "Click to upload"
+
+msgid "or drag & drop"
+msgstr "or drag & drop"
+
+msgid "File is too large (max 10MB)"
+msgstr "File is too large (max 10MB)"
+
+msgid "File type not accepted."
+msgstr "File type not accepted."
+
+msgid "Only PDF files are accepted."
+msgstr "Only PDF files are accepted."
+
+msgid "Category"
+msgstr "Category"
+
+msgid "Categories"
+msgstr "Categories"
+
+msgid "Manufacturer"
+msgstr "Manufacturer"
+
+msgid "Supplier"
+msgstr "Supplier"
+
+msgid "Item"
+msgstr "Item"
+
+msgid "Items"
+msgstr "Items"
+
+msgid "SKU"
+msgstr "SKU"
+
+msgid "Price"
+msgstr "Price"
+
+msgid "Base Price"
+msgstr "Base Price"
+
+msgid "Final Price"
+msgstr "Final Price"
+
+msgid "Unit"
+msgstr "Unit"
+
+msgid "Unit of Measure"
+msgstr "Unit of Measure"
+
+msgid "Kind"
+msgstr "Kind"
+
+msgid "Smart"
+msgstr "Smart"
+
+msgid "Standard — items priced directly"
+msgstr "Standard — items priced directly"
+
+msgid "Smart — items reference other catalogues"
+msgstr "Smart — items reference other catalogues"
+
+msgid "Markup %"
+msgstr "Markup %"
+
+msgid "Discount"
+msgstr "Discount"
+
+msgid "Table view"
+msgstr "Table view"
+
+msgid "Card view"
+msgstr "Card view"
+
+msgid "Clear"
+msgstr "Clear"
+
+msgid "Clear all"
+msgstr "Clear all"
+
+msgid "Trash"
+msgstr "Trash"
+
+msgid "Trash is empty."
+msgstr "Trash is empty."
+
+msgid "No catalogues yet."
+msgstr "No catalogues yet."
+
+msgid "No categories yet. Add one to start organizing items."
+msgstr "No categories yet. Add one to start organizing items."
+
+msgid "No manufacturers yet."
+msgstr "No manufacturers yet."
+
+msgid "No suppliers yet."
+msgstr "No suppliers yet."
+
+msgid "No items found"
+msgstr "No items found"
+
+msgid "No events recorded yet"
+msgstr "No events recorded yet"
+
+msgid "No PDFs uploaded yet."
+msgstr "No PDFs uploaded yet."
+
+msgid "Upload PDF"
+msgstr "Upload PDF"
+
+msgid "PDF library"
+msgstr "PDF library"
+
+msgid "PDF search"
+msgstr "PDF search"
+
+msgid "Find this item in PDFs"
+msgstr "Find this item in PDFs"
+
+msgid "Pages"
+msgstr "Pages"
+
+msgid "Import Complete"
+msgstr "Import Complete"
+
+msgid "Import Another"
+msgstr "Import Another"
+
+msgid "Confirm Import"
+msgstr "Confirm Import"
+
+msgid "Back to Mapping"
+msgstr "Back to Mapping"
+
+msgid "Import Items"
+msgstr "Import Items"
+
+msgid "Map Columns"
+msgstr "Map Columns"
+
+msgid "All events loaded"
+msgstr "All events loaded"
+
+msgid "Danger Zone"
+msgstr "Danger Zone"
+
+msgid "Permanently Delete Catalogue"
+msgstr "Permanently Delete Catalogue"
+
+msgid "Permanently Delete Category"
+msgstr "Permanently Delete Category"
+
+msgid "Permanently Delete Item"
+msgstr "Permanently Delete Item"
+
+msgid "Created"
+msgstr "Created"
+
+msgid "Updated"
+msgstr "Updated"
+
+msgid "Uncategorized"
+msgstr "Uncategorized"
+
+msgid "Linked Manufacturers"
+msgstr "Linked Manufacturers"
+
+msgid "Linked Suppliers"
+msgstr "Linked Suppliers"
+
+msgid "Scope"
+msgstr "Scope"
+
+msgid "Catalogue Rules"
+msgstr "Catalogue Rules"
+
+msgid "View Catalogue"
+msgstr "View Catalogue"
+
+msgid "View details"
+msgstr "View details"
+
+msgid "Back to library"
+msgstr "Back to library"
+
+msgid "Search PDFs"
+msgstr "Search PDFs"
+
+## Plural forms
+msgid "%{count} item"
+msgid_plural "%{count} items"
+msgstr[0] "%{count} item"
+msgstr[1] "%{count} items"
+
+msgid "%{count} category"
+msgid_plural "%{count} categories"
+msgstr[0] "%{count} category"
+msgstr[1] "%{count} categories"
+
+msgid "%{count} catalogue"
+msgid_plural "%{count} catalogues"
+msgstr[0] "%{count} catalogue"
+msgstr[1] "%{count} catalogues"
+
+msgid "%{active} of %{total} catalogue selected"
+msgid_plural "%{active} of %{total} catalogues selected"
+msgstr[0] "%{active} of %{total} catalogue selected"
+msgstr[1] "%{active} of %{total} catalogues selected"
+
+msgid "%{count} result for \"%{query}\""
+msgid_plural "%{count} results for \"%{query}\""
+msgstr[0] "%{count} result for \"%{query}\""
+msgstr[1] "%{count} results for \"%{query}\""
+
+msgid "%{count} PDFs"
+msgid_plural "%{count} PDFs"
+msgstr[0] "%{count} PDF"
+msgstr[1] "%{count} PDFs"
+
+msgid "%{count} events"
+msgid_plural "%{count} events"
+msgstr[0] "%{count} event"
+msgstr[1] "%{count} events"
+
+msgid "%{count} pages"
+msgid_plural "%{count} pages"
+msgstr[0] "%{count} page"
+msgstr[1] "%{count} pages"
+
+msgid "%{count} selected"
+msgid_plural "%{count} selected"
+msgstr[0] "%{count} selected"
+msgstr[1] "%{count} selected"
+
+msgid "Deleted %{count} categories."
+msgstr "Deleted %{count} categories."
+
+msgid "Deleted %{count} items."
+msgstr "Deleted %{count} items."
+
+msgid "Restored %{count} categories."
+msgstr "Restored %{count} categories."
+
+msgid "Restored %{count} items."
+msgstr "Restored %{count} items."
+
+msgid "Moved %{count} items."
+msgstr "Moved %{count} items."
+
+msgid "Permanently deleted %{count} items."
+msgstr "Permanently deleted %{count} items."

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -1,0 +1,780 @@
+## "default" domain translations for et locale.
+msgid ""
+msgstr ""
+"Language: et\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+## Tab labels
+msgid "Catalogue"
+msgstr "Kataloog"
+
+msgid "Catalogues"
+msgstr "Kataloogid"
+
+msgid "Manufacturers"
+msgstr "Tootjad"
+
+msgid "Suppliers"
+msgstr "Tarnijad"
+
+msgid "Import"
+msgstr "Importimine"
+
+msgid "Events"
+msgstr "Sündmused"
+
+msgid "PDFs"
+msgstr "PDF-failid"
+
+msgid "PDF"
+msgstr "PDF"
+
+msgid "New Catalogue"
+msgstr "Uus kataloog"
+
+msgid "Edit Catalogue"
+msgstr "Muuda kataloogi"
+
+msgid "New Manufacturer"
+msgstr "Uus tootja"
+
+msgid "Edit Manufacturer"
+msgstr "Muuda tootjat"
+
+msgid "New Supplier"
+msgstr "Uus tarnija"
+
+msgid "Edit Supplier"
+msgstr "Muuda tarnijat"
+
+msgid "New Category"
+msgstr "Uus kategooria"
+
+msgid "Edit Category"
+msgstr "Muuda kategooriat"
+
+msgid "New Item"
+msgstr "Uus toode"
+
+msgid "Edit Item"
+msgstr "Muuda toodet"
+
+## Page titles
+msgid "Edit %{name}"
+msgstr "Muuda: %{name}"
+
+msgid "Create a new product catalogue to organize categories and items."
+msgstr "Looge uus tootekataloog kategooriate ja toodete korraldamiseks."
+
+msgid "Update catalogue details and settings."
+msgstr "Uuendage kataloogi üksikasju ja seadeid."
+
+msgid "Add a new manufacturer to your catalogue system."
+msgstr "Lisage uus tootja kataloogisüsteemi."
+
+msgid "Update manufacturer details and supplier links."
+msgstr "Uuendage tootja üksikasju ja tarnijate seoseid."
+
+msgid "Add a new supplier to your catalogue system."
+msgstr "Lisage uus tarnija kataloogisüsteemi."
+
+msgid "Update supplier details and manufacturer links."
+msgstr "Uuendage tarnija üksikasju ja tootjate seoseid."
+
+msgid "Add a new category to organize items within this catalogue."
+msgstr "Lisage uus kategooria kataloogi toodete korraldamiseks."
+
+msgid "Update category details and ordering."
+msgstr "Uuendage kategooria üksikasju ja järjestust."
+
+msgid "Create a new category — fill in the details below"
+msgstr "Looge uus kategooria — täitke allolevad väljad"
+
+## Status labels
+msgid "Active"
+msgstr "Aktiivne"
+
+msgid "Inactive"
+msgstr "Mitteaktiivne"
+
+msgid "Archived"
+msgstr "Arhiveeritud"
+
+msgid "Deleted"
+msgstr "Kustutatud"
+
+msgid "Discontinued"
+msgstr "Tootmine lõpetatud"
+
+msgid "Unknown"
+msgstr "Teadmata"
+
+## PDF status labels
+msgid "Pending"
+msgstr "Ootel"
+
+msgid "Extracting"
+msgstr "Teksti eraldamine"
+
+msgid "Extracted"
+msgstr "Tekst eraldatud"
+
+msgid "Scanned (no text)"
+msgstr "Skannitud (tekst puudub)"
+
+msgid "Failed"
+msgstr "Viga"
+
+## Metadata field labels
+msgid "Color"
+msgstr "Värv"
+
+msgid "Weight"
+msgstr "Kaal"
+
+msgid "Width"
+msgstr "Laius"
+
+msgid "Height"
+msgstr "Kõrgus"
+
+msgid "Depth"
+msgstr "Sügavus"
+
+msgid "Material"
+msgstr "Materjal"
+
+msgid "Finish"
+msgstr "Viimistlus"
+
+msgid "Brand"
+msgstr "Bränd"
+
+msgid "Collection"
+msgstr "Kollektsioon"
+
+msgid "Season"
+msgstr "Hooaeg"
+
+msgid "Region"
+msgstr "Piirkond"
+
+msgid "Vendor Reference"
+msgstr "Tarnija viide"
+
+## Error messages
+msgid "Cannot move a category under itself or one of its descendants."
+msgstr "Kategooriat ei saa enda alla ega oma alamkategooriatesse teisaldada."
+
+msgid "Target belongs to a different catalogue. Move the category to the target catalogue first."
+msgstr "Sihtkoht kuulub teisesse kataloogi. Teisaldage kategooria esmalt sihtkataloogis."
+
+msgid "Parent category not found."
+msgstr "Vanemkategooriat ei leitud."
+
+msgid "Categories must share the same parent to be reordered."
+msgstr "Ümberjärjestamiseks peavad kategooriad kuuluma samale vanemale."
+
+msgid "Category not found."
+msgstr "Kategooriat ei leitud."
+
+msgid "Catalogue not found."
+msgstr "Kataloogi ei leitud."
+
+msgid "Item is already in this catalogue."
+msgstr "Toode on juba selles kataloogis."
+
+msgid "You must be logged in to upload files."
+msgstr "Failide üleslaadimiseks peate olema sisse logitud."
+
+msgid "Unsupported file format."
+msgstr "Toetamata failivorming."
+
+msgid "Unsupported file format. Please upload .xlsx or .csv."
+msgstr "Toetamata vorming. Palun laadige üles .xlsx või .csv fail."
+
+msgid "Not found."
+msgstr "Ei leitud."
+
+msgid "Missing item name."
+msgstr "Toote nimi puudub."
+
+msgid "CSV file is empty."
+msgstr "CSV-fail on tühi."
+
+msgid "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
+msgstr "Taastamine ebaõnnestus — vanemkataloog on kustutatud. Taastage esmalt kataloog."
+
+msgid "Cannot delete: %{count} smart items still reference this catalogue."
+msgstr "Kustutamine ebaõnnestus: %{count} nutikat toodet viitab endiselt sellele kataloogile."
+
+msgid "Each catalogue can only be referenced once per item."
+msgstr "Iga kataloogi saab tootes viidata ainult üks kord."
+
+msgid "Invalid price: %{raw}"
+msgstr "Vigane hind: %{raw}"
+
+msgid "Invalid markup: %{raw}"
+msgstr "Vigane juurdehindlus: %{raw}"
+
+msgid "Sheet '%{sheet}' is empty."
+msgstr "Leht «%{sheet}» on tühi."
+
+msgid "Failed to read sheet '%{sheet}'."
+msgstr "Lehe «%{sheet}» lugemine ebaõnnestus."
+
+msgid "Failed to open XLSX file."
+msgstr "XLSX-faili avamine ebaõnnestus."
+
+msgid "Failed to read XLSX file."
+msgstr "XLSX-faili lugemine ebaõnnestus."
+
+msgid "Failed to parse CSV file."
+msgstr "CSV-faili töötlemine ebaõnnestus."
+
+msgid "Unexpected error: %{reason}"
+msgstr "Ootamatu viga: %{reason}"
+
+## Time-ago strings
+msgid "just now"
+msgstr "just nüüd"
+
+msgid "%{n}m ago"
+msgstr "%{n} min tagasi"
+
+msgid "%{n}h ago"
+msgstr "%{n} t tagasi"
+
+msgid "%{n}d ago"
+msgstr "%{n} p tagasi"
+
+msgid "%b %d, %Y"
+msgstr "%d.%m.%Y"
+
+## Flash messages
+msgid "Catalogue created."
+msgstr "Kataloog loodud."
+
+msgid "Catalogue updated."
+msgstr "Kataloog uuendatud."
+
+msgid "Catalogue moved to deleted."
+msgstr "Kataloog teisaldati kustutatud kirjete hulka."
+
+msgid "Catalogue restored."
+msgstr "Kataloog taastatud."
+
+msgid "Catalogue permanently deleted."
+msgstr "Kataloog jäädavalt kustutatud."
+
+msgid "Manufacturer created."
+msgstr "Tootja loodud."
+
+msgid "Manufacturer not found."
+msgstr "Tootjat ei leitud."
+
+msgid "Manufacturer updated."
+msgstr "Tootja uuendatud."
+
+msgid "Supplier created."
+msgstr "Tarnija loodud."
+
+msgid "Supplier not found."
+msgstr "Tarnijat ei leitud."
+
+msgid "Supplier updated."
+msgstr "Tarnija uuendatud."
+
+msgid "Category created."
+msgstr "Kategooria loodud."
+
+msgid "Category updated."
+msgstr "Kategooria uuendatud."
+
+msgid "Category moved to deleted."
+msgstr "Kategooria teisaldati kustutatud kirjete hulka."
+
+msgid "Category restored."
+msgstr "Kategooria taastatud."
+
+msgid "Category permanently deleted."
+msgstr "Kategooria jäädavalt kustutatud."
+
+msgid "Category moved."
+msgstr "Kategooria teisaldatud."
+
+msgid "Category moved to another catalogue."
+msgstr "Kategooria teisaldati teise kataloogi."
+
+msgid "Item created."
+msgstr "Toode loodud."
+
+msgid "Item updated."
+msgstr "Toode uuendatud."
+
+msgid "Item moved to deleted."
+msgstr "Toode teisaldati kustutatud kirjete hulka."
+
+msgid "Item restored."
+msgstr "Toode taastatud."
+
+msgid "Item permanently deleted."
+msgstr "Toode jäädavalt kustutatud."
+
+msgid "Item moved."
+msgstr "Toode teisaldatud."
+
+msgid "Item not found."
+msgstr "Toodet ei leitud."
+
+msgid "Failed to delete catalogue."
+msgstr "Kataloogi kustutamine ebaõnnestus."
+
+msgid "Failed to delete category."
+msgstr "Kategooria kustutamine ebaõnnestus."
+
+msgid "Failed to delete categories."
+msgstr "Kategooriate kustutamine ebaõnnestus."
+
+msgid "Failed to delete item."
+msgstr "Toote kustutamine ebaõnnestus."
+
+msgid "Failed to delete manufacturer."
+msgstr "Tootja kustutamine ebaõnnestus."
+
+msgid "Failed to delete supplier."
+msgstr "Tarnija kustutamine ebaõnnestus."
+
+msgid "Failed to move category."
+msgstr "Kategooria teisaldamine ebaõnnestus."
+
+msgid "Failed to move item."
+msgstr "Toote teisaldamine ebaõnnestus."
+
+msgid "Failed to reorder categories."
+msgstr "Kategooriate ümberjärjestamine ebaõnnestus."
+
+msgid "Failed to reorder items."
+msgstr "Toodete ümberjärjestamine ebaõnnestus."
+
+msgid "Failed to restore catalogue."
+msgstr "Kataloogi taastamine ebaõnnestus."
+
+msgid "Failed to restore category."
+msgstr "Kategooria taastamine ebaõnnestus."
+
+msgid "Failed to restore item."
+msgstr "Toote taastamine ebaõnnestus."
+
+msgid "Failed to save the new order."
+msgstr "Uue järjestuse salvestamine ebaõnnestus."
+
+msgid "PDF moved to trash."
+msgstr "PDF teisaldati prügikasti."
+
+msgid "PDF permanently deleted."
+msgstr "PDF jäädavalt kustutatud."
+
+msgid "PDF restored."
+msgstr "PDF taastatud."
+
+msgid "PDF not found."
+msgstr "PDF-i ei leitud."
+
+msgid "Could not move the PDF to trash."
+msgstr "PDF-i prügikasti teisaldamine ebaõnnestus."
+
+msgid "Could not permanently delete the PDF."
+msgstr "PDF-i jäädav kustutamine ebaõnnestus."
+
+msgid "Could not restore the PDF."
+msgstr "PDF-i taastamine ebaõnnestus."
+
+## UI strings
+msgid "Back"
+msgstr "Tagasi"
+
+msgid "Cancel"
+msgstr "Tühista"
+
+msgid "Save Changes"
+msgstr "Salvesta"
+
+msgid "Delete"
+msgstr "Kustuta"
+
+msgid "Restore"
+msgstr "Taasta"
+
+msgid "Delete Forever"
+msgstr "Kustuta jäädavalt"
+
+msgid "Edit"
+msgstr "Muuda"
+
+msgid "View"
+msgstr "Vaata"
+
+msgid "Create Catalogue"
+msgstr "Loo kataloog"
+
+msgid "Create Category"
+msgstr "Loo kategooria"
+
+msgid "Create Manufacturer"
+msgstr "Loo tootja"
+
+msgid "Create Supplier"
+msgstr "Loo tarnija"
+
+msgid "Create Item"
+msgstr "Loo toode"
+
+msgid "Add Category"
+msgstr "Lisa kategooria"
+
+msgid "Add Item"
+msgstr "Lisa toode"
+
+msgid "Name"
+msgstr "Nimi"
+
+msgid "Description"
+msgstr "Kirjeldus"
+
+msgid "Status"
+msgstr "Olek"
+
+msgid "Details"
+msgstr "Üksikasjad"
+
+msgid "Metadata"
+msgstr "Metaandmed"
+
+msgid "Files"
+msgstr "Failid"
+
+msgid "Notes"
+msgstr "Märkmed"
+
+msgid "Actions"
+msgstr "Toimingud"
+
+msgid "Search..."
+msgstr "Otsi..."
+
+msgid "Search items..."
+msgstr "Otsi tooteid..."
+
+msgid "Upload"
+msgstr "Laadi üles"
+
+msgid "Download"
+msgstr "Laadi alla"
+
+msgid "Move"
+msgstr "Teisalda"
+
+msgid "Position"
+msgstr "Positsioon"
+
+msgid "Confirm"
+msgstr "Kinnita"
+
+msgid "Loading..."
+msgstr "Laadimine..."
+
+msgid "Saving..."
+msgstr "Salvestamine..."
+
+msgid "Deleting..."
+msgstr "Kustutamine..."
+
+msgid "Featured Image"
+msgstr "Põhipilt"
+
+msgid "No featured image set."
+msgstr "Põhipilt pole määratud."
+
+msgid "Change"
+msgstr "Muuda"
+
+msgid "Remove"
+msgstr "Eemalda"
+
+msgid "Set featured image"
+msgstr "Määra põhipilt"
+
+msgid "Open original"
+msgstr "Ava originaal"
+
+msgid "Add metadata"
+msgstr "Lisa metaandmeid"
+
+msgid "— Pick a field —"
+msgstr "— Valige väli —"
+
+msgid "Legacy"
+msgstr "Vananenud"
+
+msgid "Attached Files"
+msgstr "Manustatud failid"
+
+msgid "No files attached yet."
+msgstr "Faile pole veel manustatud."
+
+msgid "Drag file here or click to browse"
+msgstr "Lohistage fail siia või klõpsake sirvimiseks"
+
+msgid "Click to upload"
+msgstr "Klõpsake üleslaadimiseks"
+
+msgid "or drag & drop"
+msgstr "või lohistage"
+
+msgid "File is too large (max 10MB)"
+msgstr "Fail on liiga suur (maks. 10 MB)"
+
+msgid "File type not accepted."
+msgstr "Failitüüp pole toetatud."
+
+msgid "Only PDF files are accepted."
+msgstr "Aktsepteeritakse ainult PDF-faile."
+
+msgid "Category"
+msgstr "Kategooria"
+
+msgid "Categories"
+msgstr "Kategooriad"
+
+msgid "Manufacturer"
+msgstr "Tootja"
+
+msgid "Supplier"
+msgstr "Tarnija"
+
+msgid "Item"
+msgstr "Toode"
+
+msgid "Items"
+msgstr "Tooted"
+
+msgid "SKU"
+msgstr "Artikkel"
+
+msgid "Price"
+msgstr "Hind"
+
+msgid "Base Price"
+msgstr "Algne hind"
+
+msgid "Final Price"
+msgstr "Lõpphind"
+
+msgid "Unit"
+msgstr "Ühik"
+
+msgid "Unit of Measure"
+msgstr "Mõõtühik"
+
+msgid "Kind"
+msgstr "Tüüp"
+
+msgid "Smart"
+msgstr "Nutikas"
+
+msgid "Standard — items priced directly"
+msgstr "Standardne — toodetel on otsene hind"
+
+msgid "Smart — items reference other catalogues"
+msgstr "Nutikas — tooted viitavad teistele kataloogidele"
+
+msgid "Markup %"
+msgstr "Juurdehindlus %"
+
+msgid "Discount"
+msgstr "Allahindlus"
+
+msgid "Table view"
+msgstr "Tabelivaade"
+
+msgid "Card view"
+msgstr "Kaartide vaade"
+
+msgid "Clear"
+msgstr "Tühjenda"
+
+msgid "Clear all"
+msgstr "Tühjenda kõik"
+
+msgid "Trash"
+msgstr "Prügikast"
+
+msgid "Trash is empty."
+msgstr "Prügikast on tühi."
+
+msgid "No catalogues yet."
+msgstr "Katalooge pole veel loodud."
+
+msgid "No categories yet. Add one to start organizing items."
+msgstr "Kategooriaid pole veel. Lisage üks toodete korraldamiseks."
+
+msgid "No manufacturers yet."
+msgstr "Tootjaid pole veel lisatud."
+
+msgid "No suppliers yet."
+msgstr "Tarnijaid pole veel lisatud."
+
+msgid "No items found"
+msgstr "Tooteid ei leitud"
+
+msgid "No events recorded yet"
+msgstr "Sündmusi pole veel salvestatud"
+
+msgid "No PDFs uploaded yet."
+msgstr "PDF-faile pole veel üles laaditud."
+
+msgid "Upload PDF"
+msgstr "Laadi üles PDF"
+
+msgid "PDF library"
+msgstr "PDF-teek"
+
+msgid "PDF search"
+msgstr "PDF-otsing"
+
+msgid "Find this item in PDFs"
+msgstr "Leia toode PDF-failidest"
+
+msgid "Pages"
+msgstr "Lehed"
+
+msgid "Import Complete"
+msgstr "Import lõpetatud"
+
+msgid "Import Another"
+msgstr "Impordi veel"
+
+msgid "Confirm Import"
+msgstr "Kinnita import"
+
+msgid "Back to Mapping"
+msgstr "Tagasi veergude vastendamise juurde"
+
+msgid "Import Items"
+msgstr "Impordi tooteid"
+
+msgid "Map Columns"
+msgstr "Vastenda veerud"
+
+msgid "All events loaded"
+msgstr "Kõik sündmused laaditud"
+
+msgid "Danger Zone"
+msgstr "Ohutsoon"
+
+msgid "Permanently Delete Catalogue"
+msgstr "Kustuta kataloog jäädavalt"
+
+msgid "Permanently Delete Category"
+msgstr "Kustuta kategooria jäädavalt"
+
+msgid "Permanently Delete Item"
+msgstr "Kustuta toode jäädavalt"
+
+msgid "Created"
+msgstr "Loodud"
+
+msgid "Updated"
+msgstr "Uuendatud"
+
+msgid "Uncategorized"
+msgstr "Kategoriseerimata"
+
+msgid "Linked Manufacturers"
+msgstr "Seotud tootjad"
+
+msgid "Linked Suppliers"
+msgstr "Seotud tarnijad"
+
+msgid "Scope"
+msgstr "Ulatus"
+
+msgid "Catalogue Rules"
+msgstr "Kataloogi reeglid"
+
+msgid "View Catalogue"
+msgstr "Vaata kataloogi"
+
+msgid "View details"
+msgstr "Vaata üksikasju"
+
+msgid "Back to library"
+msgstr "Tagasi teeki"
+
+msgid "Search PDFs"
+msgstr "Otsi PDF-idest"
+
+## Plural forms (Estonian: 2 forms)
+msgid "%{count} item"
+msgid_plural "%{count} items"
+msgstr[0] "%{count} toode"
+msgstr[1] "%{count} toodet"
+
+msgid "%{count} category"
+msgid_plural "%{count} categories"
+msgstr[0] "%{count} kategooria"
+msgstr[1] "%{count} kategooriat"
+
+msgid "%{count} catalogue"
+msgid_plural "%{count} catalogues"
+msgstr[0] "%{count} kataloog"
+msgstr[1] "%{count} kataloogi"
+
+msgid "%{active} of %{total} catalogue selected"
+msgid_plural "%{active} of %{total} catalogues selected"
+msgstr[0] "Valitud %{active} kataloogist %{total}"
+msgstr[1] "Valitud %{active} kataloogist %{total}"
+
+msgid "%{count} result for \"%{query}\""
+msgid_plural "%{count} results for \"%{query}\""
+msgstr[0] "%{count} tulemus päringule «%{query}»"
+msgstr[1] "%{count} tulemust päringule «%{query}»"
+
+msgid "%{count} PDFs"
+msgid_plural "%{count} PDFs"
+msgstr[0] "%{count} PDF"
+msgstr[1] "%{count} PDF-faili"
+
+msgid "%{count} events"
+msgid_plural "%{count} events"
+msgstr[0] "%{count} sündmus"
+msgstr[1] "%{count} sündmust"
+
+msgid "%{count} pages"
+msgid_plural "%{count} pages"
+msgstr[0] "%{count} leht"
+msgstr[1] "%{count} lehte"
+
+msgid "%{count} selected"
+msgid_plural "%{count} selected"
+msgstr[0] "%{count} valitud"
+msgstr[1] "%{count} valitud"
+
+msgid "Deleted %{count} categories."
+msgstr "Kustutati %{count} kategooriat."
+
+msgid "Deleted %{count} items."
+msgstr "Kustutati %{count} toodet."
+
+msgid "Restored %{count} categories."
+msgstr "Taastati %{count} kategooriat."
+
+msgid "Restored %{count} items."
+msgstr "Taastati %{count} toodet."
+
+msgid "Moved %{count} items."
+msgstr "Teisaldati %{count} toodet."
+
+msgid "Permanently deleted %{count} items."
+msgstr "Jäädavalt kustutati %{count} toodet."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -1,0 +1,789 @@
+## "default" domain translations for ru locale.
+msgid ""
+msgstr ""
+"Language: ru\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+## Tab labels
+msgid "Catalogue"
+msgstr "Каталог"
+
+msgid "Catalogues"
+msgstr "Каталоги"
+
+msgid "Manufacturers"
+msgstr "Производители"
+
+msgid "Suppliers"
+msgstr "Поставщики"
+
+msgid "Import"
+msgstr "Импорт"
+
+msgid "Events"
+msgstr "События"
+
+msgid "PDFs"
+msgstr "PDF-файлы"
+
+msgid "PDF"
+msgstr "PDF"
+
+msgid "New Catalogue"
+msgstr "Новый каталог"
+
+msgid "Edit Catalogue"
+msgstr "Редактировать каталог"
+
+msgid "New Manufacturer"
+msgstr "Новый производитель"
+
+msgid "Edit Manufacturer"
+msgstr "Редактировать производителя"
+
+msgid "New Supplier"
+msgstr "Новый поставщик"
+
+msgid "Edit Supplier"
+msgstr "Редактировать поставщика"
+
+msgid "New Category"
+msgstr "Новая категория"
+
+msgid "Edit Category"
+msgstr "Редактировать категорию"
+
+msgid "New Item"
+msgstr "Новая позиция"
+
+msgid "Edit Item"
+msgstr "Редактировать позицию"
+
+## Page titles
+msgid "Edit %{name}"
+msgstr "Редактировать: %{name}"
+
+msgid "Create a new product catalogue to organize categories and items."
+msgstr "Создайте новый каталог для организации категорий и позиций."
+
+msgid "Update catalogue details and settings."
+msgstr "Обновите детали и настройки каталога."
+
+msgid "Add a new manufacturer to your catalogue system."
+msgstr "Добавьте нового производителя в систему каталогов."
+
+msgid "Update manufacturer details and supplier links."
+msgstr "Обновите данные производителя и связанных поставщиков."
+
+msgid "Add a new supplier to your catalogue system."
+msgstr "Добавьте нового поставщика в систему каталогов."
+
+msgid "Update supplier details and manufacturer links."
+msgstr "Обновите данные поставщика и связанных производителей."
+
+msgid "Add a new category to organize items within this catalogue."
+msgstr "Добавьте новую категорию для организации позиций в каталоге."
+
+msgid "Update category details and ordering."
+msgstr "Обновите детали категории и порядок сортировки."
+
+msgid "Create a new category — fill in the details below"
+msgstr "Создайте новую категорию — заполните поля ниже"
+
+## Status labels
+msgid "Active"
+msgstr "Активен"
+
+msgid "Inactive"
+msgstr "Неактивен"
+
+msgid "Archived"
+msgstr "Архивирован"
+
+msgid "Deleted"
+msgstr "Удалён"
+
+msgid "Discontinued"
+msgstr "Снят с производства"
+
+msgid "Unknown"
+msgstr "Неизвестно"
+
+## PDF status labels
+msgid "Pending"
+msgstr "В очереди"
+
+msgid "Extracting"
+msgstr "Извлечение текста"
+
+msgid "Extracted"
+msgstr "Текст извлечён"
+
+msgid "Scanned (no text)"
+msgstr "Отсканирован (без текста)"
+
+msgid "Failed"
+msgstr "Ошибка"
+
+## Metadata field labels
+msgid "Color"
+msgstr "Цвет"
+
+msgid "Weight"
+msgstr "Вес"
+
+msgid "Width"
+msgstr "Ширина"
+
+msgid "Height"
+msgstr "Высота"
+
+msgid "Depth"
+msgstr "Глубина"
+
+msgid "Material"
+msgstr "Материал"
+
+msgid "Finish"
+msgstr "Отделка"
+
+msgid "Brand"
+msgstr "Бренд"
+
+msgid "Collection"
+msgstr "Коллекция"
+
+msgid "Season"
+msgstr "Сезон"
+
+msgid "Region"
+msgstr "Регион"
+
+msgid "Vendor Reference"
+msgstr "Артикул поставщика"
+
+## Error messages
+msgid "Cannot move a category under itself or one of its descendants."
+msgstr "Нельзя переместить категорию в саму себя или в одного из её потомков."
+
+msgid "Target belongs to a different catalogue. Move the category to the target catalogue first."
+msgstr "Цель принадлежит другому каталогу. Сначала переместите категорию в целевой каталог."
+
+msgid "Parent category not found."
+msgstr "Родительская категория не найдена."
+
+msgid "Categories must share the same parent to be reordered."
+msgstr "Для изменения порядка категории должны иметь одного родителя."
+
+msgid "Category not found."
+msgstr "Категория не найдена."
+
+msgid "Catalogue not found."
+msgstr "Каталог не найден."
+
+msgid "Item is already in this catalogue."
+msgstr "Позиция уже находится в этом каталоге."
+
+msgid "You must be logged in to upload files."
+msgstr "Для загрузки файлов необходимо войти в систему."
+
+msgid "Unsupported file format."
+msgstr "Неподдерживаемый формат файла."
+
+msgid "Unsupported file format. Please upload .xlsx or .csv."
+msgstr "Неподдерживаемый формат. Загрузите файл .xlsx или .csv."
+
+msgid "Not found."
+msgstr "Не найдено."
+
+msgid "Missing item name."
+msgstr "Отсутствует название позиции."
+
+msgid "CSV file is empty."
+msgstr "CSV-файл пуст."
+
+msgid "Cannot restore — the parent catalogue is deleted. Restore the catalogue first."
+msgstr "Невозможно восстановить — родительский каталог удалён. Сначала восстановите каталог."
+
+msgid "Cannot delete: %{count} smart items still reference this catalogue."
+msgstr "Невозможно удалить: %{count} смарт-позиций ссылаются на этот каталог."
+
+msgid "Each catalogue can only be referenced once per item."
+msgstr "Каждый каталог может быть указан в позиции только один раз."
+
+msgid "Invalid price: %{raw}"
+msgstr "Некорректная цена: %{raw}"
+
+msgid "Invalid markup: %{raw}"
+msgstr "Некорректная наценка: %{raw}"
+
+msgid "Sheet '%{sheet}' is empty."
+msgstr "Лист «%{sheet}» пуст."
+
+msgid "Failed to read sheet '%{sheet}'."
+msgstr "Не удалось прочитать лист «%{sheet}»."
+
+msgid "Failed to open XLSX file."
+msgstr "Не удалось открыть файл XLSX."
+
+msgid "Failed to read XLSX file."
+msgstr "Не удалось прочитать файл XLSX."
+
+msgid "Failed to parse CSV file."
+msgstr "Не удалось разобрать файл CSV."
+
+msgid "Unexpected error: %{reason}"
+msgstr "Неожиданная ошибка: %{reason}"
+
+## Time-ago strings
+msgid "just now"
+msgstr "только что"
+
+msgid "%{n}m ago"
+msgstr "%{n} мин. назад"
+
+msgid "%{n}h ago"
+msgstr "%{n} ч. назад"
+
+msgid "%{n}d ago"
+msgstr "%{n} дн. назад"
+
+msgid "%b %d, %Y"
+msgstr "%d.%m.%Y"
+
+## Flash messages
+msgid "Catalogue created."
+msgstr "Каталог создан."
+
+msgid "Catalogue updated."
+msgstr "Каталог обновлён."
+
+msgid "Catalogue moved to deleted."
+msgstr "Каталог перемещён в удалённые."
+
+msgid "Catalogue restored."
+msgstr "Каталог восстановлен."
+
+msgid "Catalogue permanently deleted."
+msgstr "Каталог удалён окончательно."
+
+msgid "Manufacturer created."
+msgstr "Производитель создан."
+
+msgid "Manufacturer not found."
+msgstr "Производитель не найден."
+
+msgid "Manufacturer updated."
+msgstr "Производитель обновлён."
+
+msgid "Supplier created."
+msgstr "Поставщик создан."
+
+msgid "Supplier not found."
+msgstr "Поставщик не найден."
+
+msgid "Supplier updated."
+msgstr "Поставщик обновлён."
+
+msgid "Category created."
+msgstr "Категория создана."
+
+msgid "Category updated."
+msgstr "Категория обновлена."
+
+msgid "Category moved to deleted."
+msgstr "Категория перемещена в удалённые."
+
+msgid "Category restored."
+msgstr "Категория восстановлена."
+
+msgid "Category permanently deleted."
+msgstr "Категория удалена окончательно."
+
+msgid "Category moved."
+msgstr "Категория перемещена."
+
+msgid "Category moved to another catalogue."
+msgstr "Категория перемещена в другой каталог."
+
+msgid "Item created."
+msgstr "Позиция создана."
+
+msgid "Item updated."
+msgstr "Позиция обновлена."
+
+msgid "Item moved to deleted."
+msgstr "Позиция перемещена в удалённые."
+
+msgid "Item restored."
+msgstr "Позиция восстановлена."
+
+msgid "Item permanently deleted."
+msgstr "Позиция удалена окончательно."
+
+msgid "Item moved."
+msgstr "Позиция перемещена."
+
+msgid "Item not found."
+msgstr "Позиция не найдена."
+
+msgid "Failed to delete catalogue."
+msgstr "Не удалось удалить каталог."
+
+msgid "Failed to delete category."
+msgstr "Не удалось удалить категорию."
+
+msgid "Failed to delete categories."
+msgstr "Не удалось удалить категории."
+
+msgid "Failed to delete item."
+msgstr "Не удалось удалить позицию."
+
+msgid "Failed to delete manufacturer."
+msgstr "Не удалось удалить производителя."
+
+msgid "Failed to delete supplier."
+msgstr "Не удалось удалить поставщика."
+
+msgid "Failed to move category."
+msgstr "Не удалось переместить категорию."
+
+msgid "Failed to move item."
+msgstr "Не удалось переместить позицию."
+
+msgid "Failed to reorder categories."
+msgstr "Не удалось изменить порядок категорий."
+
+msgid "Failed to reorder items."
+msgstr "Не удалось изменить порядок позиций."
+
+msgid "Failed to restore catalogue."
+msgstr "Не удалось восстановить каталог."
+
+msgid "Failed to restore category."
+msgstr "Не удалось восстановить категорию."
+
+msgid "Failed to restore item."
+msgstr "Не удалось восстановить позицию."
+
+msgid "Failed to save the new order."
+msgstr "Не удалось сохранить новый порядок."
+
+msgid "PDF moved to trash."
+msgstr "PDF перемещён в корзину."
+
+msgid "PDF permanently deleted."
+msgstr "PDF удалён окончательно."
+
+msgid "PDF restored."
+msgstr "PDF восстановлен."
+
+msgid "PDF not found."
+msgstr "PDF не найден."
+
+msgid "Could not move the PDF to trash."
+msgstr "Не удалось переместить PDF в корзину."
+
+msgid "Could not permanently delete the PDF."
+msgstr "Не удалось окончательно удалить PDF."
+
+msgid "Could not restore the PDF."
+msgstr "Не удалось восстановить PDF."
+
+## UI strings
+msgid "Back"
+msgstr "Назад"
+
+msgid "Cancel"
+msgstr "Отмена"
+
+msgid "Save Changes"
+msgstr "Сохранить"
+
+msgid "Delete"
+msgstr "Удалить"
+
+msgid "Restore"
+msgstr "Восстановить"
+
+msgid "Delete Forever"
+msgstr "Удалить навсегда"
+
+msgid "Edit"
+msgstr "Редактировать"
+
+msgid "View"
+msgstr "Просмотр"
+
+msgid "Create Catalogue"
+msgstr "Создать каталог"
+
+msgid "Create Category"
+msgstr "Создать категорию"
+
+msgid "Create Manufacturer"
+msgstr "Создать производителя"
+
+msgid "Create Supplier"
+msgstr "Создать поставщика"
+
+msgid "Create Item"
+msgstr "Создать позицию"
+
+msgid "Add Category"
+msgstr "Добавить категорию"
+
+msgid "Add Item"
+msgstr "Добавить позицию"
+
+msgid "Name"
+msgstr "Название"
+
+msgid "Description"
+msgstr "Описание"
+
+msgid "Status"
+msgstr "Статус"
+
+msgid "Details"
+msgstr "Детали"
+
+msgid "Metadata"
+msgstr "Метаданные"
+
+msgid "Files"
+msgstr "Файлы"
+
+msgid "Notes"
+msgstr "Заметки"
+
+msgid "Actions"
+msgstr "Действия"
+
+msgid "Search..."
+msgstr "Поиск..."
+
+msgid "Search items..."
+msgstr "Поиск позиций..."
+
+msgid "Upload"
+msgstr "Загрузить"
+
+msgid "Download"
+msgstr "Скачать"
+
+msgid "Move"
+msgstr "Переместить"
+
+msgid "Position"
+msgstr "Позиция"
+
+msgid "Confirm"
+msgstr "Подтвердить"
+
+msgid "Loading..."
+msgstr "Загрузка..."
+
+msgid "Saving..."
+msgstr "Сохранение..."
+
+msgid "Deleting..."
+msgstr "Удаление..."
+
+msgid "Featured Image"
+msgstr "Главное изображение"
+
+msgid "No featured image set."
+msgstr "Главное изображение не задано."
+
+msgid "Change"
+msgstr "Изменить"
+
+msgid "Remove"
+msgstr "Удалить"
+
+msgid "Set featured image"
+msgstr "Задать главное изображение"
+
+msgid "Open original"
+msgstr "Открыть оригинал"
+
+msgid "Add metadata"
+msgstr "Добавить метаданные"
+
+msgid "— Pick a field —"
+msgstr "— Выберите поле —"
+
+msgid "Legacy"
+msgstr "Устаревшее"
+
+msgid "Attached Files"
+msgstr "Прикреплённые файлы"
+
+msgid "No files attached yet."
+msgstr "Файлы ещё не прикреплены."
+
+msgid "Drag file here or click to browse"
+msgstr "Перетащите файл или нажмите для выбора"
+
+msgid "Click to upload"
+msgstr "Нажмите для загрузки"
+
+msgid "or drag & drop"
+msgstr "или перетащите"
+
+msgid "File is too large (max 10MB)"
+msgstr "Файл слишком большой (макс. 10 МБ)"
+
+msgid "File type not accepted."
+msgstr "Тип файла не поддерживается."
+
+msgid "Only PDF files are accepted."
+msgstr "Принимаются только PDF-файлы."
+
+msgid "Category"
+msgstr "Категория"
+
+msgid "Categories"
+msgstr "Категории"
+
+msgid "Manufacturer"
+msgstr "Производитель"
+
+msgid "Supplier"
+msgstr "Поставщик"
+
+msgid "Item"
+msgstr "Позиция"
+
+msgid "Items"
+msgstr "Позиции"
+
+msgid "SKU"
+msgstr "Артикул"
+
+msgid "Price"
+msgstr "Цена"
+
+msgid "Base Price"
+msgstr "Базовая цена"
+
+msgid "Final Price"
+msgstr "Итоговая цена"
+
+msgid "Unit"
+msgstr "Единица"
+
+msgid "Unit of Measure"
+msgstr "Единица измерения"
+
+msgid "Kind"
+msgstr "Тип"
+
+msgid "Smart"
+msgstr "Смарт"
+
+msgid "Standard — items priced directly"
+msgstr "Стандартный — позиции с прямыми ценами"
+
+msgid "Smart — items reference other catalogues"
+msgstr "Смарт — позиции ссылаются на другие каталоги"
+
+msgid "Markup %"
+msgstr "Наценка %"
+
+msgid "Discount"
+msgstr "Скидка"
+
+msgid "Table view"
+msgstr "Таблица"
+
+msgid "Card view"
+msgstr "Карточки"
+
+msgid "Clear"
+msgstr "Очистить"
+
+msgid "Clear all"
+msgstr "Очистить всё"
+
+msgid "Trash"
+msgstr "Корзина"
+
+msgid "Trash is empty."
+msgstr "Корзина пуста."
+
+msgid "No catalogues yet."
+msgstr "Каталоги ещё не созданы."
+
+msgid "No categories yet. Add one to start organizing items."
+msgstr "Категорий пока нет. Добавьте категорию для организации позиций."
+
+msgid "No manufacturers yet."
+msgstr "Производители ещё не добавлены."
+
+msgid "No suppliers yet."
+msgstr "Поставщики ещё не добавлены."
+
+msgid "No items found"
+msgstr "Позиции не найдены"
+
+msgid "No events recorded yet"
+msgstr "События ещё не зафиксированы"
+
+msgid "No PDFs uploaded yet."
+msgstr "PDF-файлы ещё не загружены."
+
+msgid "Upload PDF"
+msgstr "Загрузить PDF"
+
+msgid "PDF library"
+msgstr "Библиотека PDF"
+
+msgid "PDF search"
+msgstr "Поиск в PDF"
+
+msgid "Find this item in PDFs"
+msgstr "Найти позицию в PDF"
+
+msgid "Pages"
+msgstr "Страницы"
+
+msgid "Import Complete"
+msgstr "Импорт завершён"
+
+msgid "Import Another"
+msgstr "Импортировать ещё"
+
+msgid "Confirm Import"
+msgstr "Подтвердить импорт"
+
+msgid "Back to Mapping"
+msgstr "Назад к маппингу"
+
+msgid "Import Items"
+msgstr "Импорт позиций"
+
+msgid "Map Columns"
+msgstr "Сопоставление столбцов"
+
+msgid "All events loaded"
+msgstr "Все события загружены"
+
+msgid "Danger Zone"
+msgstr "Опасная зона"
+
+msgid "Permanently Delete Catalogue"
+msgstr "Удалить каталог навсегда"
+
+msgid "Permanently Delete Category"
+msgstr "Удалить категорию навсегда"
+
+msgid "Permanently Delete Item"
+msgstr "Удалить позицию навсегда"
+
+msgid "Created"
+msgstr "Создан"
+
+msgid "Updated"
+msgstr "Обновлён"
+
+msgid "Uncategorized"
+msgstr "Без категории"
+
+msgid "Linked Manufacturers"
+msgstr "Связанные производители"
+
+msgid "Linked Suppliers"
+msgstr "Связанные поставщики"
+
+msgid "Scope"
+msgstr "Область"
+
+msgid "Catalogue Rules"
+msgstr "Правила каталога"
+
+msgid "View Catalogue"
+msgstr "Открыть каталог"
+
+msgid "View details"
+msgstr "Подробнее"
+
+msgid "Back to library"
+msgstr "В библиотеку"
+
+msgid "Search PDFs"
+msgstr "Поиск в PDF"
+
+## Plural forms (Russian: 3 forms)
+msgid "%{count} item"
+msgid_plural "%{count} items"
+msgstr[0] "%{count} позиция"
+msgstr[1] "%{count} позиции"
+msgstr[2] "%{count} позиций"
+
+msgid "%{count} category"
+msgid_plural "%{count} categories"
+msgstr[0] "%{count} категория"
+msgstr[1] "%{count} категории"
+msgstr[2] "%{count} категорий"
+
+msgid "%{count} catalogue"
+msgid_plural "%{count} catalogues"
+msgstr[0] "%{count} каталог"
+msgstr[1] "%{count} каталога"
+msgstr[2] "%{count} каталогов"
+
+msgid "%{active} of %{total} catalogue selected"
+msgid_plural "%{active} of %{total} catalogues selected"
+msgstr[0] "Выбран %{active} из %{total} каталога"
+msgstr[1] "Выбрано %{active} из %{total} каталогов"
+msgstr[2] "Выбрано %{active} из %{total} каталогов"
+
+msgid "%{count} result for \"%{query}\""
+msgid_plural "%{count} results for \"%{query}\""
+msgstr[0] "%{count} результат по запросу «%{query}»"
+msgstr[1] "%{count} результата по запросу «%{query}»"
+msgstr[2] "%{count} результатов по запросу «%{query}»"
+
+msgid "%{count} PDFs"
+msgid_plural "%{count} PDFs"
+msgstr[0] "%{count} PDF"
+msgstr[1] "%{count} PDF"
+msgstr[2] "%{count} PDF"
+
+msgid "%{count} events"
+msgid_plural "%{count} events"
+msgstr[0] "%{count} событие"
+msgstr[1] "%{count} события"
+msgstr[2] "%{count} событий"
+
+msgid "%{count} pages"
+msgid_plural "%{count} pages"
+msgstr[0] "%{count} страница"
+msgstr[1] "%{count} страницы"
+msgstr[2] "%{count} страниц"
+
+msgid "%{count} selected"
+msgid_plural "%{count} selected"
+msgstr[0] "%{count} выбран"
+msgstr[1] "%{count} выбрано"
+msgstr[2] "%{count} выбрано"
+
+msgid "Deleted %{count} categories."
+msgstr "Удалено %{count} категорий."
+
+msgid "Deleted %{count} items."
+msgstr "Удалено %{count} позиций."
+
+msgid "Restored %{count} categories."
+msgstr "Восстановлено %{count} категорий."
+
+msgid "Restored %{count} items."
+msgstr "Восстановлено %{count} позиций."
+
+msgid "Moved %{count} items."
+msgstr "Перемещено %{count} позиций."
+
+msgid "Permanently deleted %{count} items."
+msgstr "Окончательно удалено %{count} позиций."

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -1,0 +1,63 @@
+defmodule PhoenixKitCatalogue.GettextTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Dashboard.Tab
+
+  test "PhoenixKitCatalogue.Gettext compiles and is a valid gettext backend" do
+    assert Code.ensure_loaded?(PhoenixKitCatalogue.Gettext)
+  end
+
+  test "Tab.localized_label/1 returns Russian translation for Catalogue" do
+    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "ru")
+
+    tab = %Tab{
+      id: :admin_catalogue,
+      label: "Catalogue",
+      gettext_backend: PhoenixKitCatalogue.Gettext,
+      gettext_domain: "default"
+    }
+
+    assert Tab.localized_label(tab) == "Каталог"
+  after
+    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "en")
+  end
+
+  test "Tab.localized_label/1 returns Estonian translation for Catalogue" do
+    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "et")
+
+    tab = %Tab{
+      id: :admin_catalogue,
+      label: "Catalogue",
+      gettext_backend: PhoenixKitCatalogue.Gettext,
+      gettext_domain: "default"
+    }
+
+    assert Tab.localized_label(tab) == "Kataloog"
+  after
+    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "en")
+  end
+
+  test "Tab.localized_label/1 falls back to raw label when no gettext_backend set" do
+    tab = %Tab{
+      id: :admin_catalogue,
+      label: "Catalogue"
+    }
+
+    assert Tab.localized_label(tab) == "Catalogue"
+  end
+
+  test "Tab.localized_label/1 falls back to msgid when translation is missing" do
+    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "ru")
+
+    tab = %Tab{
+      id: :admin_unknown,
+      label: "This string has no translation",
+      gettext_backend: PhoenixKitCatalogue.Gettext,
+      gettext_domain: "default"
+    }
+
+    assert Tab.localized_label(tab) == "This string has no translation"
+  after
+    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "en")
+  end
+end


### PR DESCRIPTION
## Summary

Migrates the module from the host app's `PhoenixKitWeb.Gettext` to a module-owned `PhoenixKitCatalogue.Gettext` backend, per the per-module-i18n guide in `phoenix_kit`.

- New backend `lib/phoenix_kit_catalogue/gettext.ex`.
- All 16 files in `lib/` swapped from `PhoenixKitWeb.Gettext` → `PhoenixKitCatalogue.Gettext` (verified via `grep -rn "PhoenixKitWeb.Gettext" lib/` → 0 hits).
- All 19 `%Tab{}` registrations in `lib/phoenix_kit_catalogue.ex` annotated with `gettext_backend: PhoenixKitCatalogue.Gettext, gettext_domain: "default"`.
- `priv/gettext/{en,ru,et}/LC_MESSAGES/default.po` — 259 msgids each. EN is 1:1 fallback; RU with 3 CLDR plural forms; ET with 2 plural forms. Placeholders (`%{name}`, `%{count}`, etc.) verified preserved across all msgstrs.
- `test/gettext_test.exs` smoke test (5 cases): backend compiles, RU/ET resolution via `Tab.localized_label/1`, fallback when no backend, fallback for untranslated msgid.
- Version `0.1.17` → `0.2.0`. CHANGELOG entry added.

## Notes

- `mix.exs` still pins `{:phoenix_kit, "~> 1.7"}`. Bump to `"~> 1.8"` once the core release with the `gettext_backend` / `localized_label/1` API is published to Hex.
- `.pot` / `.po` files are maintained manually because the codebase calls `Gettext.gettext(Backend, "msg")` explicitly rather than via the `use Gettext` macro form, so `mix gettext.extract` does not pick up msgids. Migrating call sites to the macro form is a worthwhile follow-up but out of scope here.

## Test plan

- [x] `mix format --check-formatted` clean
- [x] `grep -rn "PhoenixKitWeb.Gettext" lib/` → empty
- [x] `mix test test/gettext_test.exs` → 5/5 green
- [ ] Visual check in the parent app on `/ru/admin/catalogue` and `/et/admin/catalogue` — tab labels, page titles, status enums, error flashes
- [ ] Verify ngettext plural cases on RU (3-form) for "%{count} result", "%{count} catalogue", "%{count} category", "%{active} of %{total} catalogue selected"

## Pre-existing

`test/web/pdf_library_live_test.exs` has a `with_scope/2 undefined` compile error in `HEAD` (predates this PR), which blocks the full `mix test` suite. Not introduced here.