### PR TITLE
i18n follow-ups: ngettext tests + ET illative fix

### DIFF
--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -167,7 +167,7 @@ msgid "Cannot move a category under itself or one of its descendants."
 msgstr "Kategooriat ei saa enda alla ega oma alamkategooriatesse teisaldada."
 
 msgid "Target belongs to a different catalogue. Move the category to the target catalogue first."
-msgstr "Sihtkoht kuulub teisesse kataloogi. Teisaldage kategooria esmalt sihtkataloogis."
+msgstr "Sihtkoht kuulub teisesse kataloogi. Teisaldage kategooria esmalt sihtkataloogi."
 
 msgid "Parent category not found."
 msgstr "Vanemkategooriat ei leitud."

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -3,6 +3,12 @@ defmodule PhoenixKitCatalogue.GettextTest do
 
   alias PhoenixKit.Dashboard.Tab
 
+  setup do
+    previous = Gettext.get_locale(PhoenixKitCatalogue.Gettext)
+    on_exit(fn -> Gettext.put_locale(PhoenixKitCatalogue.Gettext, previous) end)
+    :ok
+  end
+
   test "PhoenixKitCatalogue.Gettext compiles and is a valid gettext backend" do
     assert Code.ensure_loaded?(PhoenixKitCatalogue.Gettext)
   end
@@ -18,8 +24,6 @@ defmodule PhoenixKitCatalogue.GettextTest do
     }
 
     assert Tab.localized_label(tab) == "Каталог"
-  after
-    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "en")
   end
 
   test "Tab.localized_label/1 returns Estonian translation for Catalogue" do
@@ -33,8 +37,6 @@ defmodule PhoenixKitCatalogue.GettextTest do
     }
 
     assert Tab.localized_label(tab) == "Kataloog"
-  after
-    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "en")
   end
 
   test "Tab.localized_label/1 falls back to raw label when no gettext_backend set" do
@@ -57,7 +59,43 @@ defmodule PhoenixKitCatalogue.GettextTest do
     }
 
     assert Tab.localized_label(tab) == "This string has no translation"
-  after
-    Gettext.put_locale(PhoenixKitCatalogue.Gettext, "en")
+  end
+
+  describe "ngettext plural selection" do
+    test "Russian 3-form rules pick the right msgstr for 1 / 2 / 5 / 21 / 22" do
+      Gettext.put_locale(PhoenixKitCatalogue.Gettext, "ru")
+
+      assert ngettext_item(1) == "1 позиция"
+      assert ngettext_item(2) == "2 позиции"
+      assert ngettext_item(5) == "5 позиций"
+      assert ngettext_item(21) == "21 позиция"
+      assert ngettext_item(22) == "22 позиции"
+    end
+
+    test "Estonian 2-form rules pick singular for 1, plural otherwise" do
+      Gettext.put_locale(PhoenixKitCatalogue.Gettext, "et")
+
+      assert ngettext_item(1) == "1 toode"
+      assert ngettext_item(2) == "2 toodet"
+      assert ngettext_item(5) == "5 toodet"
+    end
+
+    test "English passthrough" do
+      Gettext.put_locale(PhoenixKitCatalogue.Gettext, "en")
+
+      assert ngettext_item(1) == "1 item"
+      assert ngettext_item(5) == "5 items"
+    end
+
+    defp ngettext_item(count) do
+      Gettext.dngettext(
+        PhoenixKitCatalogue.Gettext,
+        "default",
+        "%{count} item",
+        "%{count} items",
+        count,
+        count: count
+      )
+    end
   end
 end


### PR DESCRIPTION
Follow-ups to #26 (per-module gettext migration). Two small things, no scope creep.

## Changes

1. **ngettext plural-form tests** (`test/gettext_test.exs`): new `describe "ngettext plural selection"` block exercising `Gettext.dngettext/6` directly:
   - RU 3-form CLDR rule across counts `1 / 2 / 5 / 21 / 22` (`позиция / позиции / позиций`)
   - ET 2-form `(n != 1)` across counts `1 / 2 / 5` (`toode / toodet`)
   - EN passthrough sanity check
   Also replaces the per-test `after Gettext.put_locale(..., "en")` cleanup with a shared `setup` / `on_exit/1` that captures the previous locale on entry and restores it — avoids hardcoding `"en"` as the assumed baseline.

2. **ET illative fix** (`priv/gettext/et/LC_MESSAGES/default.po`): msgstr for *"Target belongs to a different catalogue. Move the category to the target catalogue first."* changed from `... sihtkataloogis.` (inessive — "in the target catalogue") to `... sihtkataloogi.` (illative — "into the target catalogue"), which is what the verb *teisaldage* takes.

## Test plan

- [x] `mix test test/gettext_test.exs` → 8/8 green
- [x] `mix format --check-formatted` clean
- [x] `grep -n sihtkataloogis priv/gettext/et/LC_MESSAGES/default.po` → empty