### PR TITLE
Catalogue folders, detail drill-down rework, and quality sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a **mature full-featured module** in the PhoenixKit ecosystem; the omiss
 - **No DB migrations of its own** — every schema this module owns is created by versioned migrations in core `phoenix_kit` (V87 catalogue, V89 markup, V96 catalogue_uuid backfill, V97 item markup override, V102 smart catalogues, V103 nested categories). Adding a new column means a phoenix_kit core migration first, then schema + changeset here.
 - **No authorization in the context** — every mutating function in `PhoenixKitCatalogue.Catalogue` accepts an `actor_uuid` only for activity logging. Permission gating happens at the LiveView mount layer via `live_session :phoenix_kit_admin` and the `:catalogue` permission key. Programmatic / IEx callers bypass the gate by design — that's the established phoenix_kit-ecosystem pattern.
 - **No JSONB GIN / pg_trgm search index** — `search_items/2` runs `?::text ILIKE ?` over `Item.data` for the multilang JSONB. Acceptable for the current item volumes; tracked as a perf concern for once a single catalogue exceeds ~50k items.
-- **No background jobs** — the catalogue does not use Oban. Imports run inline in `start_async/1` from the LiveView (see Import System section). The reference / dashboard data flows through PubSub broadcasts on the `"phoenix_kit_catalogue"` topic, not a queue.
+- **Almost no background jobs** — the one exception is the PDF library's `PhoenixKitCatalogue.Workers.PdfExtractor` (Oban queue `:catalogue_pdf`; see PDF library section). Everything else stays inline: imports run in `start_async/1` from the LiveView (see Import System), and reference / dashboard data flows through PubSub broadcasts on the `"phoenix_kit_catalogue"` topic, not a queue.
 - **No HTTP / API surface** — Catalogue is admin-only. No public routes, no JSON endpoints, no webhook receivers. If a consumer needs catalogue data over HTTP, they wire that up in their own host app.
 - **No per-item versioning** — soft-delete (`status: "active" | "deleted"`) is the only history mechanism. Restoring resurrects the row with its current data; we don't keep prior states. The activity log captures every mutation so the audit trail is the version history.
 
@@ -200,43 +200,41 @@ Both catalogue and item forms support a featured image + a folder-scoped file gr
 
 The dropdown is absolutely positioned with `z-50` — the container's ancestors must not clip overflow.
 
-### PDF library (V111, prototype)
+### PDF library (V111)
 
-> **Status: prototype, in development.** First in-flight feature where the catalogue grew background-job and binary-asset surfaces. The full pipeline runs end-to-end (upload → async extract → search → page jump in PDF.js) but several known cuts are deliberate v1 scope (see "Cuts from v1" below). Cross-repo touches in `phoenix_kit` core (V111) and `phoenix_kit_parent` (endpoint static plugs + Oban queue) — see "Resuming the work" at the bottom of this section if the prototype gets re-stashed.
+> **Status: shipped.** Landed in PR #24 (commits `a41b60a` "Add PDF library to catalogue", `b351416` Phase 2 sweep, `7b1094e` precommit cleanup) and is live on `main`. The "no background jobs" and "PDFs deliberately do not go through `phoenix_kit_files`" lines elsewhere in this doc predate it — this feature reversed both. There is no remaining stash; ignore any "Resuming the work" references in older notes.
 
-Admin-facing PDF library at `/admin/catalogue/pdfs` with a per-item "Search PDFs" button on the item edit form. Users upload PDFs of any size; the catalogue extracts per-page text asynchronously via Oban; clicking the button on an item searches the entire library for any of the item's translated names and opens hits in an embedded PDF.js viewer at the matching page.
+Admin-facing PDF library at `/admin/catalogue/pdfs` with a "Search PDFs" trigger on both the item edit form **and** the per-item row dropdown in catalogue detail (`catalogue_detail_live.ex`, `show_pdf_search` event). Users upload PDFs of any size; the catalogue extracts per-page text asynchronously via Oban; the trigger searches the entire library for any of the item's translated names and opens hits in an embedded PDF.js viewer at the matching page.
 
-- **Schemas** (V111 in core, see `phoenix_kit/lib/phoenix_kit/migrations/postgres/v111.ex`):
-  - `phoenix_kit_cat_pdfs` — one row per uploaded PDF. Holds `original_filename`, on-disk `file_path`, `byte_size`, `status`, `page_count`, `extracted_at`, `error_message`. Status flow `pending → extracting → extracted | scanned_no_text | failed`. Deliberately does **not** go through `phoenix_kit_files` — PDFs are non-displayable, large, and have no use for variants/folders/links, so the row owns its file metadata directly. The on-disk filename UUID and the row UUID are generated independently (filename pre-generated at upload time before the row exists); always derive the URL from `pdf.file_path`'s basename, never from `pdf.uuid`.
-  - `phoenix_kit_cat_pdf_pages` — one row per extracted page. UNIQUE on `(pdf_uuid, page_number)`, `ON DELETE CASCADE`. GIN trigram index on `text` (`gin_trgm_ops` from `pg_trgm`, enabled in V111's `up/1`) — load-bearing once the corpus exceeds ~10k pages.
-- **File storage** — uploaded PDFs land in `Application.app_dir(:phoenix_kit_catalogue, "priv/uploads/pdfs/<uuid>.pdf")`. Served by a `Plug.Static` mount on the host endpoint at `/_pdf_uploads/`. PDF.js viewer assets (~1MB, vendored from `pdfjs-dist` v4.10.38) live under `priv/static/pdfjs/`, served at `/_pdfjs/`. Both static plugs are mounts on the host's `endpoint.ex` — see "Resuming the work" for the exact wiring.
-- **Async extraction** — `PhoenixKitCatalogue.Workers.PdfExtractor` is the catalogue's first Oban worker (small pivot from the "no background jobs" line above; phoenix_kit core already provides Oban so it's not new infra). Queue `:catalogue_pdf`, `max_attempts: 3`, recommended host concurrency 2. Reads page count via `pdfinfo`, then runs `pdftotext -layout -enc UTF-8 -f N -l N file -` per page. Page text is normalized at write time: strips soft-hyphens, undoes line-break hyphenation (`Pre-\nmium` → `Premium`), unfolds common ligatures (`ﬁ`, `ﬂ`, `ﬀ`, `ﬃ`, `ﬄ`), collapses whitespace runs to single spaces. If every page comes back empty the row flips to `scanned_no_text` (deliberate signal that OCR is needed; see "Cuts from v1"). Process spawn errors / non-zero pdftotext exits flip to `failed` with a 500-char-truncated stderr.
-- **Context** — `Catalogue.PdfLibrary` submodule. Public surface re-exported via `defdelegate` from `Catalogue`: `list_pdfs/1`, `count_pdfs/1`, `get_pdf/1`, `get_pdf!/1`, `create_pdf/2`, `delete_pdf/2`, `search_pdfs_for_item/2`, `pdf_storage_dir/0`. Worker callbacks (`mark_extracting/1`, `insert_page/3`, `mark_extracted/2`, `mark_scanned_no_text/2`, `mark_failed/2`) are `@doc false` and called only from the worker.
+- **Layered on core `phoenix_kit_files`.** Unlike the original prototype (which owned its own on-disk file metadata), binaries now live in core's `Storage` — core handles bytes, content-checksum dedup, multi-bucket redundancy, and the on-disk lifecycle (`Storage.trash_file/1`, `PruneTrashJob`). The catalogue owns only four small tables (V111 in core, see `phoenix_kit/lib/phoenix_kit/migrations/postgres/v111.ex`):
+  - `phoenix_kit_cat_pdfs` — **per-upload** row ("this name in the library"). `file_uuid` (→ core file), `original_filename`, `byte_size`, `status` (`active` / `trashed`), `trashed_at`. Soft-delete via the `status` sentinel (workspace convention). `file_uuid` FK is `ON DELETE RESTRICT` so core's prune can't remove a file a catalogue row still references.
+  - `phoenix_kit_cat_pdf_extractions` — **per unique file content** (one row per `file_uuid`). Holds the worker state machine in `extraction_status`: `pending → extracting → extracted | scanned_no_text | failed`, plus `page_count`, `extracted_at`, `error_message`.
+  - `phoenix_kit_cat_pdf_pages` — per-page join, keyed by `content_hash`. Write-once (no `updated_at`); re-extraction means delete + re-insert.
+  - `phoenix_kit_cat_pdf_page_contents` — **content-addressed dedup cache**; PK is the SHA-256 hex of the normalized page text. The GIN trigram index (`gin_trgm_ops` from `pg_trgm`) lives **here**, not on the pages join. Insert via `insert_all(on_conflict: :nothing, conflict_target: [:content_hash])`.
+- **Dedup all the way down.** Two uploads of identical content with different filenames produce two `pdfs` rows sharing one `file_uuid`, one extraction, and one set of page rows (core dedupes the file by checksum; the catalogue reuses the existing extraction). Identical page text across different PDFs collapses to one `page_contents` row.
+- **File serving** — raw PDF binary via core's signed-URL path: `Paths.pdf_file/1` → `URLSigner.signed_url(file_uuid, "original")`, routed through the host's `FileController` at `/file/:file_uuid/:variant/:token` (the old `/_pdf_uploads/` Plug.Static mount is gone). PDF.js viewer assets (~1MB, vendored from `pdfjs-dist`) stay under `priv/static/pdfjs/`, served at `/_pdfjs/` via a host `Plug.Static` mount; `Paths.pdf_viewer/1,2` builds `viewer.html?file=<signed>#page=N`, wrapping the signed URL in `URI.encode_www_form` so its `?&=` don't corrupt the `#page` fragment.
+- **Async extraction** — `PhoenixKitCatalogue.Workers.PdfExtractor`, queue `:catalogue_pdf`, `max_attempts: 3`, recommended host concurrency `limit: 2`. Idempotent: re-running on a terminal extraction (`extracted` / `scanned_no_text` / `failed`) no-ops. Reads `pdfinfo` for page count (parse failure fatal → `{:pdfinfo_failed, msg}`), then `pdftotext -layout` per page; normalizes at write time (soft-hyphens, line-break dehyphenation `Pre-\nmium` → `Premium`, ligature unfold `ﬁﬂﬀﬃﬄ`, whitespace collapse), hashes, upserts into `page_contents`. All-empty → `scanned_no_text` (OCR-needed signal). Spawn/non-zero exits → `failed` with `{:pdftotext_failed, page, code, msg}` collapsed to a truncated string in `extraction.error_message`.
+- **Context** — `Catalogue.PdfLibrary` submodule. Public surface re-exported via `defdelegate` from `Catalogue`: `list_pdfs/1`, `count_pdfs/1`, `get_pdf/1`, `get_pdf!/1`, `get_pdf_extraction/1` (as `get_extraction`), `create_pdf_from_upload/3`, `trash_pdf/2`, `restore_pdf/2`, `permanently_delete_pdf/2`, `search_pdfs_for_item/2`, `more_pdf_matches_for_item/3`, `prune_orphan_pdf_page_contents/0` (as `prune_orphan_page_contents`). `create_pdf_from_upload/3` requires a non-nil `:actor_uuid` (core's `phoenix_kit_files.user_uuid` is NOT NULL) — returns `{:error, :missing_actor}` cleanly rather than crashing after writing bytes. Worker callbacks (`mark_extracting/1`, `insert_page/3`, `mark_extracted/2`, `mark_scanned_no_text/2`, `mark_failed/2`) are `@doc false` and called only from the worker.
+- **Soft-delete + permanent-delete** — `trash_pdf/2` flips `status` to `"trashed"` + stamps `trashed_at` (underlying file/extraction/pages untouched); `restore_pdf/2` flips back. `permanently_delete_pdf/2` deletes the row and, **only when no active-or-trashed PDF row still references that `file_uuid`**, hands the file to `Storage.trash_file/1` — the refcount check + handoff run inside a `Repo.transaction(_, isolation: :serializable)` so a concurrent upload can't slip a reference in between the count and the trash. `prune_orphan_page_contents/0` GCs cache rows no page join references.
 - **Search semantics** — `search_pdfs_for_item/2` builds the title list from `item.name` plus every enabled language's `data["translations"][lang]["name"]`, normalises whitespace, dedupes. Two-stage match:
   1. **Literal `ILIKE ANY($titles)`** — fast, precise, returns up to `:limit` (default 50) hits ordered by `(pdf inserted_at DESC, page_number ASC)`.
   2. **Trigram fallback** when literal returns nothing — runs `similarity(text, longest_title) > 0.4` (configurable via `:similarity_threshold` opt) and orders by similarity DESC. The fallback exists because PDF text extraction routinely mangles ligatures, line-break hyphenation, and header/footer noise even after normalisation; literal recall on real PDFs is only ~80%.
   Each hit returns `%{pdf, page_number, snippet, score}`. The 200-char snippet is centred on the first matching title in the page's text (case-insensitive substring match for the window).
 - **PubSub** — every PDF mutation broadcasts `{:catalogue_data_changed, :pdf, uuid, nil}` on the existing `"phoenix_kit_catalogue"` topic. `:pdf` is added to the `kind` typespec in `Catalogue.PubSub`. The library and detail LVs subscribe in `mount/3` (guarded by `connected?/1`) so the worker's status transitions refresh the open page without manual reload.
-- **Search button + modal** — `PhoenixKitCatalogue.Web.Components.PdfSearchModal` LiveComponent, dropped into `ItemFormLive`'s render only when `@action == :edit`. Button click sets `:show_pdf_search` true; modal runs the search on first visible mount via `update/2` (cached per-item-uuid so reopens don't re-query); close button sends `{:pdf_search_modal_closed}` back to the parent LV via `send/2`. Each hit links to `Paths.pdf_detail(pdf_uuid, page_number)` which becomes a query-param URL the detail LV plumbs into the iframe `#page=N` fragment.
-- **Activity logging** — added actions: `pdf.uploaded` (manual, on `create_pdf/2`), `pdf.extracted` (auto, on extraction success with `page_count`), `pdf.scanned_no_text` (auto), `pdf.extraction_failed` (auto, with `error_message`), `pdf.deleted` (manual). All logged via the existing `Catalogue.ActivityLog` `:ok`-only convention.
-- **Errors module** — added atoms: `:pdf_invalid_format`, `:pdf_extraction_failed`, `{:pdftotext_failed, raw}`. Test rows in `test/errors_test.exs` pin each.
+- **Search button + modal** — `PhoenixKitCatalogue.Web.Components.PdfSearchModal` LiveComponent, dropped into `ItemFormLive`'s render when `@action == :edit` and also into `CatalogueDetailLive` (driven by the per-row `show_pdf_search` event + `pdf_search_event` attr on `item_table`). Trigger sets `:show_pdf_search` / `:pdf_search_item`; modal runs the search on first visible mount via `update/2` (cached per-item-uuid so reopens don't re-query); close sends `{:pdf_search_modal_closed}` back to the parent LV via `send/2`. Each hit links to `Paths.pdf_detail(pdf_uuid, page_number)` which the detail LV plumbs into the viewer `#page=N` fragment.
+- **Activity logging** — actions: `pdf.uploaded` (manual, on `create_pdf_from_upload/3`), `pdf.extracted` (auto, on extraction success with `page_count`), `pdf.scanned_no_text` (auto), `pdf.extraction_failed` (auto, with `error_message`), `pdf.trashed` / `pdf.restored` / `pdf.permanently_deleted` (manual). All logged via the `Catalogue.ActivityLog` `:ok`-only convention.
+- **Errors module** — the prototype's `:pdf_invalid_format` / `:pdf_extraction_failed` / `{:pdftotext_failed, raw}` atoms were **removed in the 2026-05-06 Phase 2 sweep** (no callers: the LV's upload `accept` rejects non-PDF MIME, and the worker stores its raw error inline in `extraction.error_message` rather than routing through `Errors`). See the removal note at the top of `errors.ex`.
 
-**Cuts from v1 (deliberate)** — none of the below was implemented; each is a clean follow-up rather than throwaway work:
+**Remaining deferred work (deliberate cuts)** — each is a clean follow-up rather than throwaway work:
 
-- **OCR fallback** for scanned PDFs. The `scanned_no_text` status badge is the user-visible signal; integrating Tesseract via port (`tesseract input.pdf - -l eng`) is the right shape but adds 1–5s/page and external-binary dependency.
-- **Re-extraction UI** — current flow is delete + re-upload. Re-extract button on the detail page is a 10-line addition once needed.
-- **Per-catalogue scoping** — the library is global; the search button searches across all PDFs. If catalogues become reference-doc silos, add a `catalogue_uuid` FK on `phoenix_kit_cat_pdfs` and gate the search.
-- **AI / embeddings** — the per-page text rows are intentionally a clean shape for an embeddings pipeline. The `text` column doubles as input to a future `phoenix_kit_cat_pdf_embeddings(page_uuid, vector)` table.
-- **Search-click activity log** — search button clicks are not logged. Would be noisy and aren't audit-worthy at this stage.
-- **File size cap** — soft cap at 200MB in the LV upload config; no server-side enforcement beyond that. Server-side cap would live as a Setting once needed.
-- **Search button on item table rows** — only on the item edit form for v1; adding it to `item_table` rows on the catalogue detail / search results is straightforward but adds visual noise to a row-dense UI.
+- **OCR fallback** for scanned PDFs. The `scanned_no_text` status is the user-visible signal (`PdfDetailLive` surfaces "OCR support is planned"); integrating Tesseract via port (`tesseract input.pdf - -l eng`) is the right shape but adds 1–5s/page and an external-binary dependency.
+- **Re-extraction UI** — current flow is delete + re-upload. A re-extract button on the detail page is a small addition once needed.
+- **Per-catalogue scoping** — the library is global; the search trigger searches across all PDFs. If catalogues become reference-doc silos, add a `catalogue_uuid` FK on `phoenix_kit_cat_pdfs` and gate the search.
+- **AI / embeddings** — the per-page text rows (`page_contents`) are intentionally a clean shape for an embeddings pipeline; the `text` column doubles as input to a future `phoenix_kit_cat_pdf_embeddings(content_hash, vector)` table.
+- **Search-click activity log** — search-trigger clicks are not logged (noisy, not audit-worthy at this stage).
+- **File size cap** — soft cap in the LV upload config; no server-side enforcement beyond that. A server-side cap would live as a Setting once needed.
 
-**Resuming the work** — this prototype is currently stashed (see git stash list in `phoenix_kit` and `phoenix_kit_catalogue`). To resume:
-
-1. `cd phoenix_kit && git stash pop` — restores the V111 migration and orchestrator bump.
-2. `cd phoenix_kit_catalogue && git stash pop` — restores the schemas, context, worker, LVs, components, errors, vendored PDF.js, and this AGENTS.md section.
-3. Apply the V111 migration: `cd phoenix_kit_parent && mix run -e 'Ecto.Migrator.run(PhoenixKitParent.Repo, [{0, PhoenixKit.Migration}], :up, all: true)'`. The host endpoint already has the two `Plug.Static` mounts (`/_pdfjs`, `/_pdf_uploads`) and the `:catalogue_pdf` Oban queue config — those edits live in `phoenix_kit_parent` and were left unstashed because the parent is disposable.
-4. `cd phoenix_kit_parent && mix phx.server` — boot. Browse to `/phoenix_kit/<locale>/admin/catalogue/pdfs` to upload. Worker fires automatically.
+> **Implemented since the prototype** (no longer cuts): four-table model on top of `phoenix_kit_files`, soft-delete (`active`/`trashed`) + refcount-aware permanent delete, content-addressed page-text dedup cache, and the search trigger on item-table rows in catalogue detail (was edit-form-only in the prototype).
 
 ### Errors API
 
@@ -331,36 +329,117 @@ The `scope_selector/1` component in `web/components.ex` renders a disclosure wit
 - **Routes**: Admin routes auto-generated from `admin_tabs/0`
 - **Paths**: Centralized path helpers in `Paths` module — always use these instead of hardcoding URLs
 
-#### CatalogueDetailLive layout (2026-05-08)
+#### CatalogueDetailLive layout (drill-down, 2026-05-28)
 
-The detail page splits into two scoped tabs reflected into the URL via
-`?tab=items|categories` (`handle_params/3` → `push_patch` from
-`switch_tab`). Default is "items"; unknown values fall back.
+The detail page is a **category drill-down** (replaced the two-tab
+`?tab=items|categories` UI on 2026-05-28 — the boss disliked the tabs).
+The drilled-into node lives in `?category=` (`handle_params/3` →
+`push_patch`, deep-linkable + back-button friendly):
 
-- **Items tab → Active**: streamed cards (one per category + an
-  Uncategorized bucket), infinite-scroll cursor (`@cursor`,
-  `@loaded_cards`, `@has_more`). Category DnD lives only on the
-  Categories tab; items reorder within their category card.
-- **Items tab → Deleted**: flat list ordered by deletion date desc
-  (`Catalogue.list_deleted_items_for_catalogue/2`, capped at 500).
-  No category grouping, no infinite scroll. Restore + Delete Forever
-  per row; restore detaches from any deleted parent.
-- **Categories tab → Active**: depth-indented compact category rows
-  with drag handles (when ≥2 siblings), Edit + Delete actions. The
-  "Delete category" path opens the item-disposition modal when the
-  subtree has any active items.
-- **Categories tab → Deleted**: list of deleted categories with
-  Restore + Delete Forever pill buttons. No item count badge on the
-  row (separate-status: items aren't tied to the category's deleted
-  state in the Categories tab UI).
+- absent → **root level**
+- `?category=uncategorized` → the **uncategorized bucket**
+- `?category=<uuid>` → that **category** (validated against the catalogue;
+  a missing/foreign UUID bounces to root)
 
-The Active/Deleted status switcher is **per-tab**: Items tab shows
-`active_item_count` / `deleted_item_count`; Categories tab shows
-`active_category_count` / `deleted_category_count`. The auto-flip back
-to Active also runs against the per-tab count via
-`maybe_auto_flip_to_active/1` — invoked from `reset_and_load`,
-`refresh_counts`, `refresh_in_place`, and `handle_params` so the user
-never lands in an empty Deleted view of either tab.
+`current_category` resolves to `nil | :uncategorized | %Category{}`.
+Each level renders: a **breadcrumb** (only when drilled in), a scoped
+**search** box (Active mode only), the **Active/Deleted** toggle, the
+direct **child categories** as drill cards, and the current node's own
+**direct items**.
+
+- **Root → Active**: child = root categories (orphan-promoted, see below)
+  as `<.category_drill_card>` + an `<.uncategorized_drill_card>` (when
+  uncategorized items exist). No inline item list at root.
+- **Root → Deleted**: deleted root categories + the deleted uncategorized
+  items inline (root's "own items" are the uncategorized ones).
+- **Inside a category**: breadcrumb `Catalogue ▸ … ▸ <name>`, that
+  category's **subcategories** as drill cards (keep drilling), and its
+  **own direct items** (`list_items_for_category_paged/2`, single
+  `InfiniteScroll` sentinel). DnD reorders the subcategory cards (sibling
+  scope) and the active item list (node scope, see below).
+- **Inside Uncategorized**: breadcrumb `Catalogue ▸ Uncategorized`, no
+  subcategories, the uncategorized items list.
+
+**Per-level Deleted.** The Active/Deleted toggle shows
+`@level_active_count` / `@level_deleted_count` for the *current* node
+(its child categories + its direct items, both modes). `maybe_auto_flip_to_active/1`
+bounces out of an empty Deleted view (keyed on `@level_deleted_count`).
+Deleted drill cards stay clickable so you can drill the deleted subtree;
+`view_mode` persists in socket state across the patch.
+
+**Search scope** follows the level: root → `search_items_in_catalogue/3`;
+category → `search_items_in_category/3` (subtree); uncategorized →
+`search_items(only: :uncategorized_only)`. Search is **Active-mode only**
+(the context search excludes deleted rows), so the input hides in Deleted
+view.
+
+**Orphan reachability.** Child categories come from the new
+`Catalogue.list_child_categories/3`. In `:active` mode it reuses
+`list_category_tree/2`'s orphan promotion (shared `normalized_category_rows/3`
+helper) so a category restored under a still-trashed parent
+(`restore_category/2` is non-cascading by design) still surfaces at the
+root level — a strict direct-children query would strand it. The Active
+breadcrumb is likewise trimmed to its contiguous active-ancestor chain so
+it never links a deleted ancestor. `category_uuids_with_children/2` marks
+cards that have subcategories.
+
+Loading: `reset_and_load/1` (full reload, item offset → 0) and
+`refresh_counts/1` / `refresh_in_place/1` (PubSub + post-mutation,
+offset-preserving) both funnel through `load_level/2`.
+
+#### Active item list — core List-UI toolkit (2026-05-28)
+
+The **active** item list (`level_items/1` active branch) uses the core
+`phoenix_kit` List-UI toolkit, mirroring `phoenix_kit_projects`' Tasks
+page — a sort dropdown, client-side bulk-select with a floating actions
+toolbar, DnD reorder, and a strategy **Reorder** modal. The **Deleted**
+list and **search results** stay on the plain `<.item_table>` (no
+reorder).
+
+- **Sort.** `<.sort_selector ... event="sort_items" manual_field={:position}>`
+  in the toolbar's `:leading` slot + `<.sort_header_cell ... event="toggle_sort_items">`
+  on the name/sku/base_price/status headers. The select sends
+  `%{"sort_by" => …}`, the arrow `%{"sort_dir" => …}`, the headers
+  `%{"by" => field}`; the handler derives the missing half from assigns.
+  Fields are whitelisted (`@items_sort_fields`); `apply_items_sort/3`
+  resets `items_offset → 0` and reloads page 1 (else infinite-scroll
+  dupes/gaps). `items_sort_opts/1` threads `:sort_by`/`:sort_dir` into
+  `fetch_card_items/6` → `list_items_for_category_paged/2` /
+  `list_uncategorized_items_paged/2`. Deleted mode passes no sort opts.
+- **Bulk-select (client-side).** `<.bulk_select_scope id={"items-bulk-" <> (@current_category_uuid || "root")}>`
+  re-keys per node so selection can't leak across drills. The
+  `BulkSelectScope` hook pushes captured uuids as `%{"uuids" => […]}`.
+  `<.bulk_actions_toolbar on_bulk_delete="request_bulk_delete_items">`
+  ships Reorder/Delete/Clear; **Move** is a custom `data-bulk-action="request_bulk_move_items"`
+  button in the `:leading` slot (the toolbar has no built-in Move). The
+  bulk handlers (`request_bulk_delete_items` / `request_bulk_move_items`)
+  read `%{"uuids" => …}` via `sanitize_uuids/1` when present, else fall
+  back to the server-side `@selected_items` MapSet (the **Deleted** list
+  still uses server-side select + `toggle_select_item`). Every bulk op
+  ends with `push_event("bulk_select:clear", %{})` (`clear_item_selection/1`)
+  so stale client checkmarks can't persist.
+- **DnD reorder.** `<.sortable_tbody enabled={@items_sort_by == :position and active}>`
+  — drag only in manual mode. The `reorder_items` handler takes scope
+  from **socket** (`@catalogue_uuid` + `normalize_category_uuid(@current_category)`),
+  NOT DOM attrs (core `<.sortable_tbody>` carries no `data-sortable-scope-*`).
+- **Strategy reorder.** `<.reorder_modal id="items-reorder-modal" …>` (kept-in-DOM)
+  opened via the toolbar's `data-bulk-opens-dialog`. `open_items_reorder_modal`
+  captures `sanitize_uuids/1`, collapsing 0–1 uuids to `[]` ("reorder all").
+  `apply_items_reorder` maps the strategy string through the hardcoded
+  `@items_reorder_strategy_map` whitelist (never `String.to_existing_atom`
+  on input) → `Catalogue.reorder_items_by/5` with scope `:all` (captured
+  == `[]`) or the captured uuid list. `:duplicate_positions` flashes
+  "Apply Reorder all first to normalise" (catalogue items default to
+  `position: 0`, so a subset permute on an unreordered scope collides).
+- **Shared cells.** `<.item_pricing_cell>` + `<.item_row_menu>` (in
+  `Web.Components`) render name/sku/sale-price/unit/status and the
+  Edit/Search-PDFs/Delete row menu, reusing the same pricing/markup
+  helpers as `<.item_table>` so the two surfaces don't drift. Pricing
+  via `Catalogue.item_pricing/1`.
+- **Tradeoff.** Card view is dropped on the active list (the toolkit is
+  table-only; mobile uses the horizontal-scroll table). DnD only sees
+  the loaded prefix of a paginated list — **Reorder all** (server-side,
+  reindexes the whole scope) is the robust path for >100-item nodes.
 
 #### Item-disposition modal
 

--- a/dev_docs/pull_requests/2026/25-catalogue-detail-bulk-cross-tab-tabs/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/25-catalogue-detail-bulk-cross-tab-tabs/FOLLOW_UP.md
@@ -1,0 +1,100 @@
+# FOLLOW_UP — PR #25 (Catalogue detail bulk + cross-tab)
+
+Triaged 2026-05-18 against the post-merge state.
+
+The CLAUDE_REVIEW.md already documents a "Follow-up commit (this
+review's scope)" block listing what closed and what was deferred to
+follow-on PRs. Re-verified each closure against current code in this
+sweep.
+
+## Fixed (pre-existing — closed by the review's own follow-up commit)
+
+- ~~#1 (HIGH) — `restore_category/2` docstring rewritten~~ to match
+  the no-cascade behaviour, mirroring the rewritten `restore_item/2`
+  shape. Describes the no-cascade rule, the `:parent_catalogue_deleted`
+  refusal, and that descendants / ancestors / items keep their
+  statuses.
+- ~~#2 (MEDIUM) — `bulk_restore_items/2` wrapped in
+  `repo().transaction/1`~~. Body extracted to
+  `do_bulk_restore_items/1` (`catalogue.ex:3115`); read +
+  partition + writes now live in one transaction so the TOCTOU
+  window vs `category.status` flips is closed. Verified at
+  `catalogue.ex:3092-3097`.
+- ~~#5 (LOW) — `do_bulk_move/4` filters `i.status != "deleted"`~~ on
+  both clauses, restoring surface consistency with the other bulk
+  fns and defending against a stale tab submitting a deleted UUID.
+- ~~#6 (LOW) — `_scopes` payload dropped~~ from
+  `broadcast_bulk_change`, which is now `/4` (was `/5`) — verified
+  at `pub_sub.ex:163`. Receivers were already discarding the field
+  via `_scopes`; the receiver-side `reset_and_load` semantics are
+  documented on the broadcast fn instead.
+- ~~#7 (NIT) — `loading: false` removed~~ from mount default assigns
+  in `catalogue_detail_live.ex`. Only `search_loading` survives,
+  which is alive. Verified — no bare `loading:` assign in the file.
+
+## Skipped (with rationale)
+
+- **#3 (MEDIUM) — N queries in `build_loaded_cards/5`** — deferred
+  to its own PR per the review's follow-up table. Replacement is a
+  single window-function query (`ROW_NUMBER() OVER (PARTITION BY
+  category_uuid …)`) that touches the `Catalogue` query surface +
+  introduces a new context fn. Real but not urgent at current
+  admin sizes (~10 categories); linear in category count.
+- **#4 (MEDIUM) — PubSub topic is a single global string** —
+  deferred to its own PR. Migration touches `subscribe` + 4
+  broadcast fns + 4 receivers + cross-tab tests, and has a
+  back-compat angle if any external consumer subscribes to the
+  legacy topic. Not a data leak today (the `cat_uuid` filter
+  catches cross-catalogue traffic); the fix is messaging
+  efficiency, not correctness.
+- **#8 (LOW) — redundant `^target_uuid` pin** on the `:move_to`
+  disposition match — stylistic only.
+- **#9 (LOW) — `Process.sleep(1100)` in
+  `list_deleted_items_for_catalogue/2` test** — suite-perf nit;
+  cleanest fix is direct `Repo.update_all` on `updated_at` to
+  fabricate the timestamp gap. Leave for the next test-suite
+  pass.
+- **#10 (LOW) — `:sys.replace_state/2` in `expand_timeout` test**
+  — bypasses the actor model. Acceptable as a test-only workaround
+  for this PR; flagged for the next refactor.
+- **#11 (NIT) — `categories_bulk_bar` and `items_bulk_actions`
+  could be unified** — note: a workspace-shared `<.bulk_actions_bar>`
+  primitive now exists at `phoenix_kit/lib/phoenix_kit_web/components/core/bulk_actions_bar.ex`
+  (added 2026-05-18 as part of the second-pass utility lift). Both
+  catalogue bars could plug into it; tracking as a future migration
+  rather than landing here so the test-touching surface stays
+  small.
+- **#12 (NIT) — `flash_reorder/3` naming** — `push_row_flash/3`
+  would be clearer. Defer.
+
+## Files touched
+
+No new file changes in this triage pass — all closures had already
+been committed by the post-merge follow-up. New entry: the workspace
+gained a `<.bulk_actions_bar>` core component since this PR merged,
+so the #11 unification path is unblocked when someone wants to fold
+it in.
+
+## Verification
+
+Re-verified by code inspection 2026-05-18:
+
+| Check | Result |
+|---|---|
+| `restore_category/2` docstring rewritten | confirmed in `catalogue.ex` |
+| `bulk_restore_items/2` transactional | confirmed at `catalogue.ex:3092-3097` |
+| `do_bulk_move/4` filters `status != "deleted"` | confirmed (multiple sites in `catalogue.ex`) |
+| `broadcast_bulk_change/4` (was `/5`) | confirmed at `pub_sub.ex:163` |
+| `loading: false` removed | confirmed; only `search_loading` remains |
+
+`mix test` not re-run in this sweep — the post-merge tests cover the
+closed paths; no new code introduced here.
+
+## Open
+
+- **#3** — window-function query for `build_loaded_cards/5`. Wants
+  its own PR.
+- **#4** — per-catalogue PubSub topic. Wants its own PR (broadcast
+  + subscribe + receiver edits + cross-tab tests).
+- **#11** — fold catalogue's two bulk bars onto the new core
+  `<.bulk_actions_bar>` when convenient. Test surface modest.

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -790,7 +790,6 @@ defmodule PhoenixKitCatalogue.Catalogue do
     query =
       from(i in Item,
         where: i.category_uuid == ^category_uuid,
-        order_by: [asc: i.position, asc: i.name],
         offset: ^offset,
         limit: ^limit,
         preload: ^preloads
@@ -802,7 +801,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
         :deleted -> where(query, [i], i.status == "deleted")
       end
 
-    repo().all(query)
+    query |> apply_item_order(opts) |> repo().all()
   end
 
   @doc """
@@ -830,7 +829,6 @@ defmodule PhoenixKitCatalogue.Catalogue do
     query =
       from(i in Item,
         where: i.catalogue_uuid == ^catalogue_uuid and is_nil(i.category_uuid),
-        order_by: [asc: i.position, asc: i.name],
         offset: ^offset,
         limit: ^limit,
         preload: ^preloads
@@ -842,8 +840,32 @@ defmodule PhoenixKitCatalogue.Catalogue do
         :deleted -> where(query, [i], i.status == "deleted")
       end
 
-    repo().all(query)
+    query |> apply_item_order(opts) |> repo().all()
   end
+
+  # ── Item sort + strategy reorder ─────────────────────────────────
+
+  # Sortable item columns. `:position` is the manual-order default
+  # (matches the pre-sort behavior); `name` sorts on the raw `name`
+  # column (multilang lives in `data` JSONB, not sorted here).
+  @item_sort_fields ~w(position name sku base_price inserted_at status)a
+
+  # Applies `:sort_by` / `:sort_dir` from `opts` to an Item query. Every
+  # order ends with `asc: i.uuid` so paging is deterministic across ties.
+  defp apply_item_order(query, opts) do
+    sort_by = Keyword.get(opts, :sort_by, :position)
+    sort_dir = if Keyword.get(opts, :sort_dir) == :desc, do: :desc, else: :asc
+    item_order_by(query, sort_by, sort_dir)
+  end
+
+  defp item_order_by(query, :position, _dir),
+    do: order_by(query, [i], asc: i.position, asc: i.name, asc: i.uuid)
+
+  defp item_order_by(query, field, dir) when field in @item_sort_fields,
+    do: order_by(query, [i], [{^dir, field(i, ^field)}, {:asc, i.uuid}])
+
+  defp item_order_by(query, _field, _dir),
+    do: order_by(query, [i], asc: i.position, asc: i.name, asc: i.uuid)
 
   @doc """
   Counts non-deleted uncategorized items for a catalogue (items with
@@ -1894,6 +1916,32 @@ defmodule PhoenixKitCatalogue.Catalogue do
         uuid -> uuid |> Tree.subtree_uuids() |> Enum.map(&load_uuid/1)
       end
 
+    normalized = normalized_category_rows(catalogue_uuid, mode, exclude_uuids)
+    index = Tree.build_children_index(normalized)
+
+    {acc, _} =
+      Enum.reduce(Map.get(index, nil, []), {[], index}, fn root, {acc, idx} ->
+        {collect_tree(root, idx, 0, acc), idx}
+      end)
+
+    Enum.reverse(acc)
+  end
+
+  defp collect_tree(%Category{} = cat, index, depth, acc) do
+    acc = [{cat, depth} | acc]
+
+    index
+    |> Map.get(cat.uuid, [])
+    |> Enum.reduce(acc, fn child, acc -> collect_tree(child, index, depth + 1, acc) end)
+  end
+
+  # Loads the catalogue's categories for `mode`, drops the excluded
+  # subtree, and orphan-promotes rows whose parent is missing from the
+  # set (deleted ancestor in :active mode, or excluded subtree) to roots
+  # by rewriting `parent_uuid` to nil — so they never vanish from the UI.
+  # Shared by `list_category_tree/2` and `list_child_categories/3` so the
+  # drill-down's level view and the flat tree agree on what's a root.
+  defp normalized_category_rows(catalogue_uuid, mode, exclude_uuids) do
     query =
       from(c in Category,
         where: c.catalogue_uuid == ^catalogue_uuid,
@@ -1911,37 +1959,79 @@ defmodule PhoenixKitCatalogue.Catalogue do
       |> repo().all()
       |> Enum.reject(&(&1.uuid in exclude_uuids))
 
-    # Some parents may be missing from the filtered list (deleted
-    # ancestors in :active mode, or excluded subtree). Orphans — rows
-    # whose `parent_uuid` no longer has a matching row in this set —
-    # get surfaced as roots so they don't vanish from the UI.
     uuid_set = MapSet.new(categories, & &1.uuid)
 
-    normalized =
-      Enum.map(categories, fn c ->
-        if c.parent_uuid == nil or MapSet.member?(uuid_set, c.parent_uuid) do
-          c
-        else
-          %{c | parent_uuid: nil}
-        end
-      end)
-
-    index = Tree.build_children_index(normalized)
-
-    {acc, _} =
-      Enum.reduce(Map.get(index, nil, []), {[], index}, fn root, {acc, idx} ->
-        {collect_tree(root, idx, 0, acc), idx}
-      end)
-
-    Enum.reverse(acc)
+    Enum.map(categories, fn c ->
+      if c.parent_uuid == nil or MapSet.member?(uuid_set, c.parent_uuid) do
+        c
+      else
+        %{c | parent_uuid: nil}
+      end
+    end)
   end
 
-  defp collect_tree(%Category{} = cat, index, depth, acc) do
-    acc = [{cat, depth} | acc]
+  @doc """
+  Lists the categories shown at one drill level — the direct children of
+  `parent_uuid` within the catalogue (`nil` = the root level).
 
-    index
-    |> Map.get(cat.uuid, [])
-    |> Enum.reduce(acc, fn child, acc -> collect_tree(child, index, depth + 1, acc) end)
+  In `:active` mode (default) the result reuses `list_category_tree/2`'s
+  orphan promotion: a category whose parent is deleted (e.g. a child
+  restored under a still-trashed parent — `restore_category/2` does not
+  cascade) surfaces at the root level so it stays reachable by
+  drill-down. In `:deleted` mode it returns the strict set of *deleted*
+  direct children (no promotion) — the deleted subtree is navigated by
+  drilling into deleted parents.
+
+  Ordered by `position` then `name`.
+  """
+  @spec list_child_categories(Ecto.UUID.t(), Ecto.UUID.t() | nil, keyword()) :: [Category.t()]
+  def list_child_categories(catalogue_uuid, parent_uuid, opts \\ []) do
+    case Keyword.get(opts, :mode, :active) do
+      :active ->
+        catalogue_uuid
+        |> normalized_category_rows(:active, [])
+        |> Enum.filter(&(&1.parent_uuid == parent_uuid))
+
+      :deleted ->
+        base =
+          from(c in Category,
+            where: c.catalogue_uuid == ^catalogue_uuid and c.status == "deleted",
+            order_by: [asc: :position, asc: :name]
+          )
+
+        query =
+          case parent_uuid do
+            nil -> where(base, [c], is_nil(c.parent_uuid))
+            uuid -> where(base, [c], c.parent_uuid == ^uuid)
+          end
+
+        repo().all(query)
+    end
+  end
+
+  @doc """
+  Returns the set of category UUIDs (within the catalogue, in the given
+  `:mode`) that have at least one child category — lets drill cards show
+  a "has subcategories" affordance without an N+1 per card.
+  """
+  @spec category_uuids_with_children(Ecto.UUID.t(), keyword()) :: MapSet.t()
+  def category_uuids_with_children(catalogue_uuid, opts \\ []) do
+    mode = Keyword.get(opts, :mode, :active)
+
+    query =
+      from(c in Category,
+        where: c.catalogue_uuid == ^catalogue_uuid and not is_nil(c.parent_uuid),
+        select: c.parent_uuid,
+        distinct: true
+      )
+
+    query =
+      case mode do
+        :active -> where(query, [c], c.status != "deleted")
+        :deleted -> query
+      end
+
+    query |> repo().all() |> MapSet.new()
   end
 
   @doc """
@@ -2456,6 +2546,222 @@ defmodule PhoenixKitCatalogue.Catalogue do
     write_item_positions(unique_uuids)
     length(unique_uuids)
   end
+
+  @valid_item_reorder_strategies ~w(name_asc name_desc created_asc created_desc reverse)a
+
+  @doc """
+  Bulk-reorders the items in one `(catalogue_uuid, category_uuid)` scope
+  by a strategy (mirrors `PhoenixKitProjects.reorder_tasks_by/3`).
+
+  `category_uuid` is normalized via `normalize_category_uuid/1` (`nil` /
+  `:uncategorized` → the uncategorized scope). `scope`:
+
+    * `:all` — reindex the whole scope `1..N` in strategy order.
+    * a list of item UUIDs — permute those rows in place into their own
+      (sorted) position slots. Requires distinct positions; otherwise
+      `{:error, :duplicate_positions}` (run an `:all` reorder first to
+      normalise — catalogue items default to `position: 0`).
+
+  Strategies: `:name_asc` / `:name_desc` (raw `name` column),
+  `:created_asc` / `:created_desc`, `:reverse`.
+  """
+  @spec reorder_items_by(
+          Ecto.UUID.t(),
+          Ecto.UUID.t() | :uncategorized | nil,
+          atom(),
+          :all | [Ecto.UUID.t()],
+          keyword()
+        ) ::
+          :ok
+          | {:error,
+             :invalid_strategy
+             | :duplicate_positions
+             | :uuids_outside_scope
+             | :too_many_uuids
+             | term()}
+  def reorder_items_by(catalogue_uuid, category_uuid, strategy, scope, opts \\ [])
+
+  def reorder_items_by(_catalogue_uuid, _category_uuid, strategy, _scope, _opts)
+      when strategy not in @valid_item_reorder_strategies,
+      do: {:error, :invalid_strategy}
+
+  def reorder_items_by(catalogue_uuid, category_uuid, strategy, :all, opts)
+      when is_binary(catalogue_uuid) do
+    cat_uuid = normalize_category_uuid(category_uuid)
+    ordered = catalogue_uuid |> scope_items(cat_uuid) |> item_strategy_order(strategy)
+
+    cond do
+      ordered == [] ->
+        :ok
+
+      length(ordered) > @reorder_max_uuids ->
+        {:error, :too_many_uuids}
+
+      true ->
+        finish_item_reorder_by(
+          repo().transaction(fn -> write_item_positions(ordered) end),
+          catalogue_uuid,
+          cat_uuid,
+          strategy,
+          :all,
+          ordered,
+          opts
+        )
+    end
+  end
+
+  def reorder_items_by(catalogue_uuid, category_uuid, strategy, uuids, opts)
+      when is_binary(catalogue_uuid) and is_list(uuids) do
+    cat_uuid = normalize_category_uuid(category_uuid)
+    unique = Helpers.dedupe_keep_last(uuids)
+
+    if length(unique) > @reorder_max_uuids do
+      {:error, :too_many_uuids}
+    else
+      case item_scope_check(catalogue_uuid, cat_uuid, unique) do
+        :empty -> :ok
+        {:error, :wrong_scope} -> {:error, :uuids_outside_scope}
+        :ok -> permute_items_by(catalogue_uuid, cat_uuid, unique, strategy, opts)
+      end
+    end
+  end
+
+  # Permute the selected rows into their own (sorted) position slots.
+  defp permute_items_by(catalogue_uuid, cat_uuid, unique, strategy, opts) do
+    rows = from(i in Item, where: i.uuid in ^unique) |> repo().all()
+    slots = rows |> Enum.map(& &1.position) |> Enum.sort()
+
+    if slots != Enum.uniq(slots) do
+      {:error, :duplicate_positions}
+    else
+      pairs = Enum.zip(item_strategy_order(rows, strategy), slots)
+
+      finish_item_reorder_by(
+        repo().transaction(fn -> write_item_permutation(pairs) end),
+        catalogue_uuid,
+        cat_uuid,
+        strategy,
+        :selected,
+        Enum.map(pairs, fn {uuid, _} -> uuid end),
+        opts
+      )
+    end
+  end
+
+  defp finish_item_reorder_by({:ok, _}, catalogue_uuid, cat_uuid, strategy, mode, ordered, opts) do
+    log_activity(%{
+      action: "item.reordered",
+      mode: "manual",
+      actor_uuid: opts[:actor_uuid],
+      resource_type: "item",
+      resource_uuid: List.first(ordered),
+      parent_catalogue_uuid: catalogue_uuid,
+      metadata: %{
+        "category_uuid" => cat_uuid,
+        "strategy" => Atom.to_string(strategy),
+        "scope" => Atom.to_string(mode),
+        "count" => length(ordered)
+      }
+    })
+
+    :ok
+  end
+
+  defp finish_item_reorder_by(
+         {:error, reason},
+         catalogue_uuid,
+         cat_uuid,
+         _strategy,
+         _mode,
+         ordered,
+         opts
+       ) do
+    log_reorder_db_error(:item, ordered, catalogue_uuid, opts, category_uuid: cat_uuid)
+    {:error, reason}
+  end
+
+  defp scope_items(catalogue_uuid, nil) do
+    from(i in Item,
+      where:
+        i.catalogue_uuid == ^catalogue_uuid and is_nil(i.category_uuid) and i.status != "deleted"
+    )
+    |> repo().all()
+  end
+
+  defp scope_items(catalogue_uuid, category_uuid) do
+    from(i in Item,
+      where:
+        i.catalogue_uuid == ^catalogue_uuid and i.category_uuid == ^category_uuid and
+          i.status != "deleted"
+    )
+    |> repo().all()
+  end
+
+  # Writes arbitrary {uuid, position} pairs two-phase (negatives, then the
+  # final positives) to dodge transient unique collisions; uuid-sorted
+  # write order is deadlock-safe.
+  defp write_item_permutation(pairs) do
+    write_order = Enum.sort_by(pairs, fn {uuid, _pos} -> uuid end)
+
+    write_order
+    |> Enum.with_index(1)
+    |> Enum.each(fn {{uuid, _pos}, idx} ->
+      from(i in Item, where: i.uuid == ^uuid) |> repo().update_all(set: [position: -idx])
+    end)
+
+    Enum.each(write_order, fn {uuid, pos} ->
+      from(i in Item, where: i.uuid == ^uuid) |> repo().update_all(set: [position: pos])
+    end)
+
+    :ok
+  end
+
+  # Maps rows → uuids in the order a strategy implies. uuid pre-sort is a
+  # stable tiebreaker for equal names / same-second inserts.
+  defp item_strategy_order(rows, :reverse),
+    do: rows |> Enum.sort_by(& &1.position) |> Enum.reverse() |> Enum.map(& &1.uuid)
+
+  defp item_strategy_order(rows, :name_asc),
+    do:
+      rows
+      |> Enum.sort_by(& &1.uuid)
+      |> Enum.sort_by(&downcase_or_empty(&1.name))
+      |> Enum.map(& &1.uuid)
+
+  defp item_strategy_order(rows, :name_desc),
+    do:
+      rows
+      |> Enum.sort_by(& &1.uuid, :desc)
+      |> Enum.sort_by(&downcase_or_empty(&1.name), :desc)
+      |> Enum.map(& &1.uuid)
+
+  defp item_strategy_order(rows, :created_asc),
+    do: rows |> Enum.sort_by(& &1.uuid) |> Enum.sort_by(& &1.inserted_at) |> Enum.map(& &1.uuid)
+
+  defp item_strategy_order(rows, :created_desc),
+    do:
+      rows
+      |> Enum.sort_by(& &1.uuid, :desc)
+      |> Enum.sort_by(& &1.inserted_at, :desc)
+      |> Enum.map(& &1.uuid)
+
+  defp downcase_or_empty(nil), do: ""
+  defp downcase_or_empty(s) when is_binary(s), do: String.downcase(s)
+
+  @doc """
+  Normalizes a node reference to an item `category_uuid`: `nil` /
+  `:uncategorized` / `"uncategorized"` → `nil` (the uncategorized scope);
+  `%Category{}` → its uuid; a uuid string passes through. Shared by the
+  detail LV and `reorder_items_by/5` so the uncategorized bucket always
+  reaches scope checks as `category_uuid: nil`.
+  """
+  @spec normalize_category_uuid(nil | :uncategorized | String.t() | Category.t()) ::
+          Ecto.UUID.t() | nil
+  def normalize_category_uuid(nil), do: nil
+  def normalize_category_uuid(:uncategorized), do: nil
+  def normalize_category_uuid("uncategorized"), do: nil
+  def normalize_category_uuid(%Category{uuid: uuid}), do: uuid
+  def normalize_category_uuid(uuid) when is_binary(uuid), do: uuid
 
   # ═══════════════════════════════════════════════════════════════════
   # Items

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -810,13 +810,25 @@ defmodule PhoenixKitCatalogue.Catalogue do
         preload: ^preloads
       )
 
-    query =
-      case mode do
-        :active -> where(query, [i], i.status != "deleted")
-        :deleted -> where(query, [i], i.status == "deleted")
-      end
+    query |> apply_item_status_filter(opts, mode) |> apply_item_order(opts) |> repo().all()
+  end
 
-    query |> apply_item_order(opts) |> repo().all()
+  # Status filter shared by the item list/count queries. `:status` (an
+  # exact status string like `"discontinued"`) takes precedence and filters
+  # to that one status — used by the detail page's per-status tabs. Without
+  # it, the coarser `:mode` applies: `:deleted` → deleted only, anything
+  # else → all non-deleted (used for the category-card "N items" totals).
+  defp apply_item_status_filter(query, opts, mode) do
+    cond do
+      status = Keyword.get(opts, :status) ->
+        where(query, [i], i.status == ^status)
+
+      mode == :deleted ->
+        where(query, [i], i.status == "deleted")
+
+      true ->
+        where(query, [i], i.status != "deleted")
+    end
   end
 
   @doc """
@@ -849,13 +861,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
         preload: ^preloads
       )
 
-    query =
-      case mode do
-        :active -> where(query, [i], i.status != "deleted")
-        :deleted -> where(query, [i], i.status == "deleted")
-      end
-
-    query |> apply_item_order(opts) |> repo().all()
+    query |> apply_item_status_filter(opts, mode) |> apply_item_order(opts) |> repo().all()
   end
 
   # ── Item sort + strategy reorder ─────────────────────────────────
@@ -896,13 +902,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
         where: i.catalogue_uuid == ^catalogue_uuid and is_nil(i.category_uuid)
       )
 
-    query =
-      case mode do
-        :active -> where(query, [i], i.status != "deleted")
-        :deleted -> where(query, [i], i.status == "deleted")
-      end
-
-    repo().aggregate(query, :count)
+    query |> apply_item_status_filter(opts, mode) |> repo().aggregate(:count)
   end
 
   @doc """
@@ -922,13 +922,40 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
     query = from(i in Item, where: i.category_uuid == ^category_uuid)
 
-    query =
-      case mode do
-        :active -> where(query, [i], i.status != "deleted")
-        :deleted -> where(query, [i], i.status == "deleted")
-      end
+    query |> apply_item_status_filter(opts, mode) |> repo().aggregate(:count)
+  end
 
-    repo().aggregate(query, :count)
+  @doc """
+  Returns `%{status => count}` for the items in a single category, across
+  every status (`"active"`, `"inactive"`, `"discontinued"`, `"deleted"`).
+  One grouped query — drives the detail page's per-status item tabs.
+  Missing statuses are simply absent from the map (treat as 0).
+  """
+  @spec item_status_counts_for_category(Ecto.UUID.t()) :: %{String.t() => non_neg_integer()}
+  def item_status_counts_for_category(category_uuid) do
+    from(i in Item,
+      where: i.category_uuid == ^category_uuid,
+      group_by: i.status,
+      select: {i.status, count(i.uuid)}
+    )
+    |> repo().all()
+    |> Map.new()
+  end
+
+  @doc """
+  `%{status => count}` for a catalogue's uncategorized items (`category_uuid
+  IS NULL`), across every status. Per-status sibling of
+  `uncategorized_count_for_catalogue/2`.
+  """
+  @spec item_status_counts_for_uncategorized(Ecto.UUID.t()) :: %{String.t() => non_neg_integer()}
+  def item_status_counts_for_uncategorized(catalogue_uuid) do
+    from(i in Item,
+      where: i.catalogue_uuid == ^catalogue_uuid and is_nil(i.category_uuid),
+      group_by: i.status,
+      select: {i.status, count(i.uuid)}
+    )
+    |> repo().all()
+    |> Map.new()
   end
 
   @doc """

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -108,6 +108,12 @@ defmodule PhoenixKitCatalogue.Catalogue do
   defp broadcast_for(%{resource_type: "item", resource_uuid: uuid}, parent),
     do: PubSub.broadcast(:item, uuid, parent || lookup_parent(:item, uuid))
 
+  # Folders are module-global, not scoped to a single catalogue, so there's
+  # no parent_catalogue_uuid to thread — the index LV reloads its whole tree
+  # on any :folder event regardless of the parent slot.
+  defp broadcast_for(%{resource_type: "folder", resource_uuid: uuid}, _parent),
+    do: PubSub.broadcast(:folder, uuid)
+
   # Manufacturer/supplier/smart_rule activity rows never reach this
   # helper today — `Manufacturers`, `Suppliers`, and `Rules` call
   # `PubSub.broadcast/3` directly and bypass `log_activity`. Anything
@@ -2330,26 +2336,29 @@ defmodule PhoenixKitCatalogue.Catalogue do
         {:error, :cycle}
 
       true ->
-        with :ok <- validate_target_folder(new_parent) do
-          attrs = %{parent_uuid: new_parent, position: next_folder_position(new_parent)}
+        do_move_folder(folder, new_parent, opts)
+    end
+  end
 
-          with {:ok, updated} <- folder |> Folder.changeset(attrs) |> repo().update() do
-            log_activity(%{
-              action: "folder.moved",
-              mode: "manual",
-              actor_uuid: opts[:actor_uuid],
-              resource_type: "folder",
-              resource_uuid: folder.uuid,
-              metadata: %{
-                "name" => folder.name,
-                "from_parent_uuid" => folder.parent_uuid,
-                "to_parent_uuid" => new_parent
-              }
-            })
+  defp do_move_folder(folder, new_parent, opts) do
+    attrs = %{parent_uuid: new_parent, position: next_folder_position(new_parent)}
 
-            {:ok, updated}
-          end
-        end
+    with :ok <- validate_target_folder(new_parent),
+         {:ok, updated} <- folder |> Folder.changeset(attrs) |> repo().update() do
+      log_activity(%{
+        action: "folder.moved",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "folder",
+        resource_uuid: folder.uuid,
+        metadata: %{
+          "name" => folder.name,
+          "from_parent_uuid" => folder.parent_uuid,
+          "to_parent_uuid" => new_parent
+        }
+      })
+
+      {:ok, updated}
     end
   end
 
@@ -2473,26 +2482,29 @@ defmodule PhoenixKitCatalogue.Catalogue do
     if target == catalogue.folder_uuid do
       {:ok, catalogue}
     else
-      with :ok <- validate_target_folder(target) do
-        attrs = %{folder_uuid: target, position: next_catalogue_position_in_folder(target)}
+      do_move_catalogue_to_folder(catalogue, target, opts)
+    end
+  end
 
-        with {:ok, updated} <- catalogue |> Catalogue.changeset(attrs) |> repo().update() do
-          log_activity(%{
-            action: "catalogue.moved_to_folder",
-            mode: "manual",
-            actor_uuid: opts[:actor_uuid],
-            resource_type: "catalogue",
-            resource_uuid: catalogue.uuid,
-            metadata: %{
-              "name" => catalogue.name,
-              "from_folder_uuid" => catalogue.folder_uuid,
-              "to_folder_uuid" => target
-            }
-          })
+  defp do_move_catalogue_to_folder(catalogue, target, opts) do
+    attrs = %{folder_uuid: target, position: next_catalogue_position_in_folder(target)}
 
-          {:ok, updated}
-        end
-      end
+    with :ok <- validate_target_folder(target),
+         {:ok, updated} <- catalogue |> Catalogue.changeset(attrs) |> repo().update() do
+      log_activity(%{
+        action: "catalogue.moved_to_folder",
+        mode: "manual",
+        actor_uuid: opts[:actor_uuid],
+        resource_type: "catalogue",
+        resource_uuid: catalogue.uuid,
+        metadata: %{
+          "name" => catalogue.name,
+          "from_folder_uuid" => catalogue.folder_uuid,
+          "to_folder_uuid" => target
+        }
+      })
+
+      {:ok, updated}
     end
   end
 

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -63,7 +63,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
   }
 
   alias PhoenixKit.Utils.Values
-  alias PhoenixKitCatalogue.Schemas.{Catalogue, Category, Item}
+  alias PhoenixKitCatalogue.Schemas.{Catalogue, Category, Folder, Item}
 
   require Logger
 
@@ -211,6 +211,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
   defp reorder_action_for(:catalogue), do: "catalogue.reordered"
   defp reorder_action_for(:category), do: "category.reordered"
   defp reorder_action_for(:item), do: "item.reordered"
+  defp reorder_action_for(:folder), do: "folder.reordered"
 
   defp maybe_put_metadata(map, _key, nil), do: map
   defp maybe_put_metadata(map, key, value), do: Map.put(map, key, value)
@@ -309,6 +310,11 @@ defmodule PhoenixKitCatalogue.Catalogue do
       When nil (default), returns all non-deleted catalogues.
     * `:kind` — when provided, filters to a specific kind (`:standard`, `:smart`,
       or their string equivalents). When nil (default), returns all kinds.
+    * `:folder_uuid` — when provided, filters by folder home: a folder UUID
+      returns only catalogues filed there, `:unfiled` returns root (NULL-folder)
+      catalogues. When omitted, returns catalogues in any folder. Note this is a
+      strict DB filter and does NOT orphan-promote catalogues whose folder is
+      trashed — the tree view groups in-memory against the active folder set.
 
   ## Examples
 
@@ -317,6 +323,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
       Catalogue.list_catalogues(status: "active")     # only active
       Catalogue.list_catalogues(kind: :smart)         # only smart catalogues
       Catalogue.list_catalogues(kind: :standard)      # only standard catalogues
+      Catalogue.list_catalogues(folder_uuid: :unfiled) # only root (unfiled)
   """
   @spec list_catalogues(keyword()) :: [Catalogue.t()]
   def list_catalogues(opts \\ []) do
@@ -332,6 +339,14 @@ defmodule PhoenixKitCatalogue.Catalogue do
       case Keyword.get(opts, :kind) do
         nil -> query
         kind -> where(query, [c], c.kind == ^to_string(kind))
+      end
+
+    query =
+      case Keyword.get(opts, :folder_uuid, :any) do
+        :any -> query
+        :unfiled -> where(query, [c], is_nil(c.folder_uuid))
+        nil -> where(query, [c], is_nil(c.folder_uuid))
+        uuid -> where(query, [c], c.folder_uuid == ^uuid)
       end
 
     repo().all(query)
@@ -2032,6 +2047,523 @@ defmodule PhoenixKitCatalogue.Catalogue do
       end
 
     query |> repo().all() |> MapSet.new()
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Catalogue folders
+  #
+  # A module-global nesting layer for organizing catalogues on the admin
+  # index (inline tree-table). Folders are their own dedicated thing —
+  # unrelated to the media-folder system. Catalogues carry a nullable
+  # `folder_uuid` (NULL = unfiled / root). Mirrors the category-tree
+  # helpers above, minus the catalogue scoping (folders are not scoped to
+  # one catalogue). All write invariants (cycle guard, reject-trashed
+  # target, position normalization) live here in the context.
+  # ═══════════════════════════════════════════════════════════════════
+
+  @doc """
+  Returns folders paired with their tree depth, in depth-first display
+  order (`position`, then `name`, recursing into children). Each entry is
+  `{folder, depth}` where depth `0` is a root. Mirrors
+  `list_category_tree/2` but folders are module-global.
+
+  ## Options
+
+    * `:mode` — `:active` (default, excludes deleted) or `:deleted`.
+    * `:exclude_subtree_of` — skip a folder and all its descendants (the
+      folder being moved — you can't parent it under itself/its subtree).
+  """
+  @spec list_folder_tree(keyword()) :: [{Folder.t(), non_neg_integer()}]
+  def list_folder_tree(opts \\ []) do
+    mode = Keyword.get(opts, :mode, :active)
+
+    exclude_uuids =
+      case Keyword.get(opts, :exclude_subtree_of) do
+        nil -> []
+        uuid -> folder_subtree_uuids(uuid)
+      end
+
+    normalized = normalized_folder_rows(mode, exclude_uuids)
+    index = Enum.group_by(normalized, & &1.parent_uuid)
+
+    {acc, _} =
+      Enum.reduce(Map.get(index, nil, []), {[], index}, fn root, {acc, idx} ->
+        {collect_folder_tree(root, idx, 0, acc), idx}
+      end)
+
+    Enum.reverse(acc)
+  end
+
+  defp collect_folder_tree(%Folder{} = folder, index, depth, acc) do
+    acc = [{folder, depth} | acc]
+
+    index
+    |> Map.get(folder.uuid, [])
+    |> Enum.reduce(acc, fn child, acc -> collect_folder_tree(child, index, depth + 1, acc) end)
+  end
+
+  # Loads folders for `mode`, drops the excluded subtree, and
+  # orphan-promotes rows whose parent is missing from the set (a deleted
+  # parent in `:active` mode, or the excluded subtree) to roots by
+  # rewriting `parent_uuid` to nil — so a child never vanishes when its
+  # parent is trashed (trash is non-cascading, parity with categories).
+  defp normalized_folder_rows(mode, exclude_uuids) do
+    base = from(f in Folder, order_by: [asc: f.position, asc: f.name])
+
+    query =
+      case mode do
+        :active -> where(base, [f], f.status != "deleted")
+        :deleted -> base
+      end
+
+    folders =
+      query
+      |> repo().all()
+      |> Enum.reject(&(&1.uuid in exclude_uuids))
+
+    uuid_set = MapSet.new(folders, & &1.uuid)
+
+    Enum.map(folders, fn f ->
+      if f.parent_uuid == nil or MapSet.member?(uuid_set, f.parent_uuid) do
+        f
+      else
+        %{f | parent_uuid: nil}
+      end
+    end)
+  end
+
+  @doc """
+  Lists the folders shown at one level — the direct children of
+  `parent_uuid` (`nil` = root). In `:active` mode reuses the tree's
+  orphan promotion (a folder whose parent is trashed surfaces at root).
+  Ordered by `position` then `name`.
+  """
+  @spec list_child_folders(Ecto.UUID.t() | nil, keyword()) :: [Folder.t()]
+  def list_child_folders(parent_uuid, opts \\ []) do
+    mode = Keyword.get(opts, :mode, :active)
+
+    mode
+    |> normalized_folder_rows([])
+    |> Enum.filter(&(&1.parent_uuid == parent_uuid))
+  end
+
+  @doc """
+  Returns the set of folder UUIDs (in the given `:mode`) that have at
+  least one child folder — lets the tree show an expand affordance
+  without an N+1.
+  """
+  @spec folder_uuids_with_children(keyword()) :: MapSet.t()
+  def folder_uuids_with_children(opts \\ []) do
+    mode = Keyword.get(opts, :mode, :active)
+
+    base =
+      from(f in Folder, where: not is_nil(f.parent_uuid), select: f.parent_uuid, distinct: true)
+
+    query =
+      case mode do
+        :active -> where(base, [f], f.status != "deleted")
+        :deleted -> base
+      end
+
+    query |> repo().all() |> MapSet.new()
+  end
+
+  @doc """
+  Returns a `%{folder_uuid => count}` map of active (non-deleted)
+  catalogues per folder. Catalogues filed under a trashed/missing folder
+  are not counted here (they orphan-promote to root in the tree view).
+  Root/unfiled catalogues are keyed under `nil`.
+  """
+  @spec folder_catalogue_counts() :: %{(Ecto.UUID.t() | nil) => non_neg_integer()}
+  def folder_catalogue_counts do
+    from(c in Catalogue,
+      where: c.status != "deleted",
+      group_by: c.folder_uuid,
+      select: {c.folder_uuid, count(c.uuid)}
+    )
+    |> repo().all()
+    |> Map.new()
+  end
+
+  @doc """
+  Groups non-deleted catalogues by their folder home for the tree view.
+  Returns `%{(folder_uuid | nil) => [Catalogue.t()]}`. A catalogue whose
+  folder is trashed or missing is promoted to the `nil` (root) bucket so it
+  never disappears — parity with the folder/category orphan promotion.
+  Within a bucket, catalogues keep `position, name` order.
+
+  ## Options
+
+    * `:status` — passed through to `list_catalogues/1` (e.g. `"deleted"` for
+      the deleted view). Defaults to non-deleted (active + archived).
+  """
+  @spec catalogues_by_folder(keyword()) :: %{(Ecto.UUID.t() | nil) => [Catalogue.t()]}
+  def catalogues_by_folder(opts \\ []) do
+    active_folders =
+      from(f in Folder, where: f.status != "deleted", select: f.uuid)
+      |> repo().all()
+      |> MapSet.new()
+
+    catalogues =
+      case Keyword.get(opts, :status) do
+        nil -> list_catalogues()
+        status -> list_catalogues(status: status)
+      end
+
+    Enum.group_by(catalogues, fn c ->
+      if c.folder_uuid != nil and MapSet.member?(active_folders, c.folder_uuid),
+        do: c.folder_uuid,
+        else: nil
+    end)
+  end
+
+  @doc "Fetches a folder by UUID. Returns `nil` if not found."
+  @spec get_folder(Ecto.UUID.t()) :: Folder.t() | nil
+  def get_folder(uuid), do: repo().get(Folder, uuid)
+
+  @doc """
+  Creates a folder. `:parent_uuid` (optional) nests it; a new folder is
+  appended (max sibling position + 1) within its parent level.
+  """
+  @spec create_folder(map(), keyword()) ::
+          {:ok, Folder.t()} | {:error, Ecto.Changeset.t(Folder.t())}
+  def create_folder(attrs, opts \\ []) do
+    parent_uuid = normalize_folder_uuid(Map.get(attrs, :parent_uuid))
+
+    attrs =
+      attrs
+      |> Map.put(:parent_uuid, parent_uuid)
+      # New folders sort to the FRONT of their level so they're immediately
+      # visible (not buried after an expanded sibling's children).
+      |> Map.put(:position, front_folder_position(parent_uuid))
+
+    case %Folder{} |> Folder.changeset(attrs) |> repo().insert() do
+      {:ok, folder} = ok ->
+        log_activity(%{
+          action: "folder.created",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "folder",
+          resource_uuid: folder.uuid,
+          metadata: %{"name" => folder.name, "parent_uuid" => folder.parent_uuid}
+        })
+
+        ok
+
+      error ->
+        error
+    end
+  end
+
+  @doc """
+  Updates a folder's own fields (name/status/data). Parent moves go
+  through `move_folder/3` — a `parent_uuid` key here is ignored.
+  """
+  @spec update_folder(Folder.t(), map(), keyword()) ::
+          {:ok, Folder.t()} | {:error, Ecto.Changeset.t(Folder.t())}
+  def update_folder(%Folder{} = folder, attrs, opts \\ []) do
+    attrs = attrs |> Map.delete(:parent_uuid) |> Map.delete(:position)
+
+    case folder |> Folder.changeset(attrs) |> repo().update() do
+      {:ok, updated} = ok ->
+        if changed?(folder, updated, [:name, :status, :data]) do
+          log_activity(%{
+            action: "folder.updated",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "folder",
+            resource_uuid: updated.uuid,
+            metadata: %{"name" => updated.name}
+          })
+        end
+
+        ok
+
+      error ->
+        error
+    end
+  end
+
+  @doc """
+  Moves a folder under `new_parent_uuid` (`nil` = root). Rejects a move
+  into the folder's own subtree (cycle) or into a trashed/missing parent.
+  The folder is appended at the end of the target level. No-op when the
+  parent is unchanged.
+  """
+  @spec move_folder(Folder.t(), Ecto.UUID.t() | nil, keyword()) ::
+          {:ok, Folder.t()} | {:error, :cycle | :folder_not_found | :folder_trashed | term()}
+  def move_folder(%Folder{} = folder, new_parent_uuid, opts \\ []) do
+    new_parent = normalize_folder_uuid(new_parent_uuid)
+
+    cond do
+      new_parent == folder.parent_uuid ->
+        {:ok, folder}
+
+      new_parent != nil and new_parent in folder_subtree_uuids(folder.uuid) ->
+        {:error, :cycle}
+
+      true ->
+        with :ok <- validate_target_folder(new_parent) do
+          attrs = %{parent_uuid: new_parent, position: next_folder_position(new_parent)}
+
+          with {:ok, updated} <- folder |> Folder.changeset(attrs) |> repo().update() do
+            log_activity(%{
+              action: "folder.moved",
+              mode: "manual",
+              actor_uuid: opts[:actor_uuid],
+              resource_type: "folder",
+              resource_uuid: folder.uuid,
+              metadata: %{
+                "name" => folder.name,
+                "from_parent_uuid" => folder.parent_uuid,
+                "to_parent_uuid" => new_parent
+              }
+            })
+
+            {:ok, updated}
+          end
+        end
+    end
+  end
+
+  @doc """
+  Soft-deletes a folder (status `"deleted"`). Non-cascading: child
+  folders and the catalogues filed here keep their `*_uuid`, but
+  orphan-promote to root in the active tree view. Nothing else changes.
+  """
+  @spec trash_folder(Folder.t(), keyword()) ::
+          {:ok, Folder.t()} | {:error, Ecto.Changeset.t(Folder.t())}
+  def trash_folder(%Folder{} = folder, opts \\ []) do
+    case folder |> Folder.changeset(%{status: "deleted"}) |> repo().update() do
+      {:ok, _updated} = ok ->
+        log_activity(%{
+          action: "folder.trashed",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "folder",
+          resource_uuid: folder.uuid,
+          metadata: %{"name" => folder.name}
+        })
+
+        ok
+
+      error ->
+        error
+    end
+  end
+
+  @doc """
+  Restores a soft-deleted folder. If its prior parent is gone or still
+  trashed, the folder is restored to root (appended) so it stays
+  reachable; otherwise it keeps its parent.
+  """
+  @spec restore_folder(Folder.t(), keyword()) ::
+          {:ok, Folder.t()} | {:error, Ecto.Changeset.t(Folder.t())}
+  def restore_folder(%Folder{} = folder, opts \\ []) do
+    parent =
+      case validate_target_folder(folder.parent_uuid) do
+        :ok -> folder.parent_uuid
+        _ -> nil
+      end
+
+    attrs = %{status: "active", parent_uuid: parent, position: next_folder_position(parent)}
+
+    case folder |> Folder.changeset(attrs) |> repo().update() do
+      {:ok, _updated} = ok ->
+        log_activity(%{
+          action: "folder.restored",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "folder",
+          resource_uuid: folder.uuid,
+          metadata: %{"name" => folder.name, "parent_uuid" => parent}
+        })
+
+        ok
+
+      error ->
+        error
+    end
+  end
+
+  @doc """
+  Re-indexes the supplied folder UUIDs into positions `1..N`. The caller
+  passes only the UUIDs of one level (same parent); positions are global
+  integers but the tree groups by `parent_uuid` first, so per-level
+  `1..N` is correct. UUIDs missing from the table are skipped.
+  """
+  @spec reorder_folders([Ecto.UUID.t()], keyword()) ::
+          :ok | {:error, :too_many_uuids | term()}
+  def reorder_folders(ordered_uuids, opts \\ [])
+
+  def reorder_folders(ordered_uuids, opts)
+      when is_list(ordered_uuids) and length(ordered_uuids) > @reorder_max_uuids do
+    log_reorder_rejected(:folder, :too_many_uuids, length(ordered_uuids), nil, opts)
+    {:error, :too_many_uuids}
+  end
+
+  def reorder_folders(ordered_uuids, opts) when is_list(ordered_uuids) do
+    unique_uuids = Helpers.dedupe_keep_last(ordered_uuids)
+
+    result =
+      repo().transaction(fn ->
+        unique_uuids
+        |> Enum.with_index(1)
+        |> Enum.each(fn {uuid, idx} ->
+          from(f in Folder, where: f.uuid == ^uuid) |> repo().update_all(set: [position: idx])
+        end)
+      end)
+
+    case result do
+      {:ok, _} ->
+        log_activity(%{
+          action: "folder.reordered",
+          mode: "manual",
+          actor_uuid: opts[:actor_uuid],
+          resource_type: "folder",
+          resource_uuid: List.first(unique_uuids),
+          metadata: %{"count" => length(unique_uuids)}
+        })
+
+        :ok
+
+      {:error, reason} ->
+        log_reorder_db_error(:folder, unique_uuids, nil, opts)
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Files a catalogue into `folder_uuid` (`nil`/`:unfiled` = root). Rejects
+  a trashed/missing target folder; appends to the end of the target
+  level. No-op (no write, no log) when already there.
+  """
+  @spec move_catalogue_to_folder(Catalogue.t(), Ecto.UUID.t() | nil | :unfiled, keyword()) ::
+          {:ok, Catalogue.t()} | {:error, :folder_not_found | :folder_trashed | term()}
+  def move_catalogue_to_folder(%Catalogue{} = catalogue, folder_uuid, opts \\ []) do
+    target = normalize_folder_uuid(folder_uuid)
+
+    if target == catalogue.folder_uuid do
+      {:ok, catalogue}
+    else
+      with :ok <- validate_target_folder(target) do
+        attrs = %{folder_uuid: target, position: next_catalogue_position_in_folder(target)}
+
+        with {:ok, updated} <- catalogue |> Catalogue.changeset(attrs) |> repo().update() do
+          log_activity(%{
+            action: "catalogue.moved_to_folder",
+            mode: "manual",
+            actor_uuid: opts[:actor_uuid],
+            resource_type: "catalogue",
+            resource_uuid: catalogue.uuid,
+            metadata: %{
+              "name" => catalogue.name,
+              "from_folder_uuid" => catalogue.folder_uuid,
+              "to_folder_uuid" => target
+            }
+          })
+
+          {:ok, updated}
+        end
+      end
+    end
+  end
+
+  # ── Folder helpers ───────────────────────────────────────────────
+
+  # `[uuid]` for `root_uuid` + every descendant folder (textual UUIDs).
+  # In-memory walk over the full adjacency list — folders are global and
+  # few, so one cheap scan beats a recursive CTE. `UNION`-style cycle
+  # safety: visited UUIDs are never re-walked.
+  defp folder_subtree_uuids(root_uuid) do
+    index =
+      from(f in Folder, select: {f.parent_uuid, f.uuid})
+      |> repo().all()
+      |> Enum.group_by(fn {parent, _uuid} -> parent end, fn {_parent, uuid} -> uuid end)
+
+    walk_folder_subtree([root_uuid], index, [])
+  end
+
+  defp walk_folder_subtree([], _index, acc), do: acc
+
+  defp walk_folder_subtree([uuid | rest], index, acc) do
+    if uuid in acc do
+      walk_folder_subtree(rest, index, acc)
+    else
+      children = Map.get(index, uuid, [])
+      walk_folder_subtree(children ++ rest, index, [uuid | acc])
+    end
+  end
+
+  # nil/root target is always valid; otherwise the folder must exist and
+  # be active. Used by move_folder/3, restore_folder/2, and
+  # move_catalogue_to_folder/3.
+  defp validate_target_folder(nil), do: :ok
+
+  defp validate_target_folder(uuid) do
+    case repo().one(from(f in Folder, where: f.uuid == ^uuid, select: f.status)) do
+      "active" -> :ok
+      nil -> {:error, :folder_not_found}
+      _ -> {:error, :folder_trashed}
+    end
+  end
+
+  defp next_folder_position(parent_uuid) do
+    base = from(f in Folder, select: max(f.position))
+
+    query =
+      case parent_uuid do
+        nil -> where(base, [f], is_nil(f.parent_uuid))
+        uuid -> where(base, [f], f.parent_uuid == ^uuid)
+      end
+
+    case repo().one(query) do
+      nil -> 1
+      n -> n + 1
+    end
+  end
+
+  # One below the smallest sibling position, so a freshly created folder
+  # sorts first within its level. (Manual reorder later normalizes to 1..N.)
+  defp front_folder_position(parent_uuid) do
+    base = from(f in Folder, select: min(f.position))
+
+    query =
+      case parent_uuid do
+        nil -> where(base, [f], is_nil(f.parent_uuid))
+        uuid -> where(base, [f], f.parent_uuid == ^uuid)
+      end
+
+    case repo().one(query) do
+      nil -> 1
+      n -> n - 1
+    end
+  end
+
+  defp next_catalogue_position_in_folder(folder_uuid) do
+    base = from(c in Catalogue, where: c.status != "deleted", select: max(c.position))
+
+    query =
+      case folder_uuid do
+        nil -> where(base, [c], is_nil(c.folder_uuid))
+        uuid -> where(base, [c], c.folder_uuid == ^uuid)
+      end
+
+    case repo().one(query) do
+      nil -> 1
+      n -> n + 1
+    end
+  end
+
+  # Folder uuid normalization: "", "unfiled", :unfiled, nil all mean root.
+  defp normalize_folder_uuid(nil), do: nil
+  defp normalize_folder_uuid(""), do: nil
+  defp normalize_folder_uuid(:unfiled), do: nil
+  defp normalize_folder_uuid("unfiled"), do: nil
+  defp normalize_folder_uuid(uuid) when is_binary(uuid), do: uuid
+
+  defp changed?(before, after_, fields) do
+    Enum.any?(fields, fn f -> Map.get(before, f) != Map.get(after_, f) end)
   end
 
   @doc """

--- a/lib/phoenix_kit_catalogue/catalogue.ex
+++ b/lib/phoenix_kit_catalogue/catalogue.ex
@@ -62,6 +62,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
     Tree
   }
 
+  alias PhoenixKit.Utils.Values
   alias PhoenixKitCatalogue.Schemas.{Catalogue, Category, Item}
 
   require Logger
@@ -239,7 +240,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
 
         category_uuid =
           if Helpers.has_attr?(attrs, :category_uuid),
-            do: attrs |> Helpers.fetch_attr(:category_uuid) |> blank_to_nil(),
+            do: attrs |> Helpers.fetch_attr(:category_uuid) |> Values.blank_to_nil(),
             else: nil
 
         if is_binary(catalogue_uuid) do
@@ -2785,7 +2786,7 @@ defmodule PhoenixKitCatalogue.Catalogue do
   # an empty string), otherwise the item's current value (nil on create).
   defp effective_category_uuid(item, attrs) do
     if Helpers.has_attr?(attrs, :category_uuid) do
-      attrs |> Helpers.fetch_attr(:category_uuid) |> blank_to_nil()
+      attrs |> Helpers.fetch_attr(:category_uuid) |> Values.blank_to_nil()
     else
       item && Map.get(item, :category_uuid)
     end
@@ -2828,9 +2829,6 @@ defmodule PhoenixKitCatalogue.Catalogue do
         attrs
     end
   end
-
-  defp blank_to_nil(value) when value in [nil, ""], do: nil
-  defp blank_to_nil(value), do: value
 
   @doc "Updates an item with the given attributes."
   @spec update_item(Item.t(), map(), keyword()) ::

--- a/lib/phoenix_kit_catalogue/catalogue/pub_sub.ex
+++ b/lib/phoenix_kit_catalogue/catalogue/pub_sub.ex
@@ -32,6 +32,7 @@ defmodule PhoenixKitCatalogue.Catalogue.PubSub do
           :catalogue
           | :category
           | :item
+          | :folder
           | :manufacturer
           | :supplier
           | :smart_rule

--- a/lib/phoenix_kit_catalogue/paths.ex
+++ b/lib/phoenix_kit_catalogue/paths.ex
@@ -17,6 +17,17 @@ defmodule PhoenixKitCatalogue.Paths do
   def catalogue_detail(uuid), do: Routes.path("#{@base}/#{uuid}")
   def catalogue_edit(uuid), do: Routes.path("#{@base}/#{uuid}/edit")
 
+  # Drill-down levels on the catalogue detail page. The current category is
+  # carried in a `?category=` query param (in-page push_patch), so these
+  # are deep-linkable and back-button friendly. Root level is plain
+  # `catalogue_detail/1`; `category_browse/2` drills into a category;
+  # `uncategorized_browse/1` opens the uncategorized bucket.
+  def category_browse(catalogue_uuid, category_uuid),
+    do: Routes.path("#{@base}/#{catalogue_uuid}?category=#{category_uuid}")
+
+  def uncategorized_browse(catalogue_uuid),
+    do: Routes.path("#{@base}/#{catalogue_uuid}?category=uncategorized")
+
   # ── Import ───────────────────────────────────────────────────────
 
   def import, do: Routes.path("#{@base}/import")

--- a/lib/phoenix_kit_catalogue/schemas/cat_catalogue.ex
+++ b/lib/phoenix_kit_catalogue/schemas/cat_catalogue.ex
@@ -24,6 +24,15 @@ defmodule PhoenixKitCatalogue.Schemas.Catalogue do
     field(:position, :integer, default: 0)
     field(:data, :map, default: %{})
 
+    # Nullable folder home — NULL = unfiled (root). Folders are module-global
+    # (see PhoenixKitCatalogue.Schemas.Folder); ON DELETE SET NULL at the DB
+    # level so removing a folder unfiles its catalogues rather than deleting.
+    belongs_to(:folder, PhoenixKitCatalogue.Schemas.Folder,
+      foreign_key: :folder_uuid,
+      references: :uuid,
+      type: UUIDv7
+    )
+
     has_many(:categories, PhoenixKitCatalogue.Schemas.Category,
       foreign_key: :catalogue_uuid,
       references: :uuid
@@ -40,7 +49,8 @@ defmodule PhoenixKitCatalogue.Schemas.Catalogue do
     :discount_percentage,
     :status,
     :position,
-    :data
+    :data,
+    :folder_uuid
   ]
 
   def changeset(catalogue, attrs) do
@@ -58,5 +68,6 @@ defmodule PhoenixKitCatalogue.Schemas.Catalogue do
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: 100
     )
+    |> foreign_key_constraint(:folder_uuid)
   end
 end

--- a/lib/phoenix_kit_catalogue/schemas/cat_folder.ex
+++ b/lib/phoenix_kit_catalogue/schemas/cat_folder.ex
@@ -1,0 +1,69 @@
+defmodule PhoenixKitCatalogue.Schemas.Folder do
+  @moduledoc """
+  Schema for catalogue folders — a nesting layer for organizing catalogues
+  on the admin index. Folders are module-global (not scoped to a catalogue)
+  and are unrelated to the media-folder system.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @primary_key {:uuid, UUIDv7, autogenerate: true}
+  @foreign_key_type UUIDv7
+
+  @statuses ~w(active deleted)
+
+  schema "phoenix_kit_cat_folders" do
+    field(:name, :string)
+    field(:position, :integer, default: 0)
+    field(:status, :string, default: "active")
+    field(:data, :map, default: %{})
+
+    # Nullable self-FK — NULL = root folder. Cycle detection happens in the
+    # Catalogue context (needs DB lookups); the changeset only catches the
+    # direct self-parent case.
+    belongs_to(:parent, __MODULE__,
+      foreign_key: :parent_uuid,
+      references: :uuid,
+      type: UUIDv7
+    )
+
+    has_many(:children, __MODULE__,
+      foreign_key: :parent_uuid,
+      references: :uuid
+    )
+
+    has_many(:catalogues, PhoenixKitCatalogue.Schemas.Catalogue,
+      foreign_key: :folder_uuid,
+      references: :uuid
+    )
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @required_fields [:name]
+  @optional_fields [:position, :status, :data, :parent_uuid]
+
+  def changeset(folder, attrs) do
+    folder
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> validate_length(:name, min: 1, max: 255)
+    |> validate_inclusion(:status, @statuses)
+    |> validate_not_self_parent()
+    |> foreign_key_constraint(:parent_uuid)
+  end
+
+  defp validate_not_self_parent(changeset) do
+    uuid = get_field(changeset, :uuid)
+    parent = get_field(changeset, :parent_uuid)
+
+    if uuid != nil and parent != nil and uuid == parent do
+      add_error(changeset, :parent_uuid, "folder cannot be its own parent")
+    else
+      changeset
+    end
+  end
+end

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -1828,7 +1828,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-6">
+    <div class="flex flex-col w-full px-4 py-6 gap-6">
       <%!-- Loading state --%>
       <div :if={is_nil(@catalogue)} class="flex justify-center py-12">
         <span class="loading loading-spinner loading-lg"></span>

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -20,6 +20,31 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
+  import PhoenixKitWeb.Components.Core.Pagination, only: [load_more: 1]
+
+  import PhoenixKitWeb.Components.Core.BulkSelect,
+    only: [
+      bulk_select_scope: 1,
+      bulk_select_header_cell: 1,
+      bulk_select_cell: 1,
+      bulk_actions_toolbar: 1
+    ]
+
+  import PhoenixKitWeb.Components.Core.Sortable, only: [sortable_tbody: 1, sortable_row: 1]
+  import PhoenixKitWeb.Components.Core.ReorderModal, only: [reorder_modal: 1]
+  import PhoenixKitWeb.Components.Core.SortSelector, only: [sort_selector: 1]
+
+  import PhoenixKitWeb.Components.Core.TableDefault,
+    only: [
+      table_default: 1,
+      table_default_header: 1,
+      table_default_row: 1,
+      table_default_header_cell: 1,
+      sort_header_cell: 1,
+      drag_handle_cell: 1,
+      drag_handle_header_cell: 1
+    ]
+
   import PhoenixKitCatalogue.Web.Components
 
   import PhoenixKitCatalogue.Web.Helpers,
@@ -30,20 +55,30 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   alias PhoenixKitCatalogue.Catalogue.PubSub
   alias PhoenixKitCatalogue.Errors
   alias PhoenixKitCatalogue.Paths
-  alias PhoenixKitCatalogue.Schemas.{Category, Item}
+  alias PhoenixKitCatalogue.Schemas.Category
   alias PhoenixKitCatalogue.Web.Components.PdfSearchModal
 
   @per_page 100
-  @per_card 25
-  # Show-more button timeout — if the deferred :apply_expand doesn't
-  # complete within this window the button restores so the user can
-  # retry. Calibrated for "user lost network mid-click" not "the DB is
-  # slow" — the inline query itself rarely takes more than 50ms.
-  @expand_timeout_ms 8_000
   # Cross-tab bulk-change red-flash → state-refresh delay. Long enough
   # that the receiver sees the leaving rows pulse red before they
   # vanish on the refresh, short enough not to feel laggy.
   @bulk_change_apply_delay_ms 800
+
+  # Active-list sortable fields. Whitelist guards the sort events — the
+  # context validates atoms too, but the LV must not coerce attacker
+  # input into atoms. `:position` is the manual-order default.
+  @items_sort_fields ~w(position name sku base_price status)a
+  @items_sort_field_strs Enum.map(@items_sort_fields, &Atom.to_string/1)
+
+  # Hardcoded string→atom whitelist for the reorder modal strategies —
+  # NEVER String.to_existing_atom on the submitted value.
+  @items_reorder_strategy_map %{
+    "name_asc" => :name_asc,
+    "name_desc" => :name_desc,
+    "created_desc" => :created_desc,
+    "created_asc" => :created_asc,
+    "reverse" => :reverse
+  }
 
   @impl true
   def mount(%{"uuid" => uuid}, _session, socket) do
@@ -52,25 +87,48 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         page_title: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Loading..."),
         catalogue_uuid: uuid,
         catalogue: nil,
-        category_list: [],
-        category_depths: %{},
-        category_counts: %{},
-        uncategorized_total: 0,
-        loaded_cards: [],
-        expanding_cards: MapSet.new(),
+        # ── Drill-down position ──
+        # current_category_uuid: nil = root level, "uncategorized" = the
+        # uncategorized bucket, or a real category UUID. current_category
+        # is the resolved value: nil | :uncategorized | %Category{}.
+        current_category_uuid: nil,
+        current_category: nil,
+        # Trimmed active-ancestor chain above the current node (root and
+        # current node excluded). Drives the breadcrumb.
+        breadcrumb: [],
+        # Direct child categories shown as drill cards at this level.
+        child_categories: [],
+        child_counts: %{},
+        children_with_subs: MapSet.new(),
+        # Root-active only: the Uncategorized drill card.
+        uncategorized_active_count: 0,
+        # ── Current node's own direct items (single paged list) ──
+        items: [],
+        items_total: 0,
+        items_offset: 0,
+        items_has_more: false,
+        show_items_section: false,
+        # Per-level Active/Deleted counts: drive the toggle labels and the
+        # auto-flip-back-to-active when this level's Deleted bucket empties.
+        level_active_count: 0,
+        level_deleted_count: 0,
         confirm_delete: nil,
         trash_modal: nil,
         bulk_move_modal: nil,
         bulk_confirm: nil,
         selected_items: MapSet.new(),
         selected_categories: MapSet.new(),
+        # ── Active item list sort + strategy reorder ──
+        # The active list uses the core List-UI toolkit: a sort dropdown,
+        # client-side bulk-select, DnD reorder (manual mode only), and a
+        # strategy "Reorder" modal. `reorder_captured_uuids` holds the
+        # uuids the BulkSelectScope hook captured for the open modal
+        # (empty == "reorder all").
+        items_sort_by: :position,
+        items_sort_dir: :asc,
+        show_items_reorder: false,
+        reorder_captured_uuids: [],
         view_mode: "active",
-        deleted_count: 0,
-        active_item_count: 0,
-        deleted_item_count: 0,
-        active_category_count: 0,
-        deleted_category_count: 0,
-        deleted_items: [],
         search_query: "",
         search_results: nil,
         search_offset: 0,
@@ -78,63 +136,94 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         search_has_more: false,
         search_loading: false,
         show_pdf_search: false,
-        pdf_search_item: nil,
-        tab: "items"
+        pdf_search_item: nil
       )
 
-    if connected?(socket) do
-      # Subscribe BEFORE the initial load so a write that lands between
-      # the load and a connect doesn't leave the UI stale forever — the
-      # broadcast triggers a re-load via handle_info/2.
-      PubSub.subscribe()
+    # Subscribe BEFORE the first load so a write landing between connect
+    # and load doesn't leave the UI stale. The actual level load happens
+    # in handle_params/3, which runs after mount and on every `?category=`
+    # drill patch.
+    if connected?(socket), do: PubSub.subscribe()
 
-      try do
-        {:ok, reset_and_load(socket)}
-      rescue
-        Ecto.NoResultsError ->
-          Logger.warning("Catalogue not found: #{uuid}")
+    {:ok, socket}
+  end
 
-          {:ok,
-           socket
-           |> put_flash(
-             :error,
-             Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found.")
-           )
-           |> push_navigate(to: Paths.index())}
+  # The drilled-into category lives in `?category=` — `nil` = root,
+  # "uncategorized" = the uncategorized bucket, or a category UUID. This
+  # runs after mount and on every drill patch.
+  #
+  # On a *node change* we drop selections and fully reset search (so a
+  # stale async result from the previous scope can't land). The level is
+  # loaded only when connected — the disconnected first render stays a
+  # cheap loading shell, and the connected mount does the single DB load.
+  # An invalid / foreign category UUID bounces back to the root level.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    new_key = normalize_category_key(params["category"])
+
+    socket =
+      if new_key == socket.assigns.current_category_uuid do
+        socket
+      else
+        socket
+        |> assign(:current_category_uuid, new_key)
+        |> assign(:selected_items, MapSet.new())
+        |> assign(:selected_categories, MapSet.new())
+        |> clear_search()
       end
+
+    if connected?(socket) do
+      load_params_level(socket, new_key)
     else
-      {:ok, socket}
+      {:noreply, socket}
     end
   end
 
-  # `?tab=items|categories` is reflected into socket assigns on every
-  # patch. The default is "items"; any unknown value falls back to
-  # "items" so a stale link can't push the LV into an undefined tab.
-  #
-  # After updating the tab, run the per-tab auto-flip — if the user
-  # switches into a tab whose Deleted bucket is empty, flip them back
-  # to Active rather than land them in an empty Deleted view.
-  @impl true
-  def handle_params(params, _uri, socket) do
-    tab =
-      case params["tab"] do
-        "categories" -> "categories"
-        _ -> "items"
-      end
+  defp load_params_level(socket, key) do
+    case resolve_node(socket.assigns.catalogue_uuid, key) do
+      {:ok, current} ->
+        {:noreply,
+         socket
+         |> assign(:current_category, current)
+         |> reset_and_load()
+         |> maybe_auto_flip_to_active()}
 
-    socket =
-      if tab == socket.assigns[:tab] do
-        socket
-      else
-        # Tab change: drop both selection sets — selection is per-tab
-        # in the UI, but they share the same modal/action-bar pipes,
-        # so a stale set across tabs would mis-target bulk actions.
-        socket
-        |> assign(:selected_items, MapSet.new())
-        |> assign(:selected_categories, MapSet.new())
-      end
+      :invalid ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Category not found.")
+         )
+         |> push_patch(to: Paths.catalogue_detail(socket.assigns.catalogue_uuid))}
+    end
+  rescue
+    Ecto.NoResultsError ->
+      Logger.warning("Catalogue not found: #{socket.assigns.catalogue_uuid}")
 
-    {:noreply, socket |> assign(:tab, tab) |> maybe_auto_flip_to_active()}
+      {:noreply,
+       socket
+       |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue not found."))
+       |> push_navigate(to: Paths.index())}
+  end
+
+  defp normalize_category_key(nil), do: nil
+  defp normalize_category_key(""), do: nil
+  defp normalize_category_key("uncategorized"), do: "uncategorized"
+  defp normalize_category_key(uuid) when is_binary(uuid), do: uuid
+
+  # Resolves a `?category=` key to the current node. A UUID that doesn't
+  # exist or belongs to another catalogue is `:invalid` (caller bounces
+  # to root). Works in `:active` and `:deleted` view alike — drilling
+  # into a trashed category to inspect its deleted subtree is valid.
+  defp resolve_node(_catalogue_uuid, nil), do: {:ok, nil}
+  defp resolve_node(_catalogue_uuid, "uncategorized"), do: {:ok, :uncategorized}
+
+  defp resolve_node(catalogue_uuid, uuid) do
+    case Catalogue.get_category(uuid) do
+      %Category{catalogue_uuid: ^catalogue_uuid} = cat -> {:ok, cat}
+      _ -> :invalid
+    end
   end
 
   # PubSub: another LV touched a category/item/catalogue/smart-rule.
@@ -266,64 +355,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     {:noreply, socket}
   end
 
-  # Deferred apply for the show-more click. The handler that scheduled
-  # this might have been outraced by `:expand_timeout` (operator on a
-  # bad connection) — in that case the scope is no longer in
-  # `expanding_cards` and we no-op.
-  def handle_info({:apply_expand, scope}, socket) do
-    if MapSet.member?(socket.assigns.expanding_cards, scope) do
-      {:noreply, do_apply_expand(socket, scope)}
-    else
-      {:noreply, socket}
-    end
-  end
-
-  # Smart-fail: if the apply hasn't landed within @expand_timeout_ms
-  # (network hiccup, BEAM stuck), restore the button and surface a
-  # flash so the operator can retry.
-  def handle_info({:expand_timeout, scope}, socket) do
-    if MapSet.member?(socket.assigns.expanding_cards, scope) do
-      {:noreply,
-       socket
-       |> assign(:expanding_cards, MapSet.delete(socket.assigns.expanding_cards, scope))
-       |> put_flash(
-         :error,
-         Gettext.gettext(
-           PhoenixKitCatalogue.Gettext,
-           "Loading more items took too long. Please try again."
-         )
-       )}
-    else
-      {:noreply, socket}
-    end
-  end
-
   def handle_info(msg, socket) do
     Logger.debug("CatalogueDetailLive ignored unhandled message: #{inspect(msg)}")
     {:noreply, socket}
-  end
-
-  defp do_apply_expand(socket, scope) do
-    mode = view_mode_to_atom(socket.assigns.view_mode)
-    catalogue_uuid = socket.assigns.catalogue_uuid
-
-    cards =
-      Enum.map(socket.assigns.loaded_cards, &expand_one_card(&1, scope, catalogue_uuid, mode))
-
-    socket
-    |> assign(:loaded_cards, cards)
-    |> assign(:expanding_cards, MapSet.delete(socket.assigns.expanding_cards, scope))
-  end
-
-  defp expand_one_card(card, scope, catalogue_uuid, mode) do
-    if scope_matches_card?(scope, card) do
-      more =
-        fetch_card_items(card_scope(card), catalogue_uuid, mode, @per_card, length(card.items))
-
-      %{card | items: card.items ++ more}
-    else
-      card
-    end
   end
 
   defp handle_catalogue_data_changed(socket) do
@@ -353,55 +387,21 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
      |> reset_and_load()}
   end
 
-  # Items/Categories tab switch. URL is patched so the choice survives
-  # back-button + reload + share-link. handle_params/3 echoes the param
-  # into the :tab assign, so we don't update assigns here directly.
-  def handle_event("switch_tab", %{"tab" => tab}, socket) when tab in ~w(items categories) do
-    target =
-      case tab do
-        "items" -> Paths.catalogue_detail(socket.assigns.catalogue_uuid)
-        "categories" -> Paths.catalogue_detail(socket.assigns.catalogue_uuid) <> "?tab=categories"
-      end
-
-    {:noreply, push_patch(socket, to: target)}
-  end
-
-  # `load_more` is now only used by the search results pagination —
-  # the category cards expand on-demand via `expand_card` instead of
-  # via a global bottom sentinel.
+  # One bottom sentinel drives both search-result paging and the current
+  # node's item list. While a search is active it pages the results;
+  # otherwise it pages the level's own items.
   def handle_event("load_more", _params, socket) do
-    if socket.assigns.search_results != nil and socket.assigns.search_has_more and
-         not socket.assigns.search_loading do
-      {:noreply, start_search_page(socket)}
-    else
-      {:noreply, socket}
-    end
-  end
+    cond do
+      socket.assigns.search_results != nil ->
+        if socket.assigns.search_has_more and not socket.assigns.search_loading,
+          do: {:noreply, start_search_page(socket)},
+          else: {:noreply, socket}
 
-  # Per-card "Show N more" button. `scope` is either a category UUID
-  # or the literal string "uncategorized".
-  #
-  # Deferred apply pattern: the event handler returns immediately after
-  # marking the card as expanding (so the LV re-renders the disabled
-  # "Loading…" button), then `:apply_expand` does the actual fetch on
-  # the next mailbox tick. Without this defer the LV would block in
-  # one go and the user would never see the loading state.
-  #
-  # Smart-fail: if the apply doesn't land within @expand_timeout_ms
-  # (default 8s), `:expand_timeout` clears the expanding flag and
-  # surfaces a flash so the user can retry. The query itself runs
-  # inline (not async) so the timeout fires only when the BEAM /
-  # socket is genuinely stuck, not when the DB is just slow — but
-  # that's the failure mode worth recovering from.
-  def handle_event("expand_card", %{"scope" => scope}, socket) do
-    if MapSet.member?(socket.assigns.expanding_cards, scope) do
-      {:noreply, socket}
-    else
-      send(self(), {:apply_expand, scope})
-      Process.send_after(self(), {:expand_timeout, scope}, @expand_timeout_ms)
+      socket.assigns.items_has_more ->
+        {:noreply, load_next_items_page(socket)}
 
-      {:noreply,
-       assign(socket, :expanding_cards, MapSet.put(socket.assigns.expanding_cards, scope))}
+      true ->
+        {:noreply, socket}
     end
   end
 
@@ -651,12 +651,14 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   end
 
   # Bulk delete items — opens a confirm modal stamped with the selection
-  # count and the operation type. Confirmation routes through
-  # `confirm_bulk_action` below.
-  def handle_event("request_bulk_delete_items", _params, socket) do
-    count = MapSet.size(socket.assigns.selected_items)
+  # and the operation type. The active list (core toolkit) supplies the
+  # uuids client-side via `%{"uuids" => [...]}`; the deleted list (still
+  # server-side select) falls back to the `@selected_items` MapSet.
+  # Confirmation routes through `confirm_bulk_action` below.
+  def handle_event("request_bulk_delete_items", params, socket) do
+    uuids = resolve_bulk_uuids(params, socket)
 
-    if count == 0 do
+    if uuids == [] do
       {:noreply, socket}
     else
       mode =
@@ -664,19 +666,25 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           do: :permanent,
           else: :trash
 
-      {:noreply, assign(socket, :bulk_confirm, %{kind: :items, mode: mode, count: count})}
+      {:noreply,
+       assign(socket, :bulk_confirm, %{
+         kind: :items,
+         mode: mode,
+         count: length(uuids),
+         uuids: uuids
+       })}
     end
   end
 
-  def handle_event("request_bulk_restore_items", _params, socket) do
-    count = MapSet.size(socket.assigns.selected_items)
-    if count == 0, do: {:noreply, socket}, else: do_bulk_restore_items(socket)
+  def handle_event("request_bulk_restore_items", params, socket) do
+    uuids = resolve_bulk_uuids(params, socket)
+    if uuids == [], do: {:noreply, socket}, else: do_bulk_restore_items(socket, uuids)
   end
 
-  def handle_event("request_bulk_move_items", _params, socket) do
-    count = MapSet.size(socket.assigns.selected_items)
+  def handle_event("request_bulk_move_items", params, socket) do
+    uuids = resolve_bulk_uuids(params, socket)
 
-    if count == 0 do
+    if uuids == [] do
       {:noreply, socket}
     else
       targets =
@@ -685,7 +693,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
       {:noreply,
        assign(socket, :bulk_move_modal, %{
-         count: count,
+         count: length(uuids),
+         uuids: uuids,
          targets: targets,
          disposition: :uncategorize,
          target_uuid: nil
@@ -708,16 +717,19 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   def handle_event("select_bulk_move_target", %{"category_uuid" => uuid}, socket) do
     modal = socket.assigns.bulk_move_modal || %{}
-    {:noreply, assign(socket, :bulk_move_modal, %{modal | target_uuid: Values.blank_to_nil(uuid)})}
+
+    {:noreply,
+     assign(socket, :bulk_move_modal, %{modal | target_uuid: Values.blank_to_nil(uuid)})}
   end
 
   def handle_event("confirm_bulk_move_items", _params, socket) do
     case socket.assigns.bulk_move_modal do
-      %{disposition: :uncategorize} ->
-        do_bulk_move_items(socket, nil)
+      %{disposition: :uncategorize, uuids: uuids} ->
+        do_bulk_move_items(socket, uuids, nil)
 
-      %{disposition: :move_to, target_uuid: target_uuid} when not is_nil(target_uuid) ->
-        do_bulk_move_items(socket, target_uuid)
+      %{disposition: :move_to, target_uuid: target_uuid, uuids: uuids}
+      when not is_nil(target_uuid) ->
+        do_bulk_move_items(socket, uuids, target_uuid)
 
       _ ->
         {:noreply, socket}
@@ -730,11 +742,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   def handle_event("confirm_bulk_action", _params, socket) do
     case socket.assigns.bulk_confirm do
-      %{kind: :items, mode: :trash} ->
-        do_bulk_trash_items(socket)
+      %{kind: :items, mode: :trash, uuids: uuids} ->
+        do_bulk_trash_items(socket, uuids)
 
-      %{kind: :items, mode: :permanent} ->
-        do_bulk_permanent_delete_items(socket)
+      %{kind: :items, mode: :permanent, uuids: uuids} ->
+        do_bulk_permanent_delete_items(socket, uuids)
 
       %{kind: :categories} ->
         do_bulk_trash_categories(socket)
@@ -871,145 +883,169 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     apply_category_reorder(socket, ordered_ids, params["moved_id"])
   end
 
-  # Cross-category drop: SortableJS sent the source category in `from*`
-  # keys alongside the destination's scope. We move the item, then
-  # reorder the destination to match the visual order the user dropped
-  # it into. The source's remaining order is preserved implicitly —
-  # its position values stay valid since they're per-scope.
-  #
-  # Pattern-matches on `fromCatalogueUuid` (only present on cross-
-  # container drops) rather than `moved_id` (now sent for every drop
-  # so the LV can flash the moved row regardless).
-  def handle_event(
-        "reorder_items",
-        %{"ordered_ids" => ordered_ids, "moved_id" => moved_id, "fromCatalogueUuid" => _} =
-          params,
-        socket
-      )
-      when is_list(ordered_ids) and is_binary(moved_id) do
-    to_catalogue_uuid = params["catalogueUuid"]
-    to_category_uuid = Values.blank_to_nil(params["categoryUuid"])
-    from_catalogue_uuid = params["fromCatalogueUuid"]
+  # DnD reorder of the active item list. The drill view is always one
+  # node, so scope comes from socket assigns (the current node), NOT
+  # from DOM attrs — core `<.sortable_tbody>` doesn't carry the
+  # catalogue's `data-sortable-scope-*` attrs.
+  def handle_event("reorder_items", %{"ordered_ids" => ordered_ids} = params, socket)
+      when is_list(ordered_ids) do
+    catalogue_uuid = socket.assigns.catalogue_uuid
+    category_uuid = Catalogue.normalize_category_uuid(socket.assigns.current_category)
+    moved_id = params["moved_id"]
 
-    cond do
-      to_catalogue_uuid != socket.assigns.catalogue_uuid ->
+    apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids, moved_id)
+  end
+
+  # ── Active item list: sort + strategy reorder ────────────────────
+
+  # Sort selector (field <select> + direction arrow). The select sends
+  # `%{"sort_by" => ...}`, the arrow `%{"sort_dir" => ...}` — derive the
+  # missing half from assigns (race-free, see SortSelector docs). Field
+  # is whitelist-validated; direction is only `:asc`/`:desc`.
+  def handle_event("sort_items", params, socket) do
+    field =
+      case params["sort_by"] do
+        f when f in @items_sort_field_strs -> String.to_existing_atom(f)
+        _ -> socket.assigns.items_sort_by
+      end
+
+    dir =
+      case params["sort_dir"] do
+        "desc" -> :desc
+        "asc" -> :asc
+        _ -> socket.assigns.items_sort_dir
+      end
+
+    {:noreply, apply_items_sort(socket, field, dir)}
+  end
+
+  # Sortable column header click — toggles direction on the active field,
+  # otherwise switches field (ascending).
+  def handle_event("toggle_sort_items", %{"by" => field_str}, socket)
+      when field_str in @items_sort_field_strs do
+    field = String.to_existing_atom(field_str)
+
+    dir =
+      if field == socket.assigns.items_sort_by do
+        if socket.assigns.items_sort_dir == :asc, do: :desc, else: :asc
+      else
+        :asc
+      end
+
+    {:noreply, apply_items_sort(socket, field, dir)}
+  end
+
+  def handle_event("toggle_sort_items", _params, socket), do: {:noreply, socket}
+
+  # Open the strategy-reorder modal. Captures the client-side selection
+  # (via the BulkSelectScope hook payload). A 0–1 selection collapses to
+  # "reorder all" (stored as `[]`) — a single-row reorder is a no-op.
+  def handle_event("open_items_reorder_modal", params, socket) do
+    captured =
+      case sanitize_uuids(params) do
+        list when length(list) < 2 -> []
+        list -> list
+      end
+
+    {:noreply, assign(socket, show_items_reorder: true, reorder_captured_uuids: captured)}
+  end
+
+  def handle_event("close_items_reorder_modal", _params, socket) do
+    {:noreply, assign(socket, show_items_reorder: false, reorder_captured_uuids: [])}
+  end
+
+  def handle_event("apply_items_reorder", %{"strategy" => strategy_str}, socket)
+      when is_map_key(@items_reorder_strategy_map, strategy_str) do
+    strategy = Map.fetch!(@items_reorder_strategy_map, strategy_str)
+
+    scope =
+      case socket.assigns.reorder_captured_uuids do
+        [] -> :all
+        uuids -> uuids
+      end
+
+    catalogue_uuid = socket.assigns.catalogue_uuid
+    category_uuid = Catalogue.normalize_category_uuid(socket.assigns.current_category)
+
+    case Catalogue.reorder_items_by(
+           catalogue_uuid,
+           category_uuid,
+           strategy,
+           scope,
+           actor_opts(socket)
+         ) do
+      :ok ->
+        {:noreply,
+         socket
+         |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items reordered."))
+         |> assign(show_items_reorder: false, reorder_captured_uuids: [])
+         |> push_event("bulk_select:clear", %{})
+         |> reset_and_load()}
+
+      {:error, :duplicate_positions} ->
         {:noreply,
          put_flash(
            socket,
            :error,
-           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Wrong catalogue scope.")
-         )}
-
-      from_catalogue_uuid != to_catalogue_uuid ->
-        # Items can't change catalogue via DnD (Item.catalogue_uuid is
-        # the strong root scope; cross-catalogue moves go through the
-        # explicit "Move to catalogue" form). Reload to snap the DOM
-        # back to the persisted state.
-        {:noreply,
-         socket
-         |> put_flash(
-           :error,
            Gettext.gettext(
              PhoenixKitCatalogue.Gettext,
-             "Items can only be moved within the same catalogue."
+             "Selected items share positions. Apply \"Reorder all\" first to normalise."
            )
-         )
-         |> reset_and_load()}
+         )}
 
-      true ->
-        # `move_item_and_reorder_destination/4` wraps the move + reorder
-        # in a single transaction so a reorder failure rolls back the
-        # category flip — no in-between half-state where the item has
-        # the new category_uuid but the wrong position.
-        with %Item{} = item <- Catalogue.get_item(moved_id),
-             from_category_uuid = item.category_uuid,
-             {:ok, _moved} <-
-               Catalogue.move_item_and_reorder_destination(
-                 item,
-                 to_category_uuid,
-                 ordered_ids,
-                 actor_opts(socket)
-               ) do
-          from_scope = from_category_uuid || :uncategorized
-          to_scope = to_category_uuid || :uncategorized
-          # Source loses an item, destination gains one — broadcast both
-          # so other open tabs refresh both cards. Flash only on the
-          # destination scope (where the row landed).
-          PubSub.broadcast_card_refresh(to_catalogue_uuid, from_scope, nil, :ok)
-          PubSub.broadcast_card_refresh(to_catalogue_uuid, to_scope, moved_id, :ok)
+      {:error, reason} ->
+        log_operation_error(socket, "reorder_items_by", %{reason: reason})
 
-          {:noreply,
-           socket
-           |> refresh_card_items(from_scope, -1)
-           |> refresh_card_items(to_scope, +1)
-           |> refresh_counts()
-           |> flash_reorder(moved_id, :ok)}
-        else
-          nil ->
-            {:noreply,
-             socket
-             |> put_flash(:error, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Item not found."))
-             |> flash_reorder(moved_id, :error)}
-
-          {:error, reason} ->
-            log_operation_error(socket, "move_item_via_dnd", %{
-              item_uuid: moved_id,
-              to_category_uuid: to_category_uuid,
-              reason: reason
-            })
-
-            {:noreply,
-             socket
-             |> put_flash(
-               :error,
-               Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move item.")
-             )
-             |> reset_and_load()
-             |> flash_reorder(moved_id, :error)}
-        end
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to reorder items.")
+         )}
     end
   end
 
-  def handle_event("reorder_items", %{"ordered_ids" => ordered_ids} = params, socket)
-      when is_list(ordered_ids) do
-    catalogue_uuid = params["catalogueUuid"]
-    category_uuid = Values.blank_to_nil(params["categoryUuid"])
-    moved_id = params["moved_id"]
-
-    if catalogue_uuid != socket.assigns.catalogue_uuid do
-      {:noreply,
-       put_flash(
-         socket,
-         :error,
-         Gettext.gettext(PhoenixKitCatalogue.Gettext, "Wrong catalogue scope.")
-       )}
-    else
-      apply_in_scope_item_reorder(socket, catalogue_uuid, category_uuid, ordered_ids, moved_id)
-    end
+  def handle_event("apply_items_reorder", _params, socket) do
+    {:noreply,
+     put_flash(
+       socket,
+       :error,
+       Gettext.gettext(PhoenixKitCatalogue.Gettext, "Pick a strategy before applying.")
+     )}
   end
-
-  # ── Per-card expand helpers ──────────────────────────────────────
-
-  # Template helper: turns a card map into the scope key used by
-  # `expanding_cards` / `expand_card` events.
-  defp scope_key(%{kind: :uncategorized}), do: "uncategorized"
-  defp scope_key(%{kind: :category, category: %{uuid: uuid}}), do: uuid
-
-  defp scope_matches_card?("uncategorized", %{kind: :uncategorized}), do: true
-
-  defp scope_matches_card?(uuid, %{kind: :category, category: %{uuid: cat_uuid}})
-       when is_binary(uuid),
-       do: uuid == cat_uuid
-
-  defp scope_matches_card?(_, _), do: false
-
-  defp card_scope(%{kind: :uncategorized}), do: :uncategorized
-  defp card_scope(%{kind: :category, category: %{uuid: uuid}}), do: uuid
 
   # ── Bulk-action helpers ──────────────────────────────────────────
 
   defp toggle(set, uuid) do
     if MapSet.member?(set, uuid), do: MapSet.delete(set, uuid), else: MapSet.put(set, uuid)
+  end
+
+  # Resolves the target uuids for a bulk op. The active list (core
+  # toolkit) supplies them client-side via `%{"uuids" => [...]}`; the
+  # deleted list (still server-side select) falls back to the
+  # `@selected_items` MapSet.
+  defp resolve_bulk_uuids(%{"uuids" => _} = params, _socket), do: sanitize_uuids(params)
+  defp resolve_bulk_uuids(_params, socket), do: MapSet.to_list(socket.assigns.selected_items)
+
+  defp sanitize_uuids(%{"uuids" => uuids}) when is_list(uuids),
+    do: Enum.filter(uuids, &is_binary/1)
+
+  defp sanitize_uuids(_), do: []
+
+  # Clears both selection models after a bulk op: the server-side MapSet
+  # (deleted list) and the client-side BulkSelectScope (active list).
+  defp clear_item_selection(socket) do
+    socket
+    |> assign(:selected_items, MapSet.new())
+    |> push_event("bulk_select:clear", %{})
+  end
+
+  # Sort change resets the item offset to 0 and reloads page 1 — else
+  # infinite-scroll would stitch the new order onto a stale prefix.
+  defp apply_items_sort(socket, field, dir) do
+    socket
+    |> assign(items_sort_by: field, items_sort_dir: dir, items_offset: 0)
+    |> reset_and_load()
   end
 
   defp disposition_to_items_opt(:uncategorize, _), do: :uncategorize
@@ -1023,14 +1059,17 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     end)
   end
 
-  defp do_bulk_trash_items(socket) do
-    uuids = socket.assigns.selected_items |> MapSet.to_list()
+  # Active-list bulk ops read the client-captured uuids; deleted-list
+  # bulk ops pass `@selected_items`. After each op we clear BOTH the
+  # server-side MapSet (deleted list) AND push `bulk_select:clear` so a
+  # stale client-side checkmark can't persist on the active list.
+  defp do_bulk_trash_items(socket, uuids) do
     {count, _} = Catalogue.bulk_trash_items(uuids, actor_opts(socket))
     PubSub.broadcast_bulk_change(socket.assigns.catalogue_uuid, :trashed, uuids)
 
     socket
     |> assign(:bulk_confirm, nil)
-    |> assign(:selected_items, MapSet.new())
+    |> clear_item_selection()
     |> put_flash(
       :info,
       Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted %{count} items.", count: count)
@@ -1039,14 +1078,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> then(&{:noreply, &1})
   end
 
-  defp do_bulk_permanent_delete_items(socket) do
-    uuids = socket.assigns.selected_items |> MapSet.to_list()
+  defp do_bulk_permanent_delete_items(socket, uuids) do
     {count, _} = Catalogue.bulk_permanently_delete_items(uuids, actor_opts(socket))
     PubSub.broadcast_bulk_change(socket.assigns.catalogue_uuid, :permanent_delete, uuids)
 
     socket
     |> assign(:bulk_confirm, nil)
-    |> assign(:selected_items, MapSet.new())
+    |> clear_item_selection()
     |> put_flash(
       :info,
       Gettext.gettext(PhoenixKitCatalogue.Gettext, "Permanently deleted %{count} items.",
@@ -1057,13 +1095,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> then(&{:noreply, &1})
   end
 
-  defp do_bulk_restore_items(socket) do
-    uuids = socket.assigns.selected_items |> MapSet.to_list()
+  defp do_bulk_restore_items(socket, uuids) do
     {count, _} = Catalogue.bulk_restore_items(uuids, actor_opts(socket))
     PubSub.broadcast_bulk_change(socket.assigns.catalogue_uuid, :restored, uuids)
 
     socket
-    |> assign(:selected_items, MapSet.new())
+    |> clear_item_selection()
     |> put_flash(
       :info,
       Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restored %{count} items.", count: count)
@@ -1072,9 +1109,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> then(&{:noreply, &1})
   end
 
-  defp do_bulk_move_items(socket, target_uuid) do
-    uuids = socket.assigns.selected_items |> MapSet.to_list()
-
+  defp do_bulk_move_items(socket, uuids, target_uuid) do
     opts =
       actor_opts(socket) |> Keyword.put(:catalogue_uuid, socket.assigns.catalogue_uuid)
 
@@ -1086,7 +1121,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
         socket
         |> assign(:bulk_move_modal, nil)
-        |> assign(:selected_items, MapSet.new())
+        |> clear_item_selection()
         |> put_flash(
           :info,
           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Moved %{count} items.", count: count)
@@ -1295,235 +1330,190 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # actor_opts/1, actor_uuid/1, and log_operation_error/3 imported from
   # PhoenixKitCatalogue.Web.Helpers.
 
-  # Resets paging state and loads the first batch. Called on mount, when
-  # the user switches active/deleted tabs, and after any structural
-  # change (category trash/restore/permanent-delete/reorder) because
-  # those can affect which cards render and in what order.
+  # Reloads the whole drill level from scratch (item list back to page 1).
+  # Called after any structural change — drilling, view switch, trash /
+  # restore / reorder.
   defp reset_and_load(socket) do
-    uuid = socket.assigns.catalogue_uuid
-
-    deleted_item_count = Catalogue.deleted_item_count_for_catalogue(uuid)
-    deleted_category_count = Catalogue.deleted_category_count_for_catalogue(uuid)
-    deleted_count = deleted_item_count + deleted_category_count
-
-    relevant_count =
-      case socket.assigns.tab do
-        "categories" -> deleted_category_count
-        _ -> deleted_item_count
-      end
-
-    view_mode =
-      if relevant_count == 0 and socket.assigns.view_mode == "deleted",
-        do: "active",
-        else: socket.assigns.view_mode
-
-    mode = view_mode_to_atom(view_mode)
-    catalogue = Catalogue.fetch_catalogue!(uuid)
-    tree = Catalogue.list_category_tree(uuid, mode: mode)
-    category_list = Enum.map(tree, fn {cat, _depth} -> cat end)
-    category_depths = Map.new(tree, fn {cat, depth} -> {cat.uuid, depth} end)
-    category_counts = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode)
-    uncategorized_total = Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
-
-    items_tab_deleted? = view_mode == "deleted" and socket.assigns.tab == "items"
-
-    deleted_items =
-      if items_tab_deleted?,
-        do: Catalogue.list_deleted_items_for_catalogue(uuid),
-        else: []
-
-    # Per-card preview build. Each category gets its first @per_card
-    # items + a total; uncategorized too. The "Show N more" button on
-    # each card requests the next slice via `expand_card`. Replaces the
-    # global cursor walk + bottom-sentinel infinite scroll.
-    loaded_cards =
-      if items_tab_deleted? do
-        []
-      else
-        build_loaded_cards(uuid, category_list, category_counts, uncategorized_total, mode)
-      end
-
     socket
-    |> assign(
-      page_title: catalogue.name,
-      catalogue: catalogue,
-      category_list: category_list,
-      category_depths: category_depths,
-      category_counts: category_counts,
-      uncategorized_total: uncategorized_total,
-      loaded_cards: loaded_cards,
-      deleted_count: deleted_count,
-      active_item_count: Catalogue.item_count_for_catalogue(uuid),
-      deleted_item_count: deleted_item_count,
-      active_category_count: Catalogue.category_count_for_catalogue(uuid),
-      deleted_category_count: deleted_category_count,
-      view_mode: view_mode,
-      deleted_items: deleted_items
-    )
-  end
-
-  # Builds the full set of cards eagerly — one per category in display
-  # order, then an Uncategorized card if applicable. Each card holds
-  # its first @per_card items plus the total count so the template can
-  # render a "Show N more" button when more items exist.
-  defp build_loaded_cards(uuid, category_list, category_counts, uncategorized_total, mode) do
-    category_cards =
-      Enum.map(category_list, fn category ->
-        total = Map.get(category_counts, category.uuid, 0)
-
-        items =
-          if total > 0,
-            do:
-              Catalogue.list_items_for_category_paged(category.uuid,
-                mode: mode,
-                offset: 0,
-                limit: @per_card
-              ),
-            else: []
-
-        %{kind: :category, category: category, items: items, total: total}
-      end)
-
-    if uncategorized_total > 0 do
-      uncat_items =
-        Catalogue.list_uncategorized_items_paged(uuid,
-          mode: mode,
-          offset: 0,
-          limit: @per_card
-        )
-
-      category_cards ++
-        [%{kind: :uncategorized, items: uncat_items, total: uncategorized_total}]
-    else
-      category_cards
-    end
-  end
-
-  # Refreshes the header counts (Active / Deleted tabs) and the
-  # per-category + uncategorized totals after an item mutation, without
-  # reloading the card list. Preserves scroll position.
-  #
-  # Special case: when restoring/deleting drains the Deleted view to
-  # zero, we have to flip back to Active and reset_and_load — otherwise
-  # the loaded_cards (which were progressively drained by
-  # `remove_item_locally`) keep rendering empty content for items that
-  # are now active in another view. Symptom: badges show correct active
-  # counts but the cards are blank.
-  defp refresh_counts(socket) do
-    uuid = socket.assigns.catalogue_uuid
-    mode = view_mode_to_atom(socket.assigns.view_mode)
-    items_tab_deleted? = socket.assigns.view_mode == "deleted" and socket.assigns.tab == "items"
-
-    deleted_items =
-      if items_tab_deleted?,
-        do: Catalogue.list_deleted_items_for_catalogue(uuid),
-        else: socket.assigns[:deleted_items] || []
-
-    category_counts = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode)
-    uncategorized_total = Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
-
-    refreshed_cards =
-      Enum.map(socket.assigns.loaded_cards, fn card ->
-        case card do
-          %{kind: :category, category: %{uuid: cat_uuid}} ->
-            %{card | total: Map.get(category_counts, cat_uuid, 0)}
-
-          %{kind: :uncategorized} ->
-            %{card | total: uncategorized_total}
-        end
-      end)
-
-    socket =
-      assign(socket,
-        deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
-        active_item_count: Catalogue.item_count_for_catalogue(uuid),
-        deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
-        active_category_count: Catalogue.category_count_for_catalogue(uuid),
-        deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid),
-        category_counts: category_counts,
-        uncategorized_total: uncategorized_total,
-        deleted_items: deleted_items,
-        loaded_cards: refreshed_cards
-      )
-
-    maybe_auto_flip_to_active(socket)
-  end
-
-  # Per-tab auto-flip: Items tab uses deleted_item_count, Categories tab
-  # uses deleted_category_count. Without tab awareness the user would
-  # land in an empty Deleted view of one tab while the other tab still
-  # had deleted entries (since `deleted_count` is the combined total).
-  defp maybe_auto_flip_to_active(socket) do
-    relevant_count =
-      case socket.assigns.tab do
-        "categories" -> socket.assigns.deleted_category_count
-        _ -> socket.assigns.deleted_item_count
-      end
-
-    if relevant_count == 0 and socket.assigns.view_mode == "deleted" do
-      socket
-      |> assign(:view_mode, "active")
-      |> reset_and_load()
-    else
-      socket
-    end
-  end
-
-  # PubSub-driven refresh. Updates counts, the catalogue struct, and the
-  # category list (so newly-created or renamed categories show up in the
-  # tree without the user reloading), but **deliberately leaves**
-  # `loaded_cards` and `cursor` alone. A full `reset_and_load` would wipe
-  # the user's scroll state on every broadcast — combined with the
-  # global PubSub topic, that turns into a perpetual spinner whenever
-  # another admin (or the import wizard) is busy.
-  #
-  # Trade-off: an item that was deleted elsewhere may briefly remain
-  # visible in `loaded_cards` until the user navigates or refreshes; the
-  # counts will be correct, so the discrepancy is self-explanatory. The
-  # `Ecto.NoResultsError` rescue in the caller handles the edge case
-  # where this catalogue itself was deleted (caller redirects to index).
-  defp refresh_in_place(socket) do
-    uuid = socket.assigns.catalogue_uuid
-    catalogue = Catalogue.fetch_catalogue!(uuid)
-    mode = view_mode_to_atom(socket.assigns.view_mode)
-    tree = Catalogue.list_category_tree(uuid, mode: mode)
-    category_list = Enum.map(tree, fn {cat, _depth} -> cat end)
-    category_depths = Map.new(tree, fn {cat, depth} -> {cat.uuid, depth} end)
-    category_counts = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: mode)
-    uncategorized_total = Catalogue.uncategorized_count_for_catalogue(uuid, mode: mode)
-
-    # Re-sync each card's `total` from the fresh counts so the
-    # "Show N more (k)" button reflects current reality after a
-    # cross-tab mutation. Loaded `items` lists are intentionally left
-    # alone to preserve the user's expanded slice.
-    refreshed_cards =
-      Enum.map(socket.assigns.loaded_cards, fn card ->
-        case card do
-          %{kind: :category, category: %{uuid: cat_uuid}} ->
-            %{card | total: Map.get(category_counts, cat_uuid, 0)}
-
-          %{kind: :uncategorized} ->
-            %{card | total: uncategorized_total}
-        end
-      end)
-
-    socket
-    |> assign(
-      page_title: catalogue.name,
-      catalogue: catalogue,
-      category_list: category_list,
-      category_depths: category_depths,
-      category_counts: category_counts,
-      uncategorized_total: uncategorized_total,
-      loaded_cards: refreshed_cards,
-      deleted_count: Catalogue.deleted_count_for_catalogue(uuid),
-      active_item_count: Catalogue.item_count_for_catalogue(uuid),
-      deleted_item_count: Catalogue.deleted_item_count_for_catalogue(uuid),
-      active_category_count: Catalogue.category_count_for_catalogue(uuid),
-      deleted_category_count: Catalogue.deleted_category_count_for_catalogue(uuid)
-    )
+    |> load_level(@per_page)
     |> maybe_auto_flip_to_active()
   end
+
+  # Loads everything the current level renders for the active view_mode:
+  # catalogue + breadcrumb, the direct child categories (drill cards) with
+  # their item counts and has-subcategories flags, the root-only
+  # Uncategorized card count, the current node's own direct items (first
+  # `item_limit`), and the per-level Active/Deleted counts that drive the
+  # toggle labels + auto-flip. `item_limit` lets a PubSub refresh preserve
+  # the user's scroll depth instead of snapping back to page 1.
+  defp load_level(socket, item_limit) do
+    uuid = socket.assigns.catalogue_uuid
+    catalogue = Catalogue.fetch_catalogue!(uuid)
+    current = socket.assigns.current_category
+    mode = view_mode_to_atom(socket.assigns.view_mode)
+
+    {child_categories, children_with_subs, active_child_count, deleted_child_count} =
+      load_level_children(uuid, current, mode)
+
+    counts_active = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: :active)
+    counts_deleted = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: :deleted)
+    counts_map = if mode == :deleted, do: counts_deleted, else: counts_active
+
+    uncat_active = Catalogue.uncategorized_count_for_catalogue(uuid, mode: :active)
+    uncat_deleted = Catalogue.uncategorized_count_for_catalogue(uuid, mode: :deleted)
+
+    {node_active_items, node_deleted_items} =
+      node_item_counts(current, counts_active, counts_deleted, uncat_active, uncat_deleted)
+
+    # Root in Active mode normally shows only cards (its items — the
+    # uncategorized ones — are reached via the Uncategorized card). But a
+    # catalogue with NO categories has nothing to drill into, so skip the
+    # card and show its items inline. Root in Deleted mode always shows
+    # the deleted uncategorized items inline.
+    show_items_section =
+      current != nil or mode == :deleted or
+        (is_nil(current) and active_child_count == 0 and node_active_items > 0)
+
+    node_total = if mode == :deleted, do: node_deleted_items, else: node_active_items
+
+    items =
+      if show_items_section and node_total > 0,
+        do:
+          fetch_card_items(
+            node_scope(current),
+            uuid,
+            mode,
+            item_limit,
+            0,
+            items_sort_opts(socket)
+          ),
+        else: []
+
+    assign(socket,
+      page_title: catalogue.name,
+      catalogue: catalogue,
+      breadcrumb: build_breadcrumb(current, mode),
+      child_categories: child_categories,
+      child_counts: counts_map,
+      children_with_subs: children_with_subs,
+      uncategorized_active_count: uncat_active,
+      items: items,
+      items_total: node_total,
+      items_offset: length(items),
+      items_has_more: length(items) < node_total,
+      show_items_section: show_items_section,
+      level_active_count: active_child_count + node_active_items,
+      level_deleted_count: deleted_child_count + node_deleted_items
+    )
+  end
+
+  # The child categories shown at this level + counts in both modes (for
+  # the toggle). The uncategorized bucket has none. Active mode reuses
+  # orphan promotion; deleted mode is strict (see `list_child_categories/3`).
+  defp load_level_children(_uuid, :uncategorized, _mode), do: {[], MapSet.new(), 0, 0}
+
+  defp load_level_children(uuid, current, mode) do
+    parent_uuid = node_parent_uuid(current)
+    active = Catalogue.list_child_categories(uuid, parent_uuid, mode: :active)
+    deleted = Catalogue.list_child_categories(uuid, parent_uuid, mode: :deleted)
+    subs = Catalogue.category_uuids_with_children(uuid, mode: mode)
+    shown = if mode == :deleted, do: deleted, else: active
+    {shown, subs, length(active), length(deleted)}
+  end
+
+  # The current node's own direct-item counts in both modes. Root and the
+  # uncategorized bucket count the uncategorized items; a category counts
+  # its own direct items.
+  defp node_item_counts(%Category{uuid: u}, counts_active, counts_deleted, _ua, _ud),
+    do: {Map.get(counts_active, u, 0), Map.get(counts_deleted, u, 0)}
+
+  defp node_item_counts(_current, _ca, _cd, uncat_active, uncat_deleted),
+    do: {uncat_active, uncat_deleted}
+
+  # Loads the next page of the current node's own items (the bottom
+  # sentinel during normal browsing — search paging is separate).
+  defp load_next_items_page(socket) do
+    current = socket.assigns.current_category
+    mode = view_mode_to_atom(socket.assigns.view_mode)
+    offset = socket.assigns.items_offset
+
+    page =
+      fetch_card_items(
+        node_scope(current),
+        socket.assigns.catalogue_uuid,
+        mode,
+        @per_page,
+        offset,
+        items_sort_opts(socket)
+      )
+
+    new_offset = offset + length(page)
+
+    assign(socket,
+      items: socket.assigns.items ++ page,
+      items_offset: new_offset,
+      items_has_more: page != [] and new_offset < socket.assigns.items_total
+    )
+  end
+
+  # Parent scope of a node for the child-categories query.
+  defp node_parent_uuid(nil), do: nil
+  defp node_parent_uuid(:uncategorized), do: nil
+  defp node_parent_uuid(%Category{uuid: uuid}), do: uuid
+
+  # The item-fetch scope of a node: a category UUID, or `:uncategorized`
+  # for the root (whose own items are the uncategorized ones) and the
+  # uncategorized bucket.
+  defp node_scope(nil), do: :uncategorized
+  defp node_scope(:uncategorized), do: :uncategorized
+  defp node_scope(%Category{uuid: uuid}), do: uuid
+
+  # Breadcrumb ancestors above the current node (root + current excluded).
+  # In Active mode the chain is trimmed to its contiguous active suffix:
+  # an orphan promoted to root (its parent trashed) gets an empty chain,
+  # so it renders as `Catalogue ▸ <current>` — never a dead link to a
+  # deleted ancestor. In Deleted mode the full chain shows (each crumb
+  # drills within deleted mode).
+  defp build_breadcrumb(%Category{} = cat, :active) do
+    cat.uuid
+    |> Catalogue.list_category_ancestors()
+    |> Enum.reverse()
+    |> Enum.take_while(&(&1.status == "active"))
+    |> Enum.reverse()
+  end
+
+  defp build_breadcrumb(%Category{} = cat, :deleted),
+    do: Catalogue.list_category_ancestors(cat.uuid)
+
+  defp build_breadcrumb(_current, _mode), do: []
+
+  # Reloads the current level after a mutation but keeps the user's
+  # scroll depth — re-fetches at least as many items as are currently
+  # loaded instead of snapping back to page 1 — then runs the auto-flip.
+  defp refresh_counts(socket) do
+    socket
+    |> load_level(max(socket.assigns.items_offset, @per_page))
+    |> maybe_auto_flip_to_active()
+  end
+
+  # Auto-flip: if we're in the Deleted view of a level that no longer has
+  # anything deleted (its subcategories + direct items), bounce back to
+  # Active so the user never lands in an empty Deleted view.
+  defp maybe_auto_flip_to_active(socket) do
+    if socket.assigns.view_mode == "deleted" and socket.assigns.level_deleted_count == 0 do
+      socket
+      |> assign(:view_mode, "active")
+      |> load_level(@per_page)
+    else
+      socket
+    end
+  end
+
+  # PubSub-driven refresh. Reloads the current level preserving scroll
+  # depth so a cross-tab broadcast (another admin, the import wizard)
+  # doesn't collapse a deep item scroll. The `Ecto.NoResultsError` rescue
+  # in the caller handles the catalogue-was-deleted-elsewhere edge case.
+  defp refresh_in_place(socket), do: refresh_counts(socket)
 
   # Runs a fresh search query asynchronously. If a prior search is still
   # in flight, `start_async/3` cancels it — so fast typing (type-pause-
@@ -1532,17 +1522,45 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # `handle_async(:search, ...)`, guarded by a query equality check.
   defp run_search(socket, query) do
     uuid = socket.assigns.catalogue_uuid
+    current = socket.assigns.current_category
 
     socket
     |> assign(search_query: query, search_loading: true)
     |> start_async(:search, fn ->
-      results =
-        Catalogue.search_items_in_catalogue(uuid, query, limit: @per_page, offset: 0)
-
-      total = Catalogue.count_search_items_in_catalogue(uuid, query)
+      results = search_in_scope(uuid, current, query, @per_page, 0)
+      total = search_count_in_scope(uuid, current, query)
       {query, results, total}
     end)
   end
+
+  # Search scope follows the drill level: catalogue-wide at root, the
+  # category's subtree when drilled in (`search_items_in_category/3`
+  # defaults to `include_descendants: true`), and uncategorized-only in
+  # the uncategorized bucket. Search is Active-mode only (the context
+  # search excludes deleted rows), so the input is hidden in Deleted view.
+  defp search_in_scope(uuid, nil, query, limit, offset),
+    do: Catalogue.search_items_in_catalogue(uuid, query, limit: limit, offset: offset)
+
+  defp search_in_scope(uuid, :uncategorized, query, limit, offset),
+    do:
+      Catalogue.search_items(query,
+        catalogue_uuids: [uuid],
+        only: :uncategorized_only,
+        limit: limit,
+        offset: offset
+      )
+
+  defp search_in_scope(_uuid, %Category{uuid: cuuid}, query, limit, offset),
+    do: Catalogue.search_items_in_category(cuuid, query, limit: limit, offset: offset)
+
+  defp search_count_in_scope(uuid, nil, query),
+    do: Catalogue.count_search_items_in_catalogue(uuid, query)
+
+  defp search_count_in_scope(uuid, :uncategorized, query),
+    do: Catalogue.count_search_items(query, catalogue_uuids: [uuid], only: :uncategorized_only)
+
+  defp search_count_in_scope(_uuid, %Category{uuid: cuuid}, query),
+    do: Catalogue.count_search_items_in_category(cuuid, query)
 
   @impl true
   def handle_async(:search, {:ok, {query, results, total}}, socket) do
@@ -1644,12 +1662,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # `handle_async(:search_page, …)` guarded by `{query, offset}` so a
   # superseding new search or a double-scroll can't double-append.
   defp start_search_page(socket) do
-    %{catalogue_uuid: uuid, search_query: query, search_offset: offset} = socket.assigns
+    %{catalogue_uuid: uuid, current_category: current, search_query: query, search_offset: offset} =
+      socket.assigns
 
     socket
     |> assign(:search_loading, true)
     |> start_async(:search_page, fn ->
-      page = Catalogue.search_items_in_catalogue(uuid, query, limit: @per_page, offset: offset)
+      page = search_in_scope(uuid, current, query, @per_page, offset)
       {query, offset, page}
     end)
   end
@@ -1665,51 +1684,36 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     )
   end
 
-  # Removes a trashed/restored/deleted item from its card's items list
-  # in place. No DB reload, so scroll position is preserved.
+  # Removes a trashed/restored/deleted item from the current node's item
+  # list in place. No DB reload, so scroll position is preserved (the
+  # following `refresh_counts` reconciles totals).
   defp remove_item_locally(socket, item_uuid) do
-    cards =
-      Enum.map(socket.assigns.loaded_cards, fn card ->
-        Map.update!(card, :items, fn items ->
-          Enum.reject(items, &(&1.uuid == item_uuid))
-        end)
-      end)
-
-    assign(socket, :loaded_cards, cards)
+    assign(socket, :items, Enum.reject(socket.assigns.items, &(&1.uuid == item_uuid)))
   end
 
-  # Re-fetches the items inside a single loaded card after an in-place
-  # change (DnD reorder, cross-category move). `scope` is the
-  # category UUID, or `:uncategorized` for the no-category bucket.
-  # Cards that don't match the scope pass through untouched. Cursor /
-  # has_more / loading are all left alone — scroll state is preserved.
-  #
-  # `delta` adjusts the loaded count for the affected card:
-  #   * `0` — in-scope reorder (count unchanged)
-  #   * `+1` — destination card after a cross-category drop
-  #   * `-1` — source card after a cross-category drop
-  # Without this, every refresh used to pad +1 unconditionally and the
-  # loaded set crept up by one per reorder.
-  defp refresh_card_items(socket, scope, delta \\ 0) do
-    catalogue_uuid = socket.assigns.catalogue_uuid
-    mode = view_mode_to_atom(socket.assigns.view_mode)
+  # Re-fetches the current node's items after an in-place change (DnD
+  # reorder, or a cross-tab reorder broadcast). `scope` identifies which
+  # node changed; we only reload when it's the node currently on screen,
+  # preserving the loaded slice depth. `delta` is accepted for call-site
+  # compatibility but unused — there is one item list now, no cross-card
+  # count drift to correct.
+  defp refresh_card_items(socket, scope, _delta \\ 0) do
+    if scope == node_scope(socket.assigns.current_category) do
+      catalogue_uuid = socket.assigns.catalogue_uuid
+      mode = view_mode_to_atom(socket.assigns.view_mode)
+      limit = max(socket.assigns.items_offset, @per_page)
+      fresh = fetch_card_items(scope, catalogue_uuid, mode, limit, 0, items_sort_opts(socket))
+      total = card_total(scope, catalogue_uuid, mode)
 
-    fresh_total = card_total(scope, catalogue_uuid, mode)
-
-    cards =
-      Enum.map(socket.assigns.loaded_cards, fn card ->
-        if card_matches_scope?(card, scope) do
-          # Keep the same loaded slice (clamped to the new total) so a
-          # reorder/move doesn't collapse a card the user expanded.
-          limit = max(length(card.items) + delta, @per_card)
-          fresh = fetch_card_items(scope, catalogue_uuid, mode, limit)
-          %{card | items: fresh, total: fresh_total}
-        else
-          card
-        end
-      end)
-
-    assign(socket, :loaded_cards, cards)
+      assign(socket,
+        items: fresh,
+        items_total: total,
+        items_offset: length(fresh),
+        items_has_more: length(fresh) < total
+      )
+    else
+      socket
+    end
   end
 
   defp card_total(:uncategorized, catalogue_uuid, mode) do
@@ -1721,64 +1725,46 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> Map.get(category_uuid, 0)
   end
 
-  defp card_matches_scope?(%{kind: :category, category: %{uuid: uuid}}, scope)
-       when is_binary(scope),
-       do: uuid == scope
-
-  defp card_matches_scope?(%{kind: :uncategorized}, :uncategorized), do: true
-  defp card_matches_scope?(_, _), do: false
-
-  defp fetch_card_items(scope, catalogue_uuid, mode, limit, offset \\ 0)
-
-  defp fetch_card_items(:uncategorized, catalogue_uuid, mode, limit, offset) do
-    Catalogue.list_uncategorized_items_paged(catalogue_uuid,
-      mode: mode,
-      offset: offset,
-      limit: limit
+  defp fetch_card_items(:uncategorized, catalogue_uuid, mode, limit, offset, sort_opts) do
+    Catalogue.list_uncategorized_items_paged(
+      catalogue_uuid,
+      [mode: mode, offset: offset, limit: limit] ++ sort_opts
     )
   end
 
-  defp fetch_card_items(category_uuid, _catalogue_uuid, mode, limit, offset)
+  defp fetch_card_items(category_uuid, _catalogue_uuid, mode, limit, offset, sort_opts)
        when is_binary(category_uuid) do
-    Catalogue.list_items_for_category_paged(category_uuid,
-      mode: mode,
-      offset: offset,
-      limit: limit
+    Catalogue.list_items_for_category_paged(
+      category_uuid,
+      [mode: mode, offset: offset, limit: limit] ++ sort_opts
     )
   end
 
-  # Reloads the category tree (positions changed) and re-sorts
-  # `loaded_cards` to match — without touching the cursor. Used after
-  # category DnD so the user's scroll state is preserved.
+  # Sort opts threaded into the active-list paged fetches. Deleted mode
+  # keeps the position-default order (the deleted list still renders via
+  # the plain item_table without a sort control).
+  defp items_sort_opts(%{assigns: %{view_mode: "active"}} = socket) do
+    [sort_by: socket.assigns.items_sort_by, sort_dir: socket.assigns.items_sort_dir]
+  end
+
+  defp items_sort_opts(_socket), do: []
+
+  # Re-fetches the current level's child categories in their new order
+  # after a sibling DnD reorder. Items are untouched (reorder of the
+  # subcategory cards doesn't affect the node's own item scroll).
   defp refresh_categories_in_place(socket) do
     uuid = socket.assigns.catalogue_uuid
     mode = view_mode_to_atom(socket.assigns.view_mode)
-    tree = Catalogue.list_category_tree(uuid, mode: mode)
-    category_list = Enum.map(tree, fn {cat, _depth} -> cat end)
-    category_depths = Map.new(tree, fn {cat, depth} -> {cat.uuid, depth} end)
 
-    # Build a position index so we can re-sort `loaded_cards` to match
-    # the new tree order. The Uncategorized card stays at the end.
-    tree_index =
-      tree
-      |> Enum.with_index()
-      |> Map.new(fn {{cat, _depth}, idx} -> {cat.uuid, idx} end)
+    child_categories =
+      if socket.assigns.current_category == :uncategorized,
+        do: [],
+        else:
+          Catalogue.list_child_categories(uuid, node_parent_uuid(socket.assigns.current_category),
+            mode: mode
+          )
 
-    sorted_cards =
-      socket.assigns.loaded_cards
-      |> Enum.sort_by(fn
-        %{kind: :category, category: %{uuid: uuid}} ->
-          Map.get(tree_index, uuid, :infinity)
-
-        %{kind: :uncategorized} ->
-          :end_of_list
-      end)
-
-    assign(socket,
-      category_list: category_list,
-      category_depths: category_depths,
-      loaded_cards: sorted_cards
-    )
+    assign(socket, :child_categories, child_categories)
   end
 
   defp view_mode_to_atom("active"), do: :active
@@ -1794,7 +1780,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # kept under their original parent — DnD here is for sibling-only
   # reorder, not reparenting.
   defp apply_category_reorder(socket, ordered_ids, moved_id) do
-    by_uuid = Map.new(socket.assigns.category_list, fn %Category{} = c -> {c.uuid, c} end)
+    by_uuid = Map.new(socket.assigns.child_categories, fn %Category{} = c -> {c.uuid, c} end)
 
     groups =
       ordered_ids
@@ -1850,7 +1836,36 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
       <div :if={@catalogue} class="flex flex-col gap-6">
         <%!-- Header --%>
-        <.admin_page_header back={Paths.index()} title={@catalogue.name}>
+        <%!-- The title doubles as the breadcrumb trail: at root it's just
+             the catalogue name; drilled in it's `Catalogue › … › Current`
+             with the ancestors as muted patch links and the current node
+             as the bold end. `@breadcrumb` is trimmed to the active
+             ancestor chain in Active mode, so an orphan never links to a
+             deleted ancestor. --%>
+        <.admin_page_header>
+          <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content flex flex-wrap items-center gap-x-2 gap-y-1">
+            <%= if @current_category == nil do %>
+              {@catalogue.name}
+            <% else %>
+              <.link
+                patch={Paths.catalogue_detail(@catalogue.uuid)}
+                class="font-normal text-base-content/50 hover:text-primary"
+              >
+                {@catalogue.name}
+              </.link>
+              <%= for cat <- @breadcrumb do %>
+                <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+                <.link
+                  patch={Paths.category_browse(@catalogue.uuid, cat.uuid)}
+                  class="font-normal text-base-content/50 hover:text-primary"
+                >
+                  {cat.name}
+                </.link>
+              <% end %>
+              <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+              <span class="truncate">{current_node_label(@current_category)}</span>
+            <% end %>
+          </h1>
           <:actions :if={@view_mode == "active"}>
             <.link navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-outline btn-sm">
               <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
@@ -1870,41 +1885,21 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           </p>
         </div>
 
-        <%!-- Items / Categories tab bar + per-tab Active/Deleted mode
-             switcher on the same row. The switcher's counts and
-             visibility track the current tab. --%>
-        <div class="flex items-end justify-between border-b border-base-200 gap-4">
-          <div role="tablist" class="tabs tabs-bordered border-none">
-            <button
-              type="button"
-              role="tab"
-              phx-click="switch_tab"
-              phx-value-tab="items"
-              class={["tab", @tab == "items" && "tab-active"]}
-            >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items")}
-            </button>
-            <button
-              type="button"
-              role="tab"
-              phx-click="switch_tab"
-              phx-value-tab="categories"
-              class={["tab", @tab == "categories" && "tab-active"]}
-            >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Categories")} ({length(@category_list)})
-            </button>
-          </div>
+        <%!-- Toolbar: scoped search (Active mode only — context search
+             excludes deleted rows) + per-level Active/Deleted toggle. --%>
+        <div class="flex items-end justify-between gap-4 flex-wrap border-b border-base-200 pb-2">
+          <.search_input
+            :if={@view_mode == "active"}
+            class="grow"
+            query={@search_query}
+            placeholder={search_placeholder(@current_category)}
+          />
+          <div :if={@view_mode != "active"}></div>
 
-          <%!-- Inline mode switcher. Visibility per-tab: Items tab
-               shows it when deleted_item_count > 0 (or already in
-               deleted view); Categories tab uses the category count.
-               Hidden during a live search. --%>
           <div
             :if={
               is_nil(@search_results) and not @search_loading and
-                ((@tab == "items" and (@deleted_item_count > 0 or @view_mode == "deleted")) or
-                   (@tab == "categories" and
-                      (@deleted_category_count > 0 or @view_mode == "deleted")))
+                (@level_deleted_count > 0 or @view_mode == "deleted")
             }
             class="flex items-center gap-0.5 pb-1"
           >
@@ -1920,9 +1915,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 )
               ]}
             >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")} ({if @tab == "categories",
-                do: @active_category_count,
-                else: @active_item_count})
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")} ({@level_active_count})
             </button>
             <button
               type="button"
@@ -1936,44 +1929,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
                 )
               ]}
             >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({if @tab == "categories",
-                do: @deleted_category_count,
-                else: @deleted_item_count})
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({@level_deleted_count})
             </button>
           </div>
         </div>
 
-        <%!-- ── Items tab ────────────────────────────────────────── --%>
-        <div :if={@tab == "items"} class="flex flex-col gap-6">
-          <%!-- Search (Items tab only — Categories tab has no search yet) --%>
-          <.search_input :if={@view_mode == "active"} query={@search_query} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items by name, description, or SKU...")} />
-
-          <%!-- Combined row: bulk-action contents on the left (when
-               items are selected), card/table view toggle on the right.
-               Becomes sticky + styled when bulk is active so the
-               actions stay reachable while the user scrolls. --%>
-          <div
-            :if={MapSet.size(@selected_items) > 0 or @category_list != []}
-            class={[
-              "flex items-center justify-between gap-3",
-              MapSet.size(@selected_items) > 0 &&
-                "sticky top-[72px] z-40 -mx-1 px-3 py-2 rounded-lg bg-base-100/95 border border-primary/40 shadow-md backdrop-blur"
-            ]}
-          >
-            <.items_bulk_actions
-              :if={MapSet.size(@selected_items) > 0}
-              count={MapSet.size(@selected_items)}
-              view_mode={@view_mode}
-            />
-            <%!-- Spacer keeps justify-between pushing the toggle right
-                 when nothing is selected. --%>
-            <div :if={MapSet.size(@selected_items) == 0}></div>
-            <.view_mode_toggle :if={@category_list != []} storage_key="catalogue-detail-items" />
-          </div>
-
-        <%!-- Search results (visible when the user has typed a query) --%>
+        <%!-- Search results (Active mode; unchanged machinery) --%>
         <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
-          <%!-- Status line: spinner while loading, "X of Y results" when settled --%>
           <div class="flex items-center gap-2">
             <%= if @search_loading and is_nil(@search_results) do %>
               <span class="text-sm text-base-content/60">
@@ -1987,8 +1949,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
           <.empty_state :if={@search_results == [] and not @search_loading} variant="card" title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
 
-          <%!-- Stale results are dimmed while a newer query is in flight to
-               signal that the list is about to update. --%>
           <div :if={@search_results not in [nil, []]} class={["transition-opacity", @search_loading && "opacity-50"]}>
             <.item_table
               items={@search_results}
@@ -2003,145 +1963,110 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             />
           </div>
 
-          <%!-- Infinite-scroll sentinel for search results --%>
-          <div
-            :if={@search_has_more and not @search_loading}
-            id="search-load-more-sentinel"
-            phx-hook="InfiniteScroll"
-            data-cursor={"search-#{@search_offset}"}
-            class="py-4"
-          >
-            <div class="flex justify-center">
-              <span class="loading loading-spinner loading-sm text-base-content/30"></span>
-            </div>
-          </div>
-        </div>
-
-        <%!-- Status switcher moved to the tabs row above. --%>
-
-        <%!-- Empty states --%>
-        <div :if={is_nil(@search_results) and not @search_loading and @loaded_cards == [] and @view_mode == "active"} class="card bg-base-100 shadow">
-          <div class="card-body items-center text-center py-12">
-            <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No categories or items yet. Add a category or item to get started.")}</p>
-          </div>
-        </div>
-
-        <div :if={is_nil(@search_results) and not @search_loading and @deleted_items == [] and @view_mode == "deleted"} class="card bg-base-100 shadow">
-          <div class="card-body items-center text-center py-12">
-            <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No deleted items.")}</p>
-          </div>
-        </div>
-
-        <%!-- Active view: every category card eagerly rendered with a
-             25-item preview. Each card has its own "Show N more"
-             button (PdfSearchModal-style per-group expand) so the user
-             can scan the catalogue's structure at a glance and drill
-             into the categories they care about. --%>
-        <div
-          :if={is_nil(@search_results) and not @search_loading and @view_mode == "active" and @loaded_cards != []}
-          id="catalogue-detail-cards"
-          class="flex flex-col gap-6"
-        >
-          <%= for {card, card_idx} <- Enum.with_index(@loaded_cards) do %>
-            <div>
-              <.detail_card
-                card={card}
-                card_idx={card_idx}
-                view_mode={@view_mode}
-                category_total={length(@category_list)}
-                category_counts={@category_counts}
-                category_depths={@category_depths}
-                category_list={@category_list}
-                uncategorized_total={@uncategorized_total}
-                catalogue={@catalogue}
-                selected_items={@selected_items}
-                expanding={MapSet.member?(@expanding_cards, scope_key(card))}
-              />
-            </div>
-          <% end %>
-        </div>
-
-        <%!-- Deleted view: flat list ordered by deletion date. No
-             category grouping — the boss wants a recency-ordered audit
-             list, not a tree. --%>
-        <div
-          :if={is_nil(@search_results) and not @search_loading and @view_mode == "deleted" and @deleted_items != []}
-          id="catalogue-detail-deleted-items"
-        >
-          <.item_table
-            items={@deleted_items}
-            columns={[:name, :sku, :unit, :status]}
-            on_restore="restore_item"
-            on_permanent_delete="show_delete_confirm"
-            permanent_delete_type="item"
-            cards={true}
-            show_toggle={false}
-            storage_key="catalogue-detail-items"
-            id="catalogue-deleted-items"
-            selectable={true}
-            selected_uuids={@selected_items}
-            on_toggle_select="toggle_select_item"
+          <.load_more
+            :if={@search_results not in [nil, []]}
+            id="search-load-more"
+            loaded={length(@search_results)}
+            total={@search_total}
+            noun_plural={Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}
+            infinite={not @search_loading}
+            cursor={"search-#{@search_offset}"}
           />
         </div>
-        </div>
-        <%!-- ── /Items tab ───────────────────────────────────────── --%>
 
-        <%!-- ── Categories tab ───────────────────────────────────── --%>
-        <div :if={@tab == "categories"} class="flex flex-col gap-4">
-          <%!-- Bulk-action bar for categories. Active view: Delete (opens
-               disposition modal in bulk mode). Deleted view: Restore.
-               Selection cleared on tab/view-mode switch. --%>
+        <%!-- ── Browse view (no active search) ──────────────────────── --%>
+        <div :if={is_nil(@search_results) and not @search_loading} class="flex flex-col gap-6">
+          <%!-- The Uncategorized drill card only appears when there are
+               categories to drill past. With no categories, the items
+               render inline (see `show_items_section`), so the card would
+               be a redundant extra click. --%>
+          <% show_uncat_card =
+            is_nil(@current_category) and @view_mode == "active" and
+              @uncategorized_active_count > 0 and @child_categories != [] %>
+
+          <%!-- Category bulk-action bar (when subcategories selected) --%>
           <.categories_bulk_bar
             :if={MapSet.size(@selected_categories) > 0}
             count={MapSet.size(@selected_categories)}
             view_mode={@view_mode}
           />
 
-          <%!-- Status switcher moved to the tabs row above. --%>
-
-          <% visible_category_count =
-            if @view_mode == "deleted", do: @deleted_category_count, else: @active_category_count %>
-
-          <div :if={visible_category_count == 0} class="card bg-base-100 shadow">
-            <div class="card-body items-center text-center py-12">
-              <p class="text-base-content/60">
-                {if @view_mode == "deleted",
-                  do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No deleted categories."),
-                  else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No categories yet. Add one to start organizing items.")}
-              </p>
-              <.link :if={@view_mode == "active"} navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-primary btn-sm mt-2">
-                <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
-              </.link>
-            </div>
-          </div>
-
-          <%!-- Flat list of categories with depth indent. Same DnD wiring
-               as the Items tab so reorder works identically. --%>
+          <%!-- Subcategory rows (+ Uncategorized row at root/active),
+               one per line. Sibling reorder via SortableGrid in active mode. --%>
           <div
-            :if={visible_category_count > 0}
-            id="catalogue-categories-list"
+            :if={@child_categories != [] or show_uncat_card}
+            id="catalogue-child-categories"
             class="flex flex-col gap-2"
             data-sortable="true"
             data-sortable-event="reorder_categories"
             data-sortable-items=".sortable-item"
             data-sortable-hide-source="false"
-            data-sortable-group="catalogue-categories-tab"
+            data-sortable-group="catalogue-child-categories"
             data-sortable-handle=".pk-drag-handle"
             phx-hook={if @view_mode == "active", do: "SortableGrid"}
           >
-            <%= for cat <- @category_list do %>
-              <.category_row
+            <%= for cat <- @child_categories do %>
+              <.category_drill_card
+                catalogue_uuid={@catalogue.uuid}
                 category={cat}
-                depth={Map.get(@category_depths, cat.uuid, 0)}
-                count={Map.get(@category_counts, cat.uuid, 0)}
+                count={Map.get(@child_counts, cat.uuid, 0)}
+                has_subs={MapSet.member?(@children_with_subs, cat.uuid)}
                 view_mode={@view_mode}
-                sibling_count={Enum.count(@category_list, &(&1.parent_uuid == cat.parent_uuid))}
+                sibling_count={length(@child_categories)}
                 selected={MapSet.member?(@selected_categories, cat.uuid)}
               />
             <% end %>
+            <.uncategorized_drill_card
+              :if={show_uncat_card}
+              catalogue_uuid={@catalogue.uuid}
+              count={@uncategorized_active_count}
+              sibling_count={length(@child_categories)}
+            />
           </div>
+
+          <%!-- Deleted-list bulk-action bar (server-side select). The
+               active list owns its selection client-side via the core
+               BulkSelectScope toolkit inside `level_items`. --%>
+          <div
+            :if={@view_mode == "deleted" and MapSet.size(@selected_items) > 0}
+            class="sticky top-[72px] z-40 -mx-1 px-3 py-2 rounded-lg bg-base-100/95 border border-primary/40 shadow-md backdrop-blur flex items-center"
+          >
+            <.items_bulk_actions count={MapSet.size(@selected_items)} view_mode={@view_mode} />
+          </div>
+
+          <%!-- Card/table view toggle — deleted list only (it still
+               renders via `item_table` with a card view). The active
+               list is the core-toolkit table (table-only). --%>
+          <div :if={@view_mode == "deleted" and @show_items_section and @items != []} class="flex justify-end">
+            <.view_mode_toggle storage_key="catalogue-detail-items" />
+          </div>
+
+          <%!-- The current node's own direct items --%>
+          <.level_items
+            :if={@show_items_section}
+            items={@items}
+            view_mode={@view_mode}
+            catalogue={@catalogue}
+            current_category={@current_category}
+            current_category_uuid={@current_category_uuid}
+            selected_items={@selected_items}
+            items_total={@items_total}
+            items_offset={@items_offset}
+            items_sort_by={@items_sort_by}
+            items_sort_dir={@items_sort_dir}
+            show_items_reorder={@show_items_reorder}
+            reorder_captured_uuids={@reorder_captured_uuids}
+          />
+
+          <%!-- Level is completely empty (root/active with no categories
+               and no uncategorized items). The items section renders its
+               own empty message for drilled-in nodes. --%>
+          <.empty_state
+            :if={@child_categories == [] and not show_uncat_card and not @show_items_section}
+            variant="card"
+            title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No categories or items yet. Add a category or item to get started.")}
+          />
         </div>
-        <%!-- ── /Categories tab ──────────────────────────────────── --%>
       </div>
 
       <.confirm_modal
@@ -2422,259 +2347,379 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         show={@show_pdf_search}
       />
     </div>
-
-    <script>
-      window.PhoenixKitHooks = window.PhoenixKitHooks || {};
-      window.PhoenixKitHooks.InfiniteScroll = window.PhoenixKitHooks.InfiniteScroll || {
-        mounted() {
-          this.intersecting = false;
-          this.observer = new IntersectionObserver((entries) => {
-            this.intersecting = entries[0].isIntersecting;
-            if (this.intersecting) {
-              this.pushEvent("load_more", {});
-            }
-          }, { rootMargin: "200px" });
-          this.observer.observe(this.el);
-        },
-        updated() {
-          // IntersectionObserver only fires on state transitions. When the
-          // viewport is tall or the user jumped via Page Down / resize, the
-          // sentinel stays continuously in view across batches — so the
-          // observer goes silent after the first fire. Re-trigger explicitly
-          // whenever the server patches us while we're still on-screen.
-          // The server's `loading` guard dedupes duplicate events.
-          if (this.intersecting) {
-            this.pushEvent("load_more", {});
-          }
-        },
-        destroyed() {
-          this.observer.disconnect();
-        }
-      };
-    </script>
     """
   end
 
-  # Renders one card in the detail view: a category with its
-  # progressively-loaded items, or the Uncategorized bucket.
-  attr(:card, :map, required: true)
-  attr(:card_idx, :integer, required: true)
+  # ── Drill-down level components ──────────────────────────────────
+
+  # A subcategory shown at the current level. The name + chevron are the
+  # drill link into the category; checkbox + drag handle + edit pencil are
+  # separate controls so they don't fire the drill. Deleted mode swaps in
+  # Restore / Delete-forever (the name still drills, to inspect the
+  # deleted subtree). A folder badge marks categories with subcategories.
+  attr(:catalogue_uuid, :string, required: true)
+  attr(:category, :map, required: true)
+  attr(:count, :integer, required: true)
+  attr(:has_subs, :boolean, default: false)
   attr(:view_mode, :string, required: true)
-  attr(:category_total, :integer, required: true)
-  attr(:category_counts, :map, required: true)
-  attr(:category_depths, :map, default: %{})
-  attr(:category_list, :list, default: [])
-  attr(:uncategorized_total, :integer, required: true)
-  attr(:catalogue, :any, required: true)
-  attr(:selected_items, :any, default: nil)
-  attr(:expanding, :boolean, default: false)
+  attr(:sibling_count, :integer, required: true)
+  attr(:selected, :boolean, default: false)
 
-  defp detail_card(%{card: %{kind: :category}} = assigns) do
-    %{uuid: uuid} = assigns.card.category
-
-    assigns =
-      assigns
-      |> assign(:total, assigns.card[:total] || Map.get(assigns.category_counts, uuid, 0))
-      |> assign(:depth, Map.get(assigns.category_depths, uuid, 0))
-      |> assign(:loaded, length(assigns.card.items))
-
+  defp category_drill_card(assigns) do
     ~H"""
     <div
-      :if={@view_mode == "active" or @card.category.status == "deleted" or @total > 0}
-      class="card bg-base-100 shadow"
-      style={"margin-left: #{@depth * 1.5}rem"}
+      class={[
+        "group card card-sm bg-base-100 shadow",
+        @view_mode == "active" and @category.status == "active" && "sortable-item"
+      ]}
+      data-id={@view_mode == "active" and @category.status == "active" && @category.uuid}
     >
-      <div class="card-body">
-        <div class="flex items-center justify-between">
-          <div class="flex items-center gap-2">
-            <h3
-              class={["card-title text-lg", @card.category.status == "deleted" && "text-error/70"]}
+      <div class="card-body py-3 flex-row items-center justify-between gap-3">
+        <div class="flex items-center gap-2 min-w-0">
+          <div :if={@view_mode == "active" and @category.status == "active"} class="flex items-center gap-1.5 shrink-0">
+            <span
+              :if={@sibling_count > 1}
+              class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 opacity-0 group-hover:opacity-100 transition-opacity"
+              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to reorder (among siblings)")}
             >
-              {@card.category.name}
-            </h3>
-            <%!-- Active categories: hover-revealed pencil icon to edit
-                 (replaces the old Edit button, per the boss). Delete
-                 moves into the bulk-action bar via row checkboxes. --%>
-            <.link
-              :if={@view_mode == "active" and @card.category.status == "active"}
-              navigate={Paths.category_edit(@card.category.uuid)}
-              class="text-base-content/40 hover:text-primary"
-              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit category")}
-            >
-              <.icon name="hero-pencil" class="w-4 h-4" />
-            </.link>
-            <span :if={@card.category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
-            <span class="badge badge-ghost badge-sm">{@total} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}</span>
+              <.icon name="hero-bars-3" class="w-4 h-4" />
+            </span>
+            <input
+              type="checkbox"
+              class="checkbox checkbox-xs"
+              checked={@selected}
+              phx-click="toggle_select_category"
+              phx-value-uuid={@category.uuid}
+            />
           </div>
 
-          <%!-- Active mode: no per-card buttons. The Items tab is
-               read-only structure; deletion happens via item-level
-               selection or via the Categories tab. --%>
+          <.link
+            patch={Paths.category_browse(@catalogue_uuid, @category.uuid)}
+            class={["font-medium truncate hover:text-primary", @category.status == "deleted" && "text-error/70"]}
+          >
+            {@category.name}
+          </.link>
 
-          <%!-- Deleted mode: Restore + Permanent Delete (for deleted categories) --%>
-          <div :if={@view_mode == "deleted" && @card.category.status == "deleted"} class="flex gap-1">
-            <button
-              phx-click="restore_category"
-              phx-value-uuid={@card.category.uuid}
-              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
-              class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
-            >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
-            </button>
-            <button
-              phx-click="show_delete_confirm"
-              phx-value-uuid={@card.category.uuid}
-              phx-value-type="category"
-              class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-error/30 bg-error/10 hover:bg-error/20 text-error text-xs font-medium transition-colors cursor-pointer"
-            >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
-            </button>
-          </div>
+          <span
+            :if={@has_subs}
+            class="badge badge-ghost badge-xs"
+            title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Has subcategories")}
+          >
+            <.icon name="hero-rectangle-stack" class="w-3 h-3" />
+          </span>
+          <span :if={@category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
+          <span :if={@category.status == "active"} class="badge badge-ghost badge-sm shrink-0">
+            {@count} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}
+          </span>
         </div>
 
-        <p :if={@card.category.description && @view_mode == "active"} class="text-sm text-base-content/60">
-          {@card.category.description}
-        </p>
+        <div class="flex items-center gap-1 shrink-0">
+          <.link
+            :if={@view_mode == "active" and @category.status == "active"}
+            navigate={Paths.category_edit(@category.uuid)}
+            class="text-base-content/40 hover:text-primary"
+            title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit category")}
+          >
+            <.icon name="hero-pencil" class="w-4 h-4" />
+          </.link>
 
-        <%!-- Items table: active mode --%>
-        <div :if={@card.items != [] and @view_mode == "active"} class="mt-2">
-          <.item_table
-            items={@card.items}
-            columns={[:name, :sku, :price, :unit, :status]}
-            markup_percentage={@catalogue.markup_percentage}
-            edit_path={&Paths.item_edit/1}
-            on_delete="delete_item"
-            pdf_search_event="show_pdf_search"
-            cards={true}
-            show_toggle={false}
-            storage_key="catalogue-detail-items"
-            id={"cat-items-active-#{@card.category.uuid}"}
-            wrapper_class="overflow-x-auto shadow-none rounded-none"
-            on_reorder="reorder_items"
-            reorder_group="catalogue-items"
-            reorder_scope={%{
-              catalogue_uuid: @catalogue.uuid,
-              category_uuid: @card.category.uuid
-            }}
-            selectable={true}
-            selected_uuids={@selected_items}
-            on_toggle_select="toggle_select_item"
-          />
-          <%!-- Per-category "Show N more" — same expand-on-demand
-               pattern as the PDF search modal. --%>
-          <div :if={@loaded < @total} class="flex justify-center pt-2">
-            <button
-              type="button"
-              phx-click="expand_card"
-              phx-value-scope={@card.category.uuid}
-              disabled={@expanding}
-              class="btn btn-ghost btn-xs"
-            >
-              <%= if @expanding do %>
-                <span class="loading loading-spinner loading-xs"></span>
-                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Loading…")}
-              <% else %>
-                <.icon name="hero-chevron-down" class="w-3 h-3" />
-                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Show %{n} more", n: @total - @loaded)}
-              <% end %>
-            </button>
-          </div>
-        </div>
-        <%!-- Items table: deleted mode --%>
-        <div :if={@card.items != [] and @view_mode == "deleted"} class="mt-2">
-          <.item_table
-            items={@card.items}
-            columns={[:name, :sku, :price, :unit, :status]}
-            markup_percentage={@catalogue.markup_percentage}
-            on_restore="restore_item"
-            on_permanent_delete="show_delete_confirm"
-            permanent_delete_type="item"
-            cards={true}
-            show_toggle={false}
-            storage_key="catalogue-detail-items"
-            id={"cat-items-deleted-#{@card.category.uuid}"}
-            wrapper_class="overflow-x-auto shadow-none rounded-none"
-          />
-        </div>
+          <button
+            :if={@view_mode == "deleted" and @category.status == "deleted"}
+            phx-click="restore_category"
+            phx-value-uuid={@category.uuid}
+            phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
+            class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
+          >
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
+          </button>
+          <button
+            :if={@view_mode == "deleted" and @category.status == "deleted"}
+            phx-click="show_delete_confirm"
+            phx-value-uuid={@category.uuid}
+            phx-value-type="category"
+            class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-error/30 bg-error/10 hover:bg-error/20 text-error text-xs font-medium transition-colors cursor-pointer"
+          >
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
+          </button>
 
-        <p :if={@card.items == [] and @view_mode == "active"} class="text-sm text-base-content/40 text-center py-4">
-          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items in this category.")}
-        </p>
+          <.link
+            patch={Paths.category_browse(@catalogue_uuid, @category.uuid)}
+            class="text-base-content/30 group-hover:text-base-content/60"
+            title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Open")}
+          >
+            <.icon name="hero-chevron-right" class="w-4 h-4" />
+          </.link>
+        </div>
       </div>
     </div>
     """
   end
 
-  defp detail_card(%{card: %{kind: :uncategorized}} = assigns) do
-    assigns = assign(assigns, :loaded, length(assigns.card.items))
+  # The root-level "Uncategorized" drill card (Active mode only). The
+  # whole card drills into the uncategorized bucket.
+  attr(:catalogue_uuid, :string, required: true)
+  attr(:count, :integer, required: true)
+  attr(:sibling_count, :integer, default: 0)
+
+  defp uncategorized_drill_card(assigns) do
+    ~H"""
+    <.link
+      patch={Paths.uncategorized_browse(@catalogue_uuid)}
+      class="card card-sm bg-base-100 shadow hover:shadow-md transition-shadow"
+    >
+      <div class="card-body py-3 flex-row items-center justify-between gap-2">
+        <div class="flex items-center gap-2 min-w-0">
+          <%!-- Mirror the category cards' handle + checkbox cluster so the
+               "Uncategorized" name lines up with the category names. The
+               inbox sits in the (always-present) checkbox slot; the drag
+               handle slot is an invisible spacer, gated the same way. --%>
+          <div class="flex items-center gap-1.5 shrink-0">
+            <span :if={@sibling_count > 1} class="w-4 h-4" aria-hidden="true"></span>
+            <.icon name="hero-inbox" class="w-4 h-4 text-base-content/40" />
+          </div>
+          <span class="font-medium truncate text-base-content/70">
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Uncategorized")}
+          </span>
+          <span class="badge badge-ghost badge-sm shrink-0">{@count}</span>
+        </div>
+        <.icon name="hero-chevron-right" class="w-4 h-4 text-base-content/30" />
+      </div>
+    </.link>
+    """
+  end
+
+  # The current node's own direct items.
+  #
+  # Active mode: the core List-UI toolkit — a sort dropdown, client-side
+  # bulk-select with a floating actions toolbar, node-scoped DnD reorder
+  # (manual mode only), and a strategy "Reorder" modal. Deleted mode:
+  # the existing `<.item_table>` (Restore / Delete-forever per row +
+  # server-side selection). One InfiniteScroll sentinel pages the list.
+  attr(:items, :list, required: true)
+  attr(:view_mode, :string, required: true)
+  attr(:catalogue, :any, required: true)
+  attr(:current_category, :any, required: true)
+  attr(:current_category_uuid, :any, required: true)
+  attr(:selected_items, :any, required: true)
+  attr(:items_total, :integer, required: true)
+  attr(:items_offset, :integer, required: true)
+  attr(:items_sort_by, :atom, required: true)
+  attr(:items_sort_dir, :atom, required: true)
+  attr(:show_items_reorder, :boolean, required: true)
+  attr(:reorder_captured_uuids, :list, required: true)
+
+  defp level_items(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :draggable?,
+        assigns.items_sort_by == :position and assigns.view_mode == "active"
+      )
 
     ~H"""
-    <div class="card bg-base-100 shadow">
-      <div class="card-body">
-        <div :if={@category_total > 0} class="flex items-center gap-2">
-          <h3 class="card-title text-lg text-base-content/70">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Uncategorized")}</h3>
-          <span class="badge badge-ghost badge-sm">{@uncategorized_total} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}</span>
-        </div>
-
-        <div class={if @category_total > 0, do: "mt-2", else: ""}>
-          <.item_table
-            items={@card.items}
-            columns={[:name, :sku, :unit, :status]}
-            edit_path={if @view_mode == "active", do: &Paths.item_edit/1}
-            on_delete={if @view_mode == "active", do: "delete_item"}
-            on_restore={if @view_mode == "deleted", do: "restore_item"}
-            on_permanent_delete={if @view_mode == "deleted", do: "show_delete_confirm"}
-            permanent_delete_type="item"
-            pdf_search_event={if @view_mode == "active", do: "show_pdf_search"}
-            cards={true}
-            show_toggle={false}
-            storage_key="catalogue-detail-items"
-            id={"uncategorized-items-#{@card_idx}"}
-            on_reorder={if @view_mode == "active", do: "reorder_items"}
-            reorder_group="catalogue-items"
-            reorder_scope={%{
-              catalogue_uuid: @catalogue.uuid,
-              category_uuid: nil
-            }}
-            selectable={@view_mode == "active"}
-            selected_uuids={@selected_items}
-            on_toggle_select="toggle_select_item"
-          />
-          <div :if={@loaded < @uncategorized_total and @view_mode == "active"} class="flex justify-center pt-2">
+    <div class="flex flex-col gap-2">
+      <%!-- ── Active list: core List-UI toolkit ── --%>
+      <.bulk_select_scope
+        :if={@items != [] and @view_mode == "active"}
+        id={"items-bulk-" <> (@current_category_uuid || "root")}
+        total_count={@items_total}
+        class="flex flex-col gap-2"
+      >
+        <.bulk_actions_toolbar
+          on_open_reorder="open_items_reorder_modal"
+          reorder_dialog_id="items-reorder-modal"
+          reorder_gate={if @items_sort_by == :position, do: :always, else: :multi}
+          on_bulk_delete="request_bulk_delete_items"
+          noun_singular={Gettext.gettext(PhoenixKitCatalogue.Gettext, "item")}
+          noun_plural={Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}
+        >
+          <:leading>
+            <.sort_selector
+              sort_by={@items_sort_by}
+              sort_dir={@items_sort_dir}
+              options={item_sort_options()}
+              manual_field={:position}
+              event="sort_items"
+            />
+            <%!-- Move isn't a built-in toolbar action (core ships
+                 Reorder/Delete/Clear), so it's a custom client-side
+                 button: `data-bulk-action` makes the BulkSelectScope
+                 hook push the captured uuids as `%{"uuids" => [...]}`.
+                 Shown only when ≥1 row is selected. --%>
             <button
               type="button"
-              phx-click="expand_card"
-              phx-value-scope="uncategorized"
-              disabled={@expanding}
-              class="btn btn-ghost btn-xs"
+              class="btn btn-sm btn-ghost"
+              data-bulk-action="request_bulk_move_items"
+              data-bulk-show="has-selection"
+              style="display: none;"
             >
-              <%= if @expanding do %>
-                <span class="loading loading-spinner loading-xs"></span>
-                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Loading…")}
-              <% else %>
-                <.icon name="hero-chevron-down" class="w-3 h-3" />
-                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Show %{n} more", n: @uncategorized_total - @loaded)}
-              <% end %>
+              <.icon name="hero-arrows-right-left" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
             </button>
-          </div>
-        </div>
-      </div>
+          </:leading>
+        </.bulk_actions_toolbar>
+
+        <.table_default id="level-items-active" size="sm" wrapper_class="overflow-x-auto shadow-none rounded-none">
+          <.table_default_header>
+            <.table_default_row>
+              <.drag_handle_header_cell :if={@draggable?} />
+              <.bulk_select_header_cell
+                id="level-items-select-all"
+                aria_label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Select all items")}
+              />
+              <.sort_header_cell field={:name} sort={%{by: @items_sort_by, dir: @items_sort_dir}} event="toggle_sort_items">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}
+              </.sort_header_cell>
+              <.sort_header_cell field={:sku} sort={%{by: @items_sort_by, dir: @items_sort_dir}} event="toggle_sort_items">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "SKU")}
+              </.sort_header_cell>
+              <.sort_header_cell field={:base_price} sort={%{by: @items_sort_by, dir: @items_sort_dir}} event="toggle_sort_items">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Price")}
+              </.sort_header_cell>
+              <.table_default_header_cell>
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Unit")}
+              </.table_default_header_cell>
+              <.sort_header_cell field={:status} sort={%{by: @items_sort_by, dir: @items_sort_dir}} event="toggle_sort_items">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
+              </.sort_header_cell>
+              <.table_default_header_cell class="text-right whitespace-nowrap">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}
+              </.table_default_header_cell>
+            </.table_default_row>
+          </.table_default_header>
+          <.sortable_tbody
+            id={"items-body-" <> (@current_category_uuid || "root")}
+            enabled={@draggable?}
+            event="reorder_items"
+          >
+            <.sortable_row :for={item <- @items} item_id={item.uuid}>
+              <.drag_handle_cell :if={@draggable?} />
+              <.bulk_select_cell value={item.uuid} />
+              <.item_pricing_cell item={item} edit_path={&Paths.item_edit/1} />
+              <.item_row_menu
+                item={item}
+                edit_path={&Paths.item_edit/1}
+                on_delete="delete_item"
+                pdf_search_event="show_pdf_search"
+              />
+            </.sortable_row>
+          </.sortable_tbody>
+        </.table_default>
+      </.bulk_select_scope>
+
+      <%!-- ── Deleted list: existing item_table (read-only-ish) ── --%>
+      <.item_table
+        :if={@items != [] and @view_mode == "deleted"}
+        items={@items}
+        columns={[:name, :sku, :unit, :status]}
+        on_restore="restore_item"
+        on_permanent_delete="show_delete_confirm"
+        permanent_delete_type="item"
+        cards={true}
+        show_toggle={false}
+        storage_key="catalogue-detail-items"
+        id="level-items-deleted"
+        wrapper_class="overflow-x-auto shadow-none rounded-none"
+        selectable={true}
+        selected_uuids={@selected_items}
+        on_toggle_select="toggle_select_item"
+      />
+
+      <p :if={@items == []} class="text-sm text-base-content/40 text-center py-8">
+        {level_items_empty(@current_category, @view_mode)}
+      </p>
+
+      <%!-- Core load-more footer: "Showing N of M" + a manual button,
+           and (via `infinite`) auto-loads on scroll through core's
+           InfiniteScroll hook. --%>
+      <.load_more
+        :if={@items != []}
+        id="level-items-load-more"
+        loaded={length(@items)}
+        total={@items_total}
+        noun_plural={Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}
+        infinite
+        cursor={"items-#{@items_offset}"}
+      />
+
+      <%!-- Strategy reorder modal (active list). Kept-in-DOM so the
+           toolbar's `data-bulk-opens-dialog` opens it instantly. --%>
+      <.reorder_modal
+        :if={@view_mode == "active"}
+        id="items-reorder-modal"
+        show={@show_items_reorder}
+        on_close="close_items_reorder_modal"
+        on_apply="apply_items_reorder"
+        selected_count={length(@reorder_captured_uuids)}
+        total_count={@items_total}
+        strategies={item_reorder_strategies()}
+        noun_singular={Gettext.gettext(PhoenixKitCatalogue.Gettext, "item")}
+        noun_plural={Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}
+      />
     </div>
     """
   end
 
-  # One row in the Categories tab — a compact card with depth indent,
-  # drag handle (active mode only, when there are siblings to swap with),
-  # name (linked to edit), item count, and per-mode actions.
+  # Active-list sort dropdown options. `:position` is "Manual" (the DnD
+  # mode). gettext via the module backend so labels localize.
+  defp item_sort_options do
+    [
+      {:position, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manual")},
+      {:name, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")},
+      {:sku, Gettext.gettext(PhoenixKitCatalogue.Gettext, "SKU")},
+      {:base_price, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Price")},
+      {:status, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
+    ]
+  end
+
+  # Strategy-reorder modal options. Values must match the keys in
+  # `@items_reorder_strategy_map`.
+  defp item_reorder_strategies do
+    [
+      {"name_asc", Gettext.gettext(PhoenixKitCatalogue.Gettext, "A → Z by name")},
+      {"name_desc", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Z → A by name")},
+      {"created_desc", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Newest first")},
+      {"created_asc", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Oldest first")},
+      {"reverse", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Reverse current order")}
+    ]
+  end
+
+  # ── Drill-level label helpers ────────────────────────────────────
+
+  defp current_node_label(:uncategorized),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Uncategorized")
+
+  defp current_node_label(%Category{} = cat), do: cat.name
+  defp current_node_label(_), do: ""
+
+  defp search_placeholder(nil),
+    do:
+      Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items by name, description, or SKU...")
+
+  defp search_placeholder(:uncategorized),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search uncategorized items...")
+
+  defp search_placeholder(%Category{}),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search within this category...")
+
+  defp level_items_empty(_current, "deleted"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Nothing deleted here.")
+
+  defp level_items_empty(:uncategorized, _),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No uncategorized items.")
+
+  defp level_items_empty(_current, _),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items in this category.")
+
   # ── Bulk-action bars ─────────────────────────────────────────────
 
   attr(:count, :integer, required: true)
   attr(:view_mode, :string, required: true)
 
-  # Inline bulk-actions content for the Items tab. Renders as a flex
-  # cluster (count + buttons) without an outer box — the parent row
-  # supplies the sticky/styled container so the toggle and the bulk
-  # actions share one row.
+  # Inline bulk-actions content for the DELETED items list (Restore /
+  # Delete forever / Clear). The active list owns its own client-side
+  # toolbar via the core BulkSelectScope toolkit, so this bar only
+  # serves the server-side `@selected_items` selection in Deleted mode.
   defp items_bulk_actions(assigns) do
     ~H"""
     <div class="flex flex-wrap items-center gap-3 grow">
@@ -2682,25 +2727,14 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} selected", count: @count)}
       </span>
       <div class="flex items-center gap-2">
-        <%= if @view_mode == "active" do %>
-          <button phx-click="request_bulk_move_items" class="btn btn-sm btn-outline">
-            <.icon name="hero-arrows-right-left" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
-          </button>
-          <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
-            <.icon name="hero-trash" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
-          </button>
-        <% else %>
-          <button phx-click="request_bulk_restore_items" class="btn btn-sm btn-outline btn-success">
-            <.icon name="hero-arrow-path" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
-          </button>
-          <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
-            <.icon name="hero-trash" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete forever")}
-          </button>
-        <% end %>
+        <button phx-click="request_bulk_restore_items" class="btn btn-sm btn-outline btn-success">
+          <.icon name="hero-arrow-path" class="w-4 h-4" />
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
+        </button>
+        <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
+          <.icon name="hero-trash" class="w-4 h-4" />
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete forever")}
+        </button>
         <button phx-click="clear_selection" class="btn btn-sm btn-ghost">
           {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
         </button>
@@ -2733,114 +2767,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         <button phx-click="clear_selection" class="btn btn-sm btn-ghost">
           {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Clear")}
         </button>
-      </div>
-    </div>
-    """
-  end
-
-  attr(:category, :map, required: true)
-  attr(:depth, :integer, required: true)
-  attr(:count, :integer, required: true)
-  attr(:view_mode, :string, required: true)
-  attr(:sibling_count, :integer, required: true)
-  attr(:selected, :boolean, default: false)
-
-  defp category_row(assigns) do
-    ~H"""
-    <div
-      :if={@view_mode == "active" or @category.status == "deleted"}
-      class={[
-        "group",
-        cond do
-          @view_mode == "active" and @category.status == "active" -> "sortable-item"
-          true -> "sortable-ignore"
-        end
-      ]}
-      data-id={@category.status == "active" && @category.uuid}
-      style={"margin-left: #{@depth * 1.5}rem"}
-    >
-      <div class="card card-sm bg-base-100 shadow">
-        <div class="card-body py-3 flex-row items-center justify-between gap-3">
-          <div class="flex items-center gap-2 min-w-0">
-            <%!-- Active mode: combined checkbox + hover-only drag handle.
-                 Checkbox is always visible; the bars-3 grip only shows on
-                 row hover so it doesn't compete with the row content. --%>
-            <div
-              :if={@view_mode == "active" and @category.status == "active"}
-              class="flex items-center gap-1.5"
-            >
-              <span
-                :if={@sibling_count > 1}
-                class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 opacity-0 group-hover:opacity-100 transition-opacity"
-                title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to reorder (among siblings)")}
-              >
-                <.icon name="hero-bars-3" class="w-4 h-4" />
-              </span>
-              <input
-                type="checkbox"
-                class="checkbox checkbox-xs"
-                checked={@selected}
-                phx-click="toggle_select_category"
-                phx-value-uuid={@category.uuid}
-              />
-            </div>
-
-            <span
-              :if={@view_mode != "active" or @category.status != "active"}
-              class={["font-medium truncate", @category.status == "deleted" && "text-error/70"]}
-            >
-              {@category.name}
-            </span>
-
-            <%!-- Active row name + inline pencil edit icon. The edit
-                 button used to live on the right; removed by the boss
-                 to declutter the row in favour of the bulk-action bar.
-                 The pencil keeps a one-click path to the edit form. --%>
-            <span
-              :if={@view_mode == "active" and @category.status == "active"}
-              class="font-medium truncate"
-            >
-              {@category.name}
-            </span>
-            <.link
-              :if={@view_mode == "active" and @category.status == "active"}
-              navigate={Paths.category_edit(@category.uuid)}
-              class="text-base-content/40 hover:text-primary"
-              title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit category")}
-            >
-              <.icon name="hero-pencil" class="w-4 h-4" />
-            </.link>
-
-            <span :if={@category.status == "deleted"} class="badge badge-error badge-xs">deleted</span>
-            <%!-- Item count only for active categories. Once a category
-                 is deleted, its items are managed separately (Items tab
-                 Deleted view) — the count here would be confusing under
-                 the "separate status" rule. --%>
-            <span :if={@category.status == "active"} class="badge badge-ghost badge-sm">{@count} {Gettext.gettext(PhoenixKitCatalogue.Gettext, "items")}</span>
-          </div>
-
-          <%!-- Deleted mode: Restore + Permanent Delete (per-row; bulk
-               actions live in the action bar). Active mode has no
-               per-row buttons — selection drives bulk actions. --%>
-          <div :if={@view_mode == "deleted" and @category.status == "deleted"} class="flex gap-1 shrink-0">
-            <button
-              phx-click="restore_category"
-              phx-value-uuid={@category.uuid}
-              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
-              class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-success/30 bg-success/10 hover:bg-success/20 text-success text-xs font-medium transition-colors cursor-pointer"
-            >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
-            </button>
-            <button
-              phx-click="show_delete_confirm"
-              phx-value-uuid={@category.uuid}
-              phx-value-type="category"
-              class="inline-flex items-center gap-1.5 px-2.5 h-[2.5em] rounded-lg border border-error/30 bg-error/10 hover:bg-error/20 text-error text-xs font-medium transition-colors cursor-pointer"
-            >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
-            </button>
-          </div>
-        </div>
       </div>
     </div>
     """

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -19,6 +19,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
+  import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
   import PhoenixKitCatalogue.Web.Components
 
   import PhoenixKitCatalogue.Web.Helpers,
@@ -1987,7 +1988,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
             <span :if={@search_loading} class="loading loading-spinner loading-xs text-base-content/40"></span>
           </div>
 
-          <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
+          <.empty_state :if={@search_results == [] and not @search_loading} variant="card" title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
 
           <%!-- Stale results are dimmed while a newer query is in flight to
                signal that the list is about to update. --%>

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -108,10 +108,9 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         items_offset: 0,
         items_has_more: false,
         show_items_section: false,
-        # Per-level Active/Deleted counts: drive the toggle labels and the
-        # auto-flip-back-to-active when this level's Deleted bucket empties.
-        level_active_count: 0,
-        level_deleted_count: 0,
+        # Per-status item counts for the current node — drive the four
+        # per-status tab labels (active / inactive / discontinued / deleted).
+        level_status_counts: %{},
         confirm_delete: nil,
         trash_modal: nil,
         bulk_move_modal: nil,
@@ -377,7 +376,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # ── Event handlers ──────────────────────────────────────────────
 
   @impl true
-  def handle_event("switch_view", %{"mode" => mode}, socket) when mode in ~w(active deleted) do
+  def handle_event("switch_view", %{"mode" => mode}, socket)
+      when mode in ~w(active inactive discontinued deleted) do
     {:noreply,
      socket
      |> assign(:view_mode, mode)
@@ -1350,31 +1350,31 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     uuid = socket.assigns.catalogue_uuid
     catalogue = Catalogue.fetch_catalogue!(uuid)
     current = socket.assigns.current_category
-    mode = view_mode_to_atom(socket.assigns.view_mode)
+    # `status` is the exact item status of the current tab; `cat_mode` is the
+    # active/deleted bucket for the (status-less) subcategory cards.
+    status = socket.assigns.view_mode
+    cat_mode = view_mode_to_atom(status)
+    show_categories? = status in ["active", "deleted"]
 
-    {child_categories, children_with_subs, active_child_count, deleted_child_count} =
-      load_level_children(uuid, current, mode)
+    {child_categories, children_with_subs, _active_child_count, _deleted_child_count} =
+      if show_categories?,
+        do: load_level_children(uuid, current, cat_mode),
+        else: {[], MapSet.new(), 0, 0}
 
-    counts_active = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: :active)
-    counts_deleted = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: :deleted)
-    counts_map = if mode == :deleted, do: counts_deleted, else: counts_active
-
+    counts_map = Catalogue.item_counts_by_category_for_catalogue(uuid, mode: cat_mode)
     uncat_active = Catalogue.uncategorized_count_for_catalogue(uuid, mode: :active)
-    uncat_deleted = Catalogue.uncategorized_count_for_catalogue(uuid, mode: :deleted)
 
-    {node_active_items, node_deleted_items} =
-      node_item_counts(current, counts_active, counts_deleted, uncat_active, uncat_deleted)
+    # Per-status item counts for the current node — drive the four tab labels.
+    status_counts = node_status_counts(current, uuid)
+    node_total = Map.get(status_counts, status, 0)
 
-    # Root in Active mode normally shows only cards (its items — the
-    # uncategorized ones — are reached via the Uncategorized card). But a
-    # catalogue with NO categories has nothing to drill into, so skip the
-    # card and show its items inline. Root in Deleted mode always shows
-    # the deleted uncategorized items inline.
+    # Active root with categories shows only cards (its uncategorized items
+    # are reached via the Uncategorized card). Every other case — a drilled
+    # node, or any non-active tab, or an empty active root with loose items —
+    # shows the node's own item list.
     show_items_section =
-      current != nil or mode == :deleted or
-        (is_nil(current) and active_child_count == 0 and node_active_items > 0)
-
-    node_total = if mode == :deleted, do: node_deleted_items, else: node_active_items
+      current != nil or status != "active" or
+        (child_categories == [] and node_total > 0)
 
     items =
       if show_items_section and node_total > 0,
@@ -1382,7 +1382,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           fetch_card_items(
             node_scope(current),
             uuid,
-            mode,
+            status,
             item_limit,
             0,
             items_sort_opts(socket)
@@ -1392,7 +1392,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     assign(socket,
       page_title: catalogue.name,
       catalogue: catalogue,
-      breadcrumb: build_breadcrumb(current, mode),
+      breadcrumb: build_breadcrumb(current, cat_mode),
       child_categories: child_categories,
       child_counts: counts_map,
       children_with_subs: children_with_subs,
@@ -1402,8 +1402,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       items_offset: length(items),
       items_has_more: length(items) < node_total,
       show_items_section: show_items_section,
-      level_active_count: active_child_count + node_active_items,
-      level_deleted_count: deleted_child_count + node_deleted_items
+      level_status_counts: status_counts
     )
   end
 
@@ -1424,24 +1423,27 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   # The current node's own direct-item counts in both modes. Root and the
   # uncategorized bucket count the uncategorized items; a category counts
   # its own direct items.
-  defp node_item_counts(%Category{uuid: u}, counts_active, counts_deleted, _ua, _ud),
-    do: {Map.get(counts_active, u, 0), Map.get(counts_deleted, u, 0)}
+  # `%{status => count}` for the current node's own direct items — drives
+  # the four per-status tabs. Root and the Uncategorized bucket both count
+  # the catalogue's uncategorized items.
+  defp node_status_counts(%Category{uuid: u}, _catalogue_uuid),
+    do: Catalogue.item_status_counts_for_category(u)
 
-  defp node_item_counts(_current, _ca, _cd, uncat_active, uncat_deleted),
-    do: {uncat_active, uncat_deleted}
+  defp node_status_counts(_current, catalogue_uuid),
+    do: Catalogue.item_status_counts_for_uncategorized(catalogue_uuid)
 
   # Loads the next page of the current node's own items (the bottom
   # sentinel during normal browsing — search paging is separate).
   defp load_next_items_page(socket) do
     current = socket.assigns.current_category
-    mode = view_mode_to_atom(socket.assigns.view_mode)
+    status = socket.assigns.view_mode
     offset = socket.assigns.items_offset
 
     page =
       fetch_card_items(
         node_scope(current),
         socket.assigns.catalogue_uuid,
-        mode,
+        status,
         @per_page,
         offset,
         items_sort_opts(socket)
@@ -1496,18 +1498,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> maybe_auto_flip_to_active()
   end
 
-  # Auto-flip: if we're in the Deleted view of a level that no longer has
-  # anything deleted (its subcategories + direct items), bounce back to
-  # Active so the user never lands in an empty Deleted view.
-  defp maybe_auto_flip_to_active(socket) do
-    if socket.assigns.view_mode == "deleted" and socket.assigns.level_deleted_count == 0 do
-      socket
-      |> assign(:view_mode, "active")
-      |> load_level(@per_page)
-    else
-      socket
-    end
-  end
+  # No-op: with a tab shown for every status (including empty ones), an
+  # empty Deleted view is a valid, navigable place — we no longer bounce
+  # the user back to Active. Kept as a named pass-through so the reset/
+  # reload call sites read clearly.
+  defp maybe_auto_flip_to_active(socket), do: socket
 
   # PubSub-driven refresh. Reloads the current level preserving scroll
   # depth so a cross-tab broadcast (another admin, the import wizard)
@@ -1700,10 +1695,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   defp refresh_card_items(socket, scope, _delta \\ 0) do
     if scope == node_scope(socket.assigns.current_category) do
       catalogue_uuid = socket.assigns.catalogue_uuid
-      mode = view_mode_to_atom(socket.assigns.view_mode)
+      status = socket.assigns.view_mode
       limit = max(socket.assigns.items_offset, @per_page)
-      fresh = fetch_card_items(scope, catalogue_uuid, mode, limit, 0, items_sort_opts(socket))
-      total = card_total(scope, catalogue_uuid, mode)
+      fresh = fetch_card_items(scope, catalogue_uuid, status, limit, 0, items_sort_opts(socket))
+      total = card_total(scope, catalogue_uuid, status)
 
       assign(socket,
         items: fresh,
@@ -1716,38 +1711,40 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     end
   end
 
-  defp card_total(:uncategorized, catalogue_uuid, mode) do
-    Catalogue.uncategorized_count_for_catalogue(catalogue_uuid, mode: mode)
+  # `status` is the exact item status of the current tab
+  # ("active" | "inactive" | "discontinued" | "deleted").
+  defp card_total(:uncategorized, catalogue_uuid, status) do
+    Catalogue.uncategorized_count_for_catalogue(catalogue_uuid, status: status)
   end
 
-  defp card_total(category_uuid, catalogue_uuid, mode) when is_binary(category_uuid) do
-    Catalogue.item_counts_by_category_for_catalogue(catalogue_uuid, mode: mode)
-    |> Map.get(category_uuid, 0)
+  defp card_total(category_uuid, _catalogue_uuid, status) when is_binary(category_uuid) do
+    Catalogue.item_count_for_category(category_uuid, status: status)
   end
 
-  defp fetch_card_items(:uncategorized, catalogue_uuid, mode, limit, offset, sort_opts) do
+  defp fetch_card_items(:uncategorized, catalogue_uuid, status, limit, offset, sort_opts) do
     Catalogue.list_uncategorized_items_paged(
       catalogue_uuid,
-      [mode: mode, offset: offset, limit: limit] ++ sort_opts
+      [status: status, offset: offset, limit: limit] ++ sort_opts
     )
   end
 
-  defp fetch_card_items(category_uuid, _catalogue_uuid, mode, limit, offset, sort_opts)
+  defp fetch_card_items(category_uuid, _catalogue_uuid, status, limit, offset, sort_opts)
        when is_binary(category_uuid) do
     Catalogue.list_items_for_category_paged(
       category_uuid,
-      [mode: mode, offset: offset, limit: limit] ++ sort_opts
+      [status: status, offset: offset, limit: limit] ++ sort_opts
     )
   end
 
   # Sort opts threaded into the active-list paged fetches. Deleted mode
   # keeps the position-default order (the deleted list still renders via
   # the plain item_table without a sort control).
-  defp items_sort_opts(%{assigns: %{view_mode: "active"}} = socket) do
-    [sort_by: socket.assigns.items_sort_by, sort_dir: socket.assigns.items_sort_dir]
-  end
+  # The deleted list renders without a sort control; every other status
+  # (active/inactive/discontinued) uses the core toolkit table with sorting.
+  defp items_sort_opts(%{assigns: %{view_mode: "deleted"}}), do: []
 
-  defp items_sort_opts(_socket), do: []
+  defp items_sort_opts(socket),
+    do: [sort_by: socket.assigns.items_sort_by, sort_dir: socket.assigns.items_sort_dir]
 
   # Re-fetches the current level's child categories in their new order
   # after a sibling DnD reorder. Items are untouched (reorder of the
@@ -1767,8 +1764,35 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     assign(socket, :child_categories, child_categories)
   end
 
-  defp view_mode_to_atom("active"), do: :active
+  # The category bucket for the current view. Categories only have
+  # active/deleted, so the inactive/discontinued item tabs reuse the active
+  # category set (those tabs hide the category cards anyway).
   defp view_mode_to_atom("deleted"), do: :deleted
+  defp view_mode_to_atom(_), do: :active
+
+  # The four item-status tabs (status value + label), in display order.
+  defp item_status_tabs do
+    [
+      {"active", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")},
+      {"inactive", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Inactive")},
+      {"discontinued", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Discontinued")},
+      {"deleted", Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")}
+    ]
+  end
+
+  defp status_tab_active_class("deleted"), do: "border-error text-error"
+  defp status_tab_active_class(_), do: "border-primary text-primary"
+
+  # `[{status, label, count}]` for the tabs to render. Empty statuses are
+  # dropped, except Active (always the home tab) and the current tab (so the
+  # user never lands on an invisible tab).
+  defp visible_status_tabs(view_mode, counts) do
+    item_status_tabs()
+    |> Enum.map(fn {status, label} -> {status, label, Map.get(counts, status, 0)} end)
+    |> Enum.filter(fn {status, _label, count} ->
+      status == "active" or status == view_mode or count > 0
+    end)
+  end
 
   # Processes a flat list of category UUIDs that came back from the
   # detail-view DnD. Categories live in a parent-scoped tree, but the
@@ -1896,40 +1920,27 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
           />
           <div :if={@view_mode != "active"}></div>
 
+          <%!-- One tab per item status; each shows only that status's items
+               so e.g. discontinued isn't mixed in with active. Empty statuses
+               are hidden — except Active (the home tab) and the current tab. --%>
           <div
-            :if={
-              is_nil(@search_results) and not @search_loading and
-                (@level_deleted_count > 0 or @view_mode == "deleted")
-            }
-            class="flex items-center gap-0.5 pb-1"
+            :if={is_nil(@search_results) and not @search_loading}
+            class="flex items-center gap-0.5 pb-1 flex-wrap"
           >
             <button
+              :for={{status, label, count} <- visible_status_tabs(@view_mode, @level_status_counts)}
               type="button"
               phx-click="switch_view"
-              phx-value-mode="active"
+              phx-value-mode={status}
               class={[
-                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-                if(@view_mode == "active",
-                  do: "border-primary text-primary",
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer whitespace-nowrap",
+                if(@view_mode == status,
+                  do: status_tab_active_class(status),
                   else: "border-transparent text-base-content/50 hover:text-base-content"
                 )
               ]}
             >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")} ({@level_active_count})
-            </button>
-            <button
-              type="button"
-              phx-click="switch_view"
-              phx-value-mode="deleted"
-              class={[
-                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-                if(@view_mode == "deleted",
-                  do: "border-error text-error",
-                  else: "border-transparent text-base-content/50 hover:text-base-content"
-                )
-              ]}
-            >
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({@level_deleted_count})
+              {label} ({count})
             </button>
           </div>
         </div>
@@ -2513,14 +2524,14 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       assign(
         assigns,
         :draggable?,
-        assigns.items_sort_by == :position and assigns.view_mode == "active"
+        assigns.items_sort_by == :position and assigns.view_mode != "deleted"
       )
 
     ~H"""
     <div class="flex flex-col gap-2">
       <%!-- ── Active list: core List-UI toolkit ── --%>
       <.bulk_select_scope
-        :if={@items != [] and @view_mode == "active"}
+        :if={@items != [] and @view_mode != "deleted"}
         id={"items-bulk-" <> (@current_category_uuid || "root")}
         total_count={@items_total}
         class="flex flex-col gap-2"
@@ -2642,10 +2653,10 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         cursor={"items-#{@items_offset}"}
       />
 
-      <%!-- Strategy reorder modal (active list). Kept-in-DOM so the
+      <%!-- Strategy reorder modal (non-deleted lists). Kept-in-DOM so the
            toolbar's `data-bulk-opens-dialog` opens it instantly. --%>
       <.reorder_modal
-        :if={@view_mode == "active"}
+        :if={@view_mode != "deleted"}
         id="items-reorder-modal"
         show={@show_items_reorder}
         on_close="close_items_reorder_modal"
@@ -2704,6 +2715,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   defp level_items_empty(_current, "deleted"),
     do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Nothing deleted here.")
+
+  defp level_items_empty(_current, "inactive"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No inactive items here.")
+
+  defp level_items_empty(_current, "discontinued"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No discontinued items here.")
 
   defp level_items_empty(:uncategorized, _),
     do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No uncategorized items.")

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -1498,11 +1498,24 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     |> maybe_auto_flip_to_active()
   end
 
-  # No-op: with a tab shown for every status (including empty ones), an
-  # empty Deleted view is a valid, navigable place — we no longer bounce
-  # the user back to Active. Kept as a named pass-through so the reset/
-  # reload call sites read clearly.
-  defp maybe_auto_flip_to_active(socket), do: socket
+  # When a mutation (restore / trash / permanent-delete) empties the
+  # current non-Active status tab, flip the view back to Active so the
+  # user isn't stranded on an empty tab. Runs only after `load_level` has
+  # refreshed `items_total` (items of the current status) and
+  # `child_categories` (the deleted subcategories shown in the Deleted
+  # tab), so a tab that still lists deleted subcategories — even with no
+  # items of its own — correctly stays put.
+  defp maybe_auto_flip_to_active(%{assigns: %{view_mode: "active"}} = socket), do: socket
+
+  defp maybe_auto_flip_to_active(socket) do
+    if socket.assigns.items_total == 0 and socket.assigns.child_categories == [] do
+      socket
+      |> assign(:view_mode, "active")
+      |> load_level(@per_page)
+    else
+      socket
+    end
+  end
 
   # PubSub-driven refresh. Reloads the current level preserving scroll
   # depth so a cross-tab broadcast (another admin, the import wizard)

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -25,6 +25,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   import PhoenixKitCatalogue.Web.Helpers,
     only: [actor_opts: 1, actor_uuid: 1, log_operation_error: 3]
 
+  alias PhoenixKit.Utils.Values
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Catalogue.PubSub
   alias PhoenixKitCatalogue.Errors
@@ -588,7 +589,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   def handle_event("select_trash_target", %{"category_uuid" => uuid}, socket) do
     modal = socket.assigns.trash_modal || %{}
-    {:noreply, assign(socket, :trash_modal, %{modal | target_uuid: blank_to_nil(uuid)})}
+    {:noreply, assign(socket, :trash_modal, %{modal | target_uuid: Values.blank_to_nil(uuid)})}
   end
 
   def handle_event("confirm_trash_category", _params, socket) do
@@ -707,7 +708,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
 
   def handle_event("select_bulk_move_target", %{"category_uuid" => uuid}, socket) do
     modal = socket.assigns.bulk_move_modal || %{}
-    {:noreply, assign(socket, :bulk_move_modal, %{modal | target_uuid: blank_to_nil(uuid)})}
+    {:noreply, assign(socket, :bulk_move_modal, %{modal | target_uuid: Values.blank_to_nil(uuid)})}
   end
 
   def handle_event("confirm_bulk_move_items", _params, socket) do
@@ -887,7 +888,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
       )
       when is_list(ordered_ids) and is_binary(moved_id) do
     to_catalogue_uuid = params["catalogueUuid"]
-    to_category_uuid = blank_to_nil(params["categoryUuid"])
+    to_category_uuid = Values.blank_to_nil(params["categoryUuid"])
     from_catalogue_uuid = params["fromCatalogueUuid"]
 
     cond do
@@ -972,7 +973,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   def handle_event("reorder_items", %{"ordered_ids" => ordered_ids} = params, socket)
       when is_list(ordered_ids) do
     catalogue_uuid = params["catalogueUuid"]
-    category_uuid = blank_to_nil(params["categoryUuid"])
+    category_uuid = Values.blank_to_nil(params["categoryUuid"])
     moved_id = params["moved_id"]
 
     if catalogue_uuid != socket.assigns.catalogue_uuid do
@@ -1835,10 +1836,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
          |> flash_reorder(moved_id, :error)}
     end
   end
-
-  defp blank_to_nil(nil), do: nil
-  defp blank_to_nil(""), do: nil
-  defp blank_to_nil(value) when is_binary(value), do: value
 
   # ── Render ──────────────────────────────────────────────────────
 

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -17,6 +17,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   import PhoenixKitWeb.Components.Core.TableDefault
   import PhoenixKitWeb.Components.Core.TableRowMenu
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
+  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
 
   import PhoenixKitCatalogue.Web.Components
 
@@ -862,31 +863,11 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-6">
-      <%!-- Tab navigation --%>
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <div role="tablist" class="tabs tabs-bordered">
-          <.link
-            patch={Paths.index()}
-            class={["tab", @active_tab == :index && "tab-active"]}
-          >
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogues")}
-          </.link>
-          <.link
-            patch={Paths.manufacturers()}
-            class={["tab", @active_tab == :manufacturers && "tab-active"]}
-          >
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturers")}
-          </.link>
-          <.link
-            patch={Paths.suppliers()}
-            class={["tab", @active_tab == :suppliers && "tab-active"]}
-          >
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Suppliers")}
-          </.link>
-        </div>
-
-        <div class="self-end sm:self-auto flex items-center gap-2">
+    <div class="flex flex-col w-full px-4 py-6 gap-6">
+      <%!-- Navigation between Catalogues / Manufacturers / Suppliers lives in
+           the admin sidebar; the page just titles the current view. --%>
+      <.admin_page_header title={tab_title(@active_tab)}>
+        <:actions>
           <button
             :if={@active_tab == :index && @catalogue_view_mode == "active"}
             type="button"
@@ -905,8 +886,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <.link :if={@active_tab == :suppliers} navigate={Paths.supplier_new()} class="btn btn-primary btn-sm">
             {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Supplier")}
           </.link>
-        </div>
-      </div>
+        </:actions>
+      </.admin_page_header>
 
       <%!-- Global search (only on catalogues tab). While a tree row is being
            dragged, the CatalogueTreeDnD hook swaps the search bar for the

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -13,7 +13,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   require Logger
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
-  import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
+  import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1, modal: 1]
   import PhoenixKitWeb.Components.Core.TableDefault
   import PhoenixKitWeb.Components.Core.TableRowMenu
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
@@ -43,6 +43,12 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
        confirm_delete: nil,
        catalogue_view_mode: "active",
        deleted_catalogue_count: 0,
+       deleted_folder_count: 0,
+       rows: [],
+       expanded_folders: MapSet.new(),
+       renaming_folder: nil,
+       move_dialog: nil,
+       folder_options: [],
        search_query: "",
        search_results: nil,
        search_offset: 0,
@@ -122,28 +128,31 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
   defp load_data(socket, :index) do
     if connected?(socket) do
-      mode = socket.assigns.catalogue_view_mode
+      requested = socket.assigns.catalogue_view_mode
+      deleted_cat_count = Catalogue.deleted_catalogue_count()
+      deleted_folders = Catalogue.list_folder_tree(mode: :deleted)
+      deleted_folder_count = length(deleted_folders)
 
-      catalogues =
-        if mode == "deleted",
-          do: Catalogue.list_catalogues(status: "deleted"),
-          else: Catalogue.list_catalogues()
+      # Auto-switch to active when nothing is deleted in either dimension.
+      mode =
+        if requested == "deleted" and deleted_cat_count == 0 and deleted_folder_count == 0,
+          do: "active",
+          else: requested
 
-      deleted_count = Catalogue.deleted_catalogue_count()
-
-      # Auto-switch to active if no deleted catalogues
-      mode = if deleted_count == 0 && mode == "deleted", do: "active", else: mode
-
-      catalogues =
-        if mode != socket.assigns.catalogue_view_mode,
-          do: Catalogue.list_catalogues(),
-          else: catalogues
+      rows =
+        if mode == "deleted" do
+          build_deleted_rows(deleted_folders, Catalogue.list_catalogues(status: "deleted"))
+        else
+          build_active_rows(socket.assigns.expanded_folders)
+        end
 
       assign(socket,
-        catalogues: catalogues,
+        rows: rows,
         item_counts: Catalogue.item_counts_by_catalogue(),
-        deleted_catalogue_count: deleted_count,
-        catalogue_view_mode: mode
+        deleted_catalogue_count: deleted_cat_count,
+        deleted_folder_count: deleted_folder_count,
+        catalogue_view_mode: mode,
+        folder_options: folder_options()
       )
     else
       socket
@@ -162,6 +171,140 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       else: socket
   end
 
+  # ── Tree-row assembly ────────────────────────────────────────────
+  #
+  # The active view is a single flattened list of `{:folder, …}` /
+  # `{:catalogue, …}` rows in depth-first display order: at each level
+  # child folders come first (each recursing only when expanded), then
+  # the catalogues filed at that level; the root level ends with the
+  # unfiled catalogues. Orphan promotion (a child of a trashed folder, or
+  # a catalogue whose folder is trashed) is already handled by the
+  # context — promoted rows arrive with `parent_uuid`/folder = nil.
+  defp build_active_rows(expanded) do
+    folders = Catalogue.list_folder_tree(mode: :active) |> Enum.map(fn {f, _depth} -> f end)
+    folders_by_parent = Enum.group_by(folders, & &1.parent_uuid)
+    cats_by_folder = Catalogue.catalogues_by_folder()
+    counts = Catalogue.folder_catalogue_counts()
+    with_child_folders = Catalogue.folder_uuids_with_children(mode: :active)
+
+    walk_level(nil, 0, folders_by_parent, cats_by_folder, counts, with_child_folders, expanded)
+  end
+
+  defp walk_level(parent_uuid, depth, folders_by_parent, cats, counts, with_children, expanded) do
+    # `parent_key` identifies the sibling group for drag-reorder ("root"
+    # at the top level). Both folders and the catalogues filed here share
+    # this level's parent.
+    parent_key = parent_uuid || "root"
+
+    folder_rows =
+      folders_by_parent
+      |> Map.get(parent_uuid, [])
+      |> Enum.flat_map(fn folder ->
+        cat_count = Map.get(counts, folder.uuid, 0)
+        has_children = MapSet.member?(with_children, folder.uuid) or cat_count > 0
+        is_expanded = MapSet.member?(expanded, folder.uuid)
+
+        meta = %{expanded: is_expanded, has_children: has_children, count: cat_count}
+        row = {:folder, folder, depth, meta, parent_key}
+
+        if is_expanded do
+          [
+            row
+            | walk_level(
+                folder.uuid,
+                depth + 1,
+                folders_by_parent,
+                cats,
+                counts,
+                with_children,
+                expanded
+              )
+          ]
+        else
+          [row]
+        end
+      end)
+
+    catalogue_rows =
+      cats |> Map.get(parent_uuid, []) |> Enum.map(&{:catalogue, &1, depth, parent_key})
+
+    folder_rows ++ catalogue_rows
+  end
+
+  # Deleted view is a flat recovery list: deleted folders first, then
+  # deleted catalogues. No nesting, no expand/collapse, no DnD.
+  defp build_deleted_rows(deleted_folder_tree, deleted_catalogues) do
+    folder_rows =
+      Enum.map(deleted_folder_tree, fn {folder, _depth} ->
+        {:folder, folder, 0, %{expanded: false, has_children: false, count: 0}, "root"}
+      end)
+
+    folder_rows ++ Enum.map(deleted_catalogues, &{:catalogue, &1, 0, "root"})
+  end
+
+  # Depth-indented `{value, label}` options for the "Move to folder"
+  # picker — active folders only; root is the empty-string sentinel.
+  defp folder_options do
+    nested =
+      Catalogue.list_folder_tree(mode: :active)
+      |> Enum.map(fn {folder, depth} ->
+        {folder.uuid, String.duplicate("  ", depth) <> folder.name}
+      end)
+
+    [{"", Gettext.gettext(PhoenixKitCatalogue.Gettext, "— Root (unfiled) —")} | nested]
+  end
+
+  defp default_folder_name, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "New folder")
+
+  defp do_move_catalogue(socket, uuid, target) do
+    with %{} = catalogue <- Catalogue.get_catalogue(uuid),
+         {:ok, _} <- Catalogue.move_catalogue_to_folder(catalogue, target, actor_opts(socket)) do
+      put_flash(socket, :info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue moved."))
+    else
+      {:error, reason} ->
+        put_flash(socket, :error, move_error_message(reason))
+
+      _ ->
+        put_flash(
+          socket,
+          :error,
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move catalogue.")
+        )
+    end
+  end
+
+  defp do_move_folder(socket, uuid, target) do
+    with %{} = folder <- Catalogue.get_folder(uuid),
+         {:ok, _} <- Catalogue.move_folder(folder, target, actor_opts(socket)) do
+      put_flash(socket, :info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folder moved."))
+    else
+      {:error, reason} ->
+        put_flash(socket, :error, move_error_message(reason))
+
+      _ ->
+        put_flash(
+          socket,
+          :error,
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move folder.")
+        )
+    end
+  end
+
+  defp move_error_message(:cycle),
+    do:
+      Gettext.gettext(
+        PhoenixKitCatalogue.Gettext,
+        "Can't move a folder into itself or one of its subfolders."
+      )
+
+  defp move_error_message(:folder_trashed),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "That folder is in the trash.")
+
+  defp move_error_message(:folder_not_found),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "That folder no longer exists.")
+
+  defp move_error_message(_), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to move.")
+
   # ── Event handlers ──────────────────────────────────────────────
 
   @impl true
@@ -171,7 +314,166 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
      socket
      |> assign(:catalogue_view_mode, mode)
      |> assign(:confirm_delete, nil)
+     |> assign(:renaming_folder, nil)
      |> load_data(:index)}
+  end
+
+  # ── Folder handlers ─────────────────────────────────────────────
+
+  def handle_event("toggle_folder", %{"uuid" => uuid}, socket) do
+    expanded =
+      if MapSet.member?(socket.assigns.expanded_folders, uuid),
+        do: MapSet.delete(socket.assigns.expanded_folders, uuid),
+        else: MapSet.put(socket.assigns.expanded_folders, uuid)
+
+    {:noreply, socket |> assign(:expanded_folders, expanded) |> load_data(:index)}
+  end
+
+  def handle_event("new_folder", _params, socket) do
+    case Catalogue.create_folder(%{name: default_folder_name()}, actor_opts(socket)) do
+      {:ok, folder} ->
+        {:noreply, socket |> assign(:renaming_folder, folder.uuid) |> load_data(:index)}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to create folder.")
+         )}
+    end
+  end
+
+  def handle_event("new_subfolder", %{"uuid" => parent_uuid}, socket) do
+    case Catalogue.create_folder(
+           %{name: default_folder_name(), parent_uuid: parent_uuid},
+           actor_opts(socket)
+         ) do
+      {:ok, folder} ->
+        expanded = MapSet.put(socket.assigns.expanded_folders, parent_uuid)
+
+        {:noreply,
+         socket
+         |> assign(expanded_folders: expanded, renaming_folder: folder.uuid)
+         |> load_data(:index)}
+
+      {:error, _} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to create folder.")
+         )}
+    end
+  end
+
+  def handle_event("start_rename_folder", %{"uuid" => uuid}, socket) do
+    {:noreply, assign(socket, :renaming_folder, uuid)}
+  end
+
+  def handle_event("cancel_rename", _params, socket) do
+    {:noreply, assign(socket, :renaming_folder, nil)}
+  end
+
+  # Commits the inline rename and closes the field. Fired by Enter
+  # (form submit → "name") and by clicking off (phx-blur → "value").
+  # A blank name is treated as "no change" — the folder keeps its name.
+  def handle_event("rename_folder", %{"uuid" => uuid} = params, socket) do
+    name = (params["name"] || params["value"] || "") |> String.trim()
+
+    socket =
+      with true <- name != "",
+           %{} = folder <- Catalogue.get_folder(uuid),
+           {:ok, _} <- Catalogue.update_folder(folder, %{name: name}, actor_opts(socket)) do
+        socket
+      else
+        _ -> socket
+      end
+
+    {:noreply, socket |> assign(:renaming_folder, nil) |> load_data(:index)}
+  end
+
+  def handle_event("trash_folder", %{"uuid" => uuid}, socket) do
+    with %{} = folder <- Catalogue.get_folder(uuid),
+         {:ok, _} <- Catalogue.trash_folder(folder, actor_opts(socket)) do
+      {:noreply,
+       socket
+       |> put_flash(
+         :info,
+         Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folder moved to deleted.")
+       )
+       |> load_data(:index)}
+    else
+      _ ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to delete folder.")
+         )
+         |> load_data(:index)}
+    end
+  end
+
+  def handle_event("restore_folder", %{"uuid" => uuid}, socket) do
+    with %{} = folder <- Catalogue.get_folder(uuid),
+         {:ok, _} <- Catalogue.restore_folder(folder, actor_opts(socket)) do
+      {:noreply,
+       socket
+       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folder restored."))
+       |> load_data(:index)}
+    else
+      _ ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to restore folder.")
+         )
+         |> load_data(:index)}
+    end
+  end
+
+  def handle_event("open_move", %{"type" => type, "uuid" => uuid}, socket)
+      when type in ~w(folder catalogue) do
+    target_type = if type == "folder", do: :folder, else: :catalogue
+    {:noreply, assign(socket, :move_dialog, {target_type, uuid})}
+  end
+
+  def handle_event("cancel_move", _params, socket) do
+    {:noreply, assign(socket, :move_dialog, nil)}
+  end
+
+  def handle_event("confirm_move", %{"folder_uuid" => target}, socket) do
+    target = if target == "", do: nil, else: target
+
+    socket =
+      case socket.assigns.move_dialog do
+        {:catalogue, uuid} -> do_move_catalogue(socket, uuid, target)
+        {:folder, uuid} -> do_move_folder(socket, uuid, target)
+        _ -> socket
+      end
+
+    {:noreply, socket |> assign(:move_dialog, nil) |> load_data(:index)}
+  end
+
+  # Native drag-to-file (CatalogueTreeDnD hook): a row dropped onto a
+  # folder row. `target` is the destination folder uuid (or "root").
+  def handle_event(
+        "move_to_folder",
+        %{"type" => type, "uuid" => uuid, "target" => target},
+        socket
+      )
+      when type in ~w(folder catalogue) do
+    target = if target == "root", do: nil, else: target
+
+    socket =
+      case type do
+        "catalogue" -> do_move_catalogue(socket, uuid, target)
+        "folder" -> do_move_folder(socket, uuid, target)
+      end
+
+    {:noreply, load_data(socket, :index)}
   end
 
   def handle_event("reorder_catalogues", %{"ordered_ids" => ordered_ids}, socket)
@@ -182,6 +484,24 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
       {:error, reason} ->
         log_operation_error(socket, "reorder_catalogues", %{reason: reason})
+
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to save the new order.")
+         )}
+    end
+  end
+
+  def handle_event("reorder_folders", %{"ordered_ids" => ordered_ids}, socket)
+      when is_list(ordered_ids) do
+    case Catalogue.reorder_folders(ordered_ids, actor_opts(socket)) do
+      :ok ->
+        {:noreply, load_data(socket, :index)}
+
+      {:error, reason} ->
+        log_operation_error(socket, "reorder_folders", %{reason: reason})
 
         {:noreply,
          put_flash(
@@ -566,7 +886,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           </.link>
         </div>
 
-        <div class="self-end sm:self-auto">
+        <div class="self-end sm:self-auto flex items-center gap-2">
+          <button
+            :if={@active_tab == :index && @catalogue_view_mode == "active"}
+            type="button"
+            phx-click="new_folder"
+            class="btn btn-ghost btn-sm gap-1"
+          >
+            <.icon name="hero-folder-plus" class="w-4 h-4" />
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Folder")}
+          </button>
           <.link :if={@active_tab == :index && @catalogue_view_mode == "active"} navigate={Paths.catalogue_new()} class="btn btn-primary btn-sm">
             {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Catalogue")}
           </.link>
@@ -579,8 +908,22 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         </div>
       </div>
 
-      <%!-- Global search (only on catalogues tab) --%>
-      <.search_input :if={@active_tab == :index} query={@search_query} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items across all catalogues...")} />
+      <%!-- Global search (only on catalogues tab). While a tree row is being
+           dragged, the CatalogueTreeDnD hook swaps the search bar for the
+           "move to root" drop target in-place, so the layout doesn't jump. --%>
+      <div :if={@active_tab == :index} class="relative">
+        <.search_input query={@search_query} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items across all catalogues...")} />
+        <%!-- Overlaid on the search bar's exact box while dragging (absolute, so
+             it adds no height) → the "move to root" target appears with no jump. --%>
+        <div
+          data-tree-rootzone="1"
+          data-tree-drop="root"
+          class="hidden absolute inset-0 z-10 flex items-center justify-center gap-1 rounded-lg border-2 border-dashed border-primary/50 bg-base-100 text-sm text-base-content/60"
+        >
+          <.icon name="hero-arrow-up-tray" class="w-4 h-4" />
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drop here to move to root (unfiled)")}
+        </div>
+      </div>
 
       <%!-- Search results (visible when the user has typed a query) --%>
       <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
@@ -660,7 +1003,12 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           </button>
         </div>
 
-        <.catalogues_table catalogues={@catalogues} item_counts={@item_counts} view_mode={@catalogue_view_mode} />
+        <.folder_tree_table
+          rows={@rows}
+          item_counts={@item_counts}
+          view_mode={@catalogue_view_mode}
+          renaming_folder={@renaming_folder}
+        />
       </div>
 
       <div :if={@active_tab == :manufacturers and is_nil(@search_results)}>
@@ -703,6 +1051,26 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
         danger={true}
       />
+
+      <.modal :if={@move_dialog != nil} id="move-to-folder-modal" show on_close="cancel_move">
+        <form phx-submit="confirm_move" class="flex flex-col gap-4">
+          <h3 class="text-lg font-semibold">
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")}
+          </h3>
+          <p class="text-sm text-base-content/60">{move_dialog_label(@move_dialog)}</p>
+          <select name="folder_uuid" class="select select-bordered w-full">
+            <option :for={{value, label} <- @folder_options} value={value}>{label}</option>
+          </select>
+          <div class="flex justify-end gap-2">
+            <button type="button" phx-click="cancel_move" class="btn btn-ghost btn-sm">
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}
+            </button>
+            <button type="submit" class="btn btn-primary btn-sm">
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
+            </button>
+          </div>
+        </form>
+      </.modal>
     </div>
 
     <script>
@@ -733,137 +1101,329 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           this.observer.disconnect();
         }
       };
+
+      // Native HTML5 DnD for the catalogue folder tree-table — one system,
+      // no SortableJS, so nothing collides. Grab a row's handle, then drop:
+      //   • on a folder's MIDDLE → file into that folder
+      //   • on a row's TOP/BOTTOM edge → reorder among same-parent siblings
+      //   • on a "move to root" zone → unfile to root
+      // The context enforces the cycle / trashed-target guards server-side.
+      window.PhoenixKitHooks.CatalogueTreeDnD = window.PhoenixKitHooks.CatalogueTreeDnD || {
+        mounted() { this.setupTreeDnD(); },
+        updated() { this.setupTreeDnD(); },
+        setupTreeDnD() {
+          var hook = this;
+
+          // Drag sources: the grip handles.
+          this.el.querySelectorAll("[data-tree-item]").forEach(function(handle) {
+            handle.setAttribute("draggable", "true");
+            handle.ondragstart = function(e) {
+              var row = handle.closest("tr");
+              hook._drag = row && {
+                uuid: row.dataset.treeUuid,
+                type: row.dataset.treeType,
+                parent: row.dataset.treeParent
+              };
+              e.dataTransfer.setData("text/plain", handle.dataset.treeItem);
+              e.dataTransfer.effectAllowed = "move";
+              if (row) {
+                try { e.dataTransfer.setDragImage(row, 12, 12); } catch (err) {}
+                row.classList.add("opacity-50");
+                hook._dragRowEl = row;
+              }
+              // Reveal the "move to root" target, overlaid on the search bar's
+              // box (absolute → no layout shift).
+              document.querySelectorAll("[data-tree-rootzone]").forEach(function(z) {
+                z.classList.remove("hidden");
+              });
+            };
+            handle.ondragend = function() { hook.endDrag(); };
+          });
+
+          // Row targets: file-into (folder middle) or reorder (top/bottom edge).
+          this.el.querySelectorAll("[data-tree-uuid]").forEach(function(row) {
+            row.ondragover = function(e) {
+              var intent = hook.dropIntent(row, e);
+              if (!intent) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              hook.showIndicator(row, intent);
+            };
+            row.ondragleave = function() { hook.clearRow(row); };
+            row.ondrop = function(e) {
+              var intent = hook.dropIntent(row, e);
+              hook.clearRow(row);
+              if (!intent || !hook._drag) return;
+              e.preventDefault();
+              var drag = hook._drag;
+              if (intent === "into") {
+                hook.pushEvent("move_to_folder", { type: drag.type, uuid: drag.uuid, target: row.dataset.treeDrop });
+              } else {
+                hook.reorder(drag, row, intent);
+              }
+            };
+          });
+
+          // Root drop zone lives in the search-bar slot (outside this.el),
+          // so query the whole document to bind + toggle it.
+          document.querySelectorAll("[data-tree-rootzone]").forEach(function(zone) {
+            zone.ondragover = function(e) {
+              if (!hook._drag) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              zone.classList.add("bg-primary/10");
+            };
+            zone.ondragleave = function() { zone.classList.remove("bg-primary/10"); };
+            zone.ondrop = function(e) {
+              e.preventDefault();
+              zone.classList.remove("bg-primary/10");
+              if (hook._drag) {
+                hook.pushEvent("move_to_folder", { type: hook._drag.type, uuid: hook._drag.uuid, target: "root" });
+              }
+            };
+          });
+        },
+
+        // "into" | "before" | "after" | null for the pointer over `row`.
+        dropIntent(row, e) {
+          var drag = this._drag;
+          if (!drag || drag.uuid === row.dataset.treeUuid) return null;
+          var rect = row.getBoundingClientRect();
+          var ratio = (e.clientY - rect.top) / rect.height;
+          var isFolder = row.hasAttribute("data-tree-drop");
+          if (isFolder && ratio > 0.25 && ratio < 0.75) return "into";
+          if (drag.parent === row.dataset.treeParent && drag.type === row.dataset.treeType) {
+            return ratio < 0.5 ? "before" : "after";
+          }
+          // Over a folder but not a sibling → fall back to filing into it.
+          return isFolder ? "into" : null;
+        },
+
+        reorder(drag, row, intent) {
+          // Same-parent, same-type siblings in current DOM order.
+          var order = [];
+          this.el.querySelectorAll("[data-tree-uuid]").forEach(function(r) {
+            if (r.dataset.treeParent === drag.parent &&
+                r.dataset.treeType === drag.type &&
+                r.dataset.treeUuid !== drag.uuid) {
+              order.push(r.dataset.treeUuid);
+            }
+          });
+          var idx = order.indexOf(row.dataset.treeUuid);
+          if (idx < 0) return;
+          order.splice(intent === "before" ? idx : idx + 1, 0, drag.uuid);
+          this.pushEvent(drag.type === "folder" ? "reorder_folders" : "reorder_catalogues", { ordered_ids: order });
+        },
+
+        showIndicator(row, intent) {
+          this.clearAll();
+          if (intent === "into") {
+            // Inline style (not a class) so the highlight wins over the
+            // table-zebra row background, which otherwise hides it.
+            row.style.backgroundColor = "rgba(59, 130, 246, 0.18)";
+          } else {
+            row.style.boxShadow = intent === "before"
+              ? "inset 0 3px 0 0 rgb(59 130 246)"
+              : "inset 0 -3px 0 0 rgb(59 130 246)";
+          }
+        },
+
+        clearRow(row) {
+          row.style.backgroundColor = "";
+          row.style.boxShadow = "";
+        },
+
+        clearAll() {
+          var self = this;
+          this.el.querySelectorAll("[data-tree-uuid]").forEach(function(r) { self.clearRow(r); });
+        },
+
+        endDrag() {
+          if (this._dragRowEl) { this._dragRowEl.classList.remove("opacity-50"); this._dragRowEl = null; }
+          this._drag = null;
+          document.querySelectorAll("[data-tree-rootzone]").forEach(function(z) {
+            z.classList.add("hidden");
+            z.classList.remove("bg-primary/10");
+          });
+          this.clearAll();
+        }
+      };
     </script>
     """
   end
 
-  defp build_catalogue_card_fields("active", item_counts) do
-    fn c ->
-      [
-        %{
-          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items"),
-          value: Map.get(item_counts, c.uuid, 0)
-        },
-        %{
-          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"),
-          value: status_label(c.status)
-        },
-        %{
-          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated"),
-          value: Calendar.strftime(c.updated_at, "%Y-%m-%d %H:%M")
-        }
-      ]
-    end
-  end
-
-  defp build_catalogue_card_fields("deleted", _item_counts) do
-    fn c ->
-      [
-        %{
-          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"),
-          value: status_label(c.status)
-        },
-        %{
-          label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated"),
-          value: Calendar.strftime(c.updated_at, "%Y-%m-%d %H:%M")
-        }
-      ]
-    end
-  end
-
-  defp catalogues_table(assigns) do
+  defp folder_tree_table(assigns) do
     ~H"""
-    <div :if={@catalogues == []} class="card bg-base-100 shadow">
+    <div :if={@rows == []} class="card bg-base-100 shadow">
       <div class="card-body items-center text-center py-12">
         <p class="text-base-content/60">
-          {if @view_mode == "deleted", do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No deleted catalogues."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No catalogues yet.")}
+          {if @view_mode == "deleted", do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Nothing in the trash."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No catalogues yet.")}
         </p>
       </div>
     </div>
 
-    <div :if={@catalogues != []}>
-      <.table_default
-        variant="zebra" size="sm" toggleable={true}
-        id={"catalogues-#{@view_mode}"} items={@catalogues}
-        on_reorder="reorder_catalogues"
-        item_id={fn cat -> cat.uuid end}
-        card_fields={build_catalogue_card_fields(@view_mode, @item_counts)}
-      >
-        <.table_default_header>
-          <.table_default_row>
-            <.table_default_header_cell :if={length(@catalogues) > 1} class="w-8"></.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</.table_default_header_cell>
-            <.table_default_header_cell :if={@view_mode == "active"} class="text-right">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated")}</.table_default_header_cell>
-            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</.table_default_header_cell>
-          </.table_default_row>
-        </.table_default_header>
-        <tbody
-          id={"catalogues-tbody-#{@view_mode}"}
-          data-sortable="true"
-          data-sortable-event="reorder_catalogues"
-          data-sortable-items=".sortable-item"
-          data-sortable-hide-source="false"
-          data-sortable-handle=".pk-drag-handle"
-          phx-hook="SortableGrid"
-        >
-          <.table_default_row :for={catalogue <- @catalogues} class="sortable-item" data-id={catalogue.uuid}>
-            <.table_default_cell
-              :if={length(@catalogues) > 1}
-              class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/40"
-            >
-              <.icon name="hero-bars-3" class="w-4 h-4" />
-            </.table_default_cell>
-            <.table_default_cell>
-              <.link :if={@view_mode == "active"} navigate={Paths.catalogue_detail(catalogue.uuid)} class="link link-hover font-medium">
-                {catalogue.name}
-              </.link>
-              <span :if={@view_mode == "deleted"} class="font-medium text-base-content/50">{catalogue.name}</span>
-            </.table_default_cell>
-            <.table_default_cell :if={@view_mode == "active"} class="text-right tabular-nums">
-              {Map.get(@item_counts, catalogue.uuid, 0)}
-            </.table_default_cell>
-            <.table_default_cell><.status_badge status={catalogue.status} size={:sm} /></.table_default_cell>
-            <.table_default_cell class="text-sm text-base-content/60">
-              {Calendar.strftime(catalogue.updated_at, "%Y-%m-%d %H:%M")}
-            </.table_default_cell>
-            <%!-- Active mode actions --%>
-            <.table_default_cell :if={@view_mode == "active"} class="text-right whitespace-nowrap">
-              <.table_row_menu mode="auto" id={"cat-menu-#{catalogue.uuid}"}>
-                <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")} />
-                <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} variant="secondary" />
-                <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
-              </.table_row_menu>
-            </.table_default_cell>
-            <%!-- Deleted mode actions --%>
-            <.table_default_cell :if={@view_mode == "deleted"} class="text-right whitespace-nowrap">
-              <.table_row_menu mode="auto" id={"cat-del-menu-#{catalogue.uuid}"}>
-                <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
-                <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")} variant="error" />
-              </.table_row_menu>
-            </.table_default_cell>
-          </.table_default_row>
+    <div :if={@rows != []} id={"cat-tree-#{@view_mode}"} phx-hook="CatalogueTreeDnD" class="overflow-x-auto">
+      <table class="table table-zebra table-sm">
+        <thead>
+          <tr>
+            <th :if={@view_mode == "active"} class="w-8"></th>
+            <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</th>
+            <th class="text-right">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items")}</th>
+            <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</th>
+            <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated")}</th>
+            <th class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for row <- @rows do %>
+            <%= case row do %>
+              <% {:folder, folder, depth, meta, parent_key} -> %>
+                <tr
+                  class={["group/row hover"]}
+                  data-tree-uuid={@view_mode == "active" && folder.uuid}
+                  data-tree-type={@view_mode == "active" && "folder"}
+                  data-tree-parent={@view_mode == "active" && parent_key}
+                  data-tree-drop={@view_mode == "active" && folder.uuid}
+                >
+                  <td
+                    :if={@view_mode == "active"}
+                    data-tree-item={"folder:" <> folder.uuid}
+                    class="w-8 pk-tree-handle cursor-grab active:cursor-grabbing text-base-content/40 opacity-0 group-hover/row:opacity-100 transition-opacity"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to move into a folder")}
+                  >
+                    <.icon name="hero-bars-3" class="w-4 h-4" />
+                  </td>
+                  <td>
+                    <div class="flex items-center gap-1.5" style={"padding-left: #{depth * 1.5}rem"}>
+                      <button
+                        :if={meta.has_children}
+                        type="button"
+                        phx-click="toggle_folder"
+                        phx-value-uuid={folder.uuid}
+                        class="btn btn-ghost btn-xs p-0 min-h-0 h-5 w-5"
+                        aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Toggle folder")}
+                      >
+                        <.icon name={if meta.expanded, do: "hero-chevron-down-mini", else: "hero-chevron-right-mini"} class="w-4 h-4 text-base-content/50" />
+                      </button>
+                      <span :if={not meta.has_children} class="w-5"></span>
+                      <.icon name="hero-folder" class="w-4 h-4 text-warning shrink-0" />
+                      <%= cond do %>
+                        <% @renaming_folder == folder.uuid -> %>
+                          <form phx-submit="rename_folder" phx-value-uuid={folder.uuid}>
+                            <input
+                              type="text"
+                              name="name"
+                              value={folder.name}
+                              phx-mounted={Phoenix.LiveView.JS.focus()}
+                              phx-blur="rename_folder"
+                              phx-value-uuid={folder.uuid}
+                              class="input input-bordered input-xs"
+                            />
+                          </form>
+                        <% @view_mode == "active" -> %>
+                          <button
+                            type="button"
+                            phx-click="start_rename_folder"
+                            phx-value-uuid={folder.uuid}
+                            class="font-medium text-left cursor-pointer hover:underline decoration-dotted underline-offset-2"
+                            title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Click to rename")}
+                          >
+                            {folder.name}
+                          </button>
+                        <% true -> %>
+                          <span class="font-medium text-base-content/50">{folder.name}</span>
+                      <% end %>
+                    </div>
+                  </td>
+                  <td class="text-right tabular-nums text-base-content/60">{meta.count}</td>
+                  <td><.status_badge status={folder.status} size={:sm} /></td>
+                  <td class="text-sm text-base-content/60">{Calendar.strftime(folder.updated_at, "%Y-%m-%d %H:%M")}</td>
+                  <td class="text-right whitespace-nowrap">
+                    <.table_row_menu :if={@view_mode == "active"} mode="auto" id={"folder-menu-#{folder.uuid}"}>
+                      <.table_row_menu_button phx-click="new_subfolder" phx-value-uuid={folder.uuid} icon="hero-folder-plus" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "New subfolder")} />
+                      <.table_row_menu_button phx-click="start_rename_folder" phx-value-uuid={folder.uuid} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Rename")} variant="secondary" />
+                      <.table_row_menu_button phx-click="open_move" phx-value-type="folder" phx-value-uuid={folder.uuid} icon="hero-folder-arrow-down" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")} variant="secondary" />
+                      <.table_row_menu_divider />
+                      <.table_row_menu_button phx-click="trash_folder" phx-value-uuid={folder.uuid} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
+                    </.table_row_menu>
+                    <.table_row_menu :if={@view_mode == "deleted"} mode="auto" id={"folder-del-menu-#{folder.uuid}"}>
+                      <.table_row_menu_button phx-click="restore_folder" phx-value-uuid={folder.uuid} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
+                    </.table_row_menu>
+                  </td>
+                </tr>
+              <% {:catalogue, catalogue, depth, parent_key} -> %>
+                <tr
+                  class={["group/row hover"]}
+                  data-tree-uuid={@view_mode == "active" && catalogue.uuid}
+                  data-tree-type={@view_mode == "active" && "catalogue"}
+                  data-tree-parent={@view_mode == "active" && parent_key}
+                >
+                  <td
+                    :if={@view_mode == "active"}
+                    data-tree-item={"catalogue:" <> catalogue.uuid}
+                    class="w-8 pk-tree-handle cursor-grab active:cursor-grabbing text-base-content/40 opacity-0 group-hover/row:opacity-100 transition-opacity"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to move into a folder")}
+                  >
+                    <.icon name="hero-bars-3" class="w-4 h-4" />
+                  </td>
+                  <td>
+                    <div class="flex items-center gap-1.5" style={"padding-left: #{depth * 1.5 + 1.5}rem"}>
+                      <.icon name="hero-document-text" class="w-4 h-4 text-base-content/40 shrink-0" />
+                      <.link :if={@view_mode == "active"} navigate={Paths.catalogue_detail(catalogue.uuid)} class="link link-hover font-medium">
+                        {catalogue.name}
+                      </.link>
+                      <span :if={@view_mode == "deleted"} class="font-medium text-base-content/50">{catalogue.name}</span>
+                    </div>
+                  </td>
+                  <td class="text-right tabular-nums">{Map.get(@item_counts, catalogue.uuid, 0)}</td>
+                  <td><.status_badge status={catalogue.status} size={:sm} /></td>
+                  <td class="text-sm text-base-content/60">{Calendar.strftime(catalogue.updated_at, "%Y-%m-%d %H:%M")}</td>
+                  <td class="text-right whitespace-nowrap">
+                    <.table_row_menu :if={@view_mode == "active"} mode="auto" id={"cat-menu-#{catalogue.uuid}"}>
+                      <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")} />
+                      <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} variant="secondary" />
+                      <.table_row_menu_button phx-click="open_move" phx-value-type="catalogue" phx-value-uuid={catalogue.uuid} icon="hero-folder-arrow-down" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")} variant="secondary" />
+                      <.table_row_menu_divider />
+                      <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
+                    </.table_row_menu>
+                    <.table_row_menu :if={@view_mode == "deleted"} mode="auto" id={"cat-del-menu-#{catalogue.uuid}"}>
+                      <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
+                      <.table_row_menu_divider />
+                      <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")} variant="error" />
+                    </.table_row_menu>
+                  </td>
+                </tr>
+            <% end %>
+          <% end %>
         </tbody>
-        <:card_header :let={catalogue}>
-          <.link :if={@view_mode == "active"} navigate={Paths.catalogue_detail(catalogue.uuid)} class="font-medium text-sm link link-hover">{catalogue.name}</.link>
-          <span :if={@view_mode == "deleted"} class="font-medium text-sm text-base-content/50">{catalogue.name}</span>
-        </:card_header>
-        <:card_actions :let={catalogue} :if={@view_mode == "active"}>
-          <.link navigate={Paths.catalogue_detail(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")}</.link>
-          <.link navigate={Paths.catalogue_edit(catalogue.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}</.link>
-          <button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}</button>
-        </:card_actions>
-        <:card_actions :let={catalogue} :if={@view_mode == "deleted"}>
-          <button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} class="btn btn-ghost btn-xs text-success">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}</button>
-          <button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}</button>
-        </:card_actions>
-      </.table_default>
+      </table>
+      <%!-- "Move to root" target below the list (revealed only while dragging).
+           Below the table, so appearing here doesn't shift the rows above. --%>
+      <div
+        :if={@view_mode == "active"}
+        data-tree-rootzone="1"
+        data-tree-drop="root"
+        class="hidden mt-2 rounded-lg border-2 border-dashed border-primary/50 py-3 text-center text-sm text-base-content/60"
+      >
+        <.icon name="hero-arrow-up-tray" class="w-4 h-4 inline-block mr-1 align-text-bottom" />
+        {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drop here to move to root (unfiled)")}
+      </div>
     </div>
     """
   end
+
+  defp move_dialog_label({:folder, _uuid}),
+    do:
+      Gettext.gettext(PhoenixKitCatalogue.Gettext, "Choose a destination folder for this folder.")
+
+  defp move_dialog_label({:catalogue, _uuid}),
+    do:
+      Gettext.gettext(
+        PhoenixKitCatalogue.Gettext,
+        "Choose a destination folder for this catalogue."
+      )
+
+  defp move_dialog_label(_), do: ""
 
   defp manufacturers_table(assigns) do
     ~H"""

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -66,7 +66,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   @impl true
   def handle_info({:catalogue_data_changed, kind, _uuid, _parent}, socket) do
     cond do
-      socket.assigns.active_tab == :index and kind in [:catalogue, :item, :category] ->
+      socket.assigns.active_tab == :index and kind in [:catalogue, :item, :category, :folder] ->
         {:noreply, load_data(socket, :index)}
 
       socket.assigns.active_tab == :manufacturers and kind in [:manufacturer, :links] ->
@@ -872,6 +872,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             :if={@active_tab == :index && @catalogue_view_mode == "active"}
             type="button"
             phx-click="new_folder"
+            phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Creating...")}
             class="btn btn-ghost btn-sm gap-1"
           >
             <.icon name="hero-folder-plus" class="w-4 h-4" />
@@ -1046,7 +1047,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             <button type="button" phx-click="cancel_move" class="btn btn-ghost btn-sm">
               {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Cancel")}
             </button>
-            <button type="submit" class="btn btn-primary btn-sm">
+            <button type="submit" phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Moving...")} class="btn btn-primary btn-sm">
               {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move")}
             </button>
           </div>
@@ -1321,14 +1322,14 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
                   <td class="text-sm text-base-content/60">{Calendar.strftime(folder.updated_at, "%Y-%m-%d %H:%M")}</td>
                   <td class="text-right whitespace-nowrap">
                     <.table_row_menu :if={@view_mode == "active"} mode="auto" id={"folder-menu-#{folder.uuid}"}>
-                      <.table_row_menu_button phx-click="new_subfolder" phx-value-uuid={folder.uuid} icon="hero-folder-plus" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "New subfolder")} />
+                      <.table_row_menu_button phx-click="new_subfolder" phx-value-uuid={folder.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Creating...")} icon="hero-folder-plus" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "New subfolder")} />
                       <.table_row_menu_button phx-click="start_rename_folder" phx-value-uuid={folder.uuid} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Rename")} variant="secondary" />
                       <.table_row_menu_button phx-click="open_move" phx-value-type="folder" phx-value-uuid={folder.uuid} icon="hero-folder-arrow-down" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")} variant="secondary" />
                       <.table_row_menu_divider />
-                      <.table_row_menu_button phx-click="trash_folder" phx-value-uuid={folder.uuid} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
+                      <.table_row_menu_button phx-click="trash_folder" phx-value-uuid={folder.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
                     </.table_row_menu>
                     <.table_row_menu :if={@view_mode == "deleted"} mode="auto" id={"folder-del-menu-#{folder.uuid}"}>
-                      <.table_row_menu_button phx-click="restore_folder" phx-value-uuid={folder.uuid} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
+                      <.table_row_menu_button phx-click="restore_folder" phx-value-uuid={folder.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
                     </.table_row_menu>
                   </td>
                 </tr>

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -16,6 +16,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.TableDefault
   import PhoenixKitWeb.Components.Core.TableRowMenu
+  import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
 
   import PhoenixKitCatalogue.Web.Components
 
@@ -595,7 +596,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <span :if={@search_loading} class="loading loading-spinner loading-xs text-base-content/40"></span>
         </div>
 
-        <.empty_state :if={@search_results == [] and not @search_loading} message={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
+        <.empty_state :if={@search_results == [] and not @search_loading} variant="card" title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
 
         <%!-- Stale results are dimmed while a newer query is in flight to
              signal that the list is about to update. --%>

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -14,6 +14,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   import PhoenixKitCatalogue.Web.Components, only: [featured_image_card: 1]
   import PhoenixKitCatalogue.Web.Helpers, only: [actor_opts: 1]
 
+  alias PhoenixKit.Utils.Values
   alias PhoenixKitCatalogue.Attachments
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
@@ -29,7 +30,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       case action do
         :new ->
           catalogue_uuid = params["catalogue_uuid"]
-          parent_uuid = blank_to_nil(params["parent_uuid"])
+          parent_uuid = Values.blank_to_nil(params["parent_uuid"])
           next_pos = Catalogue.next_category_position(catalogue_uuid, parent_uuid)
 
           cat = %Category{
@@ -116,10 +117,6 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       {String.duplicate("— ", depth) <> category.name, category.uuid}
     end)
   end
-
-  defp blank_to_nil(nil), do: nil
-  defp blank_to_nil(""), do: nil
-  defp blank_to_nil(value), do: value
 
   defp assign_changeset(socket, changeset) do
     socket
@@ -241,7 +238,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   end
 
   def handle_event("select_parent_move_target", %{"parent_uuid" => uuid}, socket) do
-    target = blank_to_nil(uuid)
+    target = Values.blank_to_nil(uuid)
     {:noreply, assign(socket, :parent_move_target, target)}
   end
 

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -67,6 +67,7 @@ defmodule PhoenixKitCatalogue.Web.Components do
 
   alias PhoenixKit.Modules.Storage.URLSigner
   alias PhoenixKitCatalogue.Attachments
+  alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Metadata
   alias PhoenixKitCatalogue.Schemas.Item
 
@@ -1299,6 +1300,94 @@ defmodule PhoenixKitCatalogue.Web.Components do
         />
       </:card_actions>
     </.table_default>
+    """
+  end
+
+  # ── Shared item cells (reused by item_table AND the core-toolkit
+  #    table in CatalogueDetailLive's active list, so the two surfaces
+  #    don't drift on pricing / action markup) ───────────────────────
+
+  @doc """
+  The name + SKU + sale-price cells for an item, rendered as standalone
+  `<td>`s for a core-toolkit `<.table_default>` row. Pricing uses
+  `Catalogue.item_pricing/1` so the figures match the rest of the
+  module. Pass `edit_path` (a 1-arity `uuid -> path` fn) to make the
+  name a link.
+
+  Renders four cells: name (link), SKU, sale price, unit.
+  """
+  attr(:item, :any, required: true)
+  attr(:edit_path, :any, default: nil)
+
+  def item_pricing_cell(assigns) do
+    pricing = Catalogue.item_pricing(assigns.item)
+    assigns = assign(assigns, :sale_price, pricing.sale_price)
+
+    ~H"""
+    <.table_default_cell class="font-medium">
+      <.link
+        :if={@edit_path && @item.uuid}
+        navigate={safe_call(@edit_path, @item.uuid)}
+        class="link link-hover"
+      >
+        {@item.name || "—"}
+      </.link>
+      <span :if={!@edit_path || !@item.uuid}>{@item.name || "—"}</span>
+    </.table_default_cell>
+    <.table_default_cell class="text-sm font-mono text-base-content/60">
+      {@item.sku || "—"}
+    </.table_default_cell>
+    <.table_default_cell class="text-sm font-semibold">
+      {format_price(@sale_price)}
+    </.table_default_cell>
+    <.table_default_cell class="text-sm">{format_unit(@item.unit)}</.table_default_cell>
+    <.table_default_cell>
+      <.status_badge status={@item.status || "unknown"} size={:xs} />
+    </.table_default_cell>
+    """
+  end
+
+  @doc """
+  The per-row action menu for an active item (Edit / Search PDFs /
+  Delete), rendered as a standalone `<td>` for a core-toolkit row.
+  Mirrors `item_table`'s `item_actions` action set for the active list.
+  """
+  attr(:item, :any, required: true)
+  attr(:edit_path, :any, default: nil)
+  attr(:on_delete, :string, default: nil)
+  attr(:pdf_search_event, :string, default: nil)
+
+  def item_row_menu(assigns) do
+    ~H"""
+    <.table_default_cell class="text-right whitespace-nowrap">
+      <.table_row_menu id={"item-row-menu-#{@item.uuid}"}>
+        <.table_row_menu_link
+          :if={@edit_path}
+          navigate={safe_call(@edit_path, @item.uuid)}
+          icon="hero-pencil"
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+        />
+        <.table_row_menu_button
+          :if={@pdf_search_event}
+          phx-click={@pdf_search_event}
+          phx-value-uuid={@item.uuid}
+          icon="hero-document-magnifying-glass"
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search PDFs")}
+        />
+        <.table_row_menu_divider :if={
+          (@edit_path || @pdf_search_event) && @on_delete
+        } />
+        <.table_row_menu_button
+          :if={@on_delete}
+          phx-click={@on_delete}
+          phx-value-uuid={@item.uuid}
+          phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")}
+          icon="hero-trash"
+          label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+          variant="error"
+        />
+      </.table_row_menu>
+    </.table_default_cell>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -528,35 +528,6 @@ defmodule PhoenixKitCatalogue.Web.Components do
   end
 
   # ═══════════════════════════════════════════════════════════════════
-  # Empty state
-  # ═══════════════════════════════════════════════════════════════════
-
-  @doc """
-  Renders an empty state card with a message and optional action slot.
-
-  ## Attributes
-
-    * `message` — the text to display (required)
-
-  ## Slots
-
-    * `inner_block` — optional action content (buttons, links)
-  """
-  attr(:message, :string, required: true)
-  slot(:inner_block)
-
-  def empty_state(assigns) do
-    ~H"""
-    <div class="card bg-base-100 shadow">
-      <div class="card-body items-center text-center py-12">
-        <p class="text-base-content/60">{@message}</p>
-        {render_slot(@inner_block)}
-      </div>
-    </div>
-    """
-  end
-
-  # ═══════════════════════════════════════════════════════════════════
   # View mode toggle
   # ═══════════════════════════════════════════════════════════════════
 

--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -28,10 +28,9 @@ defmodule PhoenixKitCatalogue.Web.Components do
       item forms (opt-in fields from `Metadata.definitions/1`). Expects
       `add_meta_field` and `remove_meta_field` events wired up in the LV;
       text edits are absorbed via the form's `validate`.
-    * `empty_state/1` — centered empty state card with message and optional action
 
   Several of these (`search_input`, `search_results_summary`,
-  `view_mode_toggle`, `empty_state`) are deliberately generic — no
+  `view_mode_toggle`) are deliberately generic — no
   catalogue-specific schema knowledge — and are candidates for
   promotion to `phoenix_kit` core once a coordinated release lands.
   Keeping them here for now avoids coupling catalogue's hex dep to

--- a/lib/phoenix_kit_catalogue/web/events_live.ex
+++ b/lib/phoenix_kit_catalogue/web/events_live.ex
@@ -253,7 +253,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-4">
+    <div class="flex flex-col w-full px-4 py-6 gap-4">
       <div class="flex items-center justify-between">
         <div class="text-sm text-base-content/60">
           {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} events", count: @total)}
@@ -318,19 +318,17 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
             </div>
 
             <%!-- Resource + name --%>
-            <div class="flex-1 min-w-0">
+            <div class="flex-1 min-w-0 flex items-center gap-1.5">
               <%= if entry.resource_type do %>
-                <span class="badge badge-ghost badge-xs">{entry.resource_type}</span>
+                <span class="badge badge-ghost badge-xs shrink-0">{entry.resource_type}</span>
                 <%= if entry.metadata["name"] do %>
-                  <span class="text-sm ml-1 font-medium">{entry.metadata["name"]}</span>
+                  <span class="text-sm font-medium shrink-0">{entry.metadata["name"]}</span>
                 <% end %>
               <% end %>
               <% summary = summarize_metadata(entry.metadata) %>
               <%= if summary do %>
-                <span
-                  class="text-xs text-base-content/50 ml-2 truncate inline-block max-w-[200px] align-bottom"
-                  title={summary}
-                >
+                <%!-- Fills remaining row width; ellipsizes only on real overflow, not a fixed cap. --%>
+                <span class="text-xs text-base-content/50 truncate min-w-0" title={summary}>
                   {summary}
                 </span>
               <% end %>

--- a/lib/phoenix_kit_catalogue/web/events_live.ex
+++ b/lib/phoenix_kit_catalogue/web/events_live.ex
@@ -14,6 +14,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
 
   alias PhoenixKit.Utils.Routes
+  alias PhoenixKit.Utils.Values
   alias PhoenixKitCatalogue.Paths
 
   @per_page 20
@@ -94,8 +95,8 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
 
   defp apply_params(socket, params) do
     socket
-    |> assign(:filter_action, blank_to_nil(params["action"]))
-    |> assign(:filter_resource_type, blank_to_nil(params["resource_type"]))
+    |> assign(:filter_action, Values.blank_to_nil(params["action"]))
+    |> assign(:filter_resource_type, Values.blank_to_nil(params["resource_type"]))
   end
 
   defp load_filter_options(socket) do
@@ -153,10 +154,6 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   rescue
     _ -> assign(socket, loading: false)
   end
-
-  defp blank_to_nil(nil), do: nil
-  defp blank_to_nil(""), do: nil
-  defp blank_to_nil(val), do: val
 
   # Translates the raw resource_type string for the filter dropdown.
   # `resource_types` is built from DB content and may surface unknown

--- a/lib/phoenix_kit_catalogue/web/import_live.ex
+++ b/lib/phoenix_kit_catalogue/web/import_live.ex
@@ -1165,7 +1165,7 @@ defmodule PhoenixKitCatalogue.Web.ImportLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-6">
+    <div class="flex flex-col w-full px-4 py-6 gap-6">
       <%!-- Step indicator --%>
       <div class="flex items-center justify-center gap-2 text-sm">
         <.step_badge step={:upload} current={@step} label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Upload")} />

--- a/lib/phoenix_kit_catalogue/web/pdf_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/pdf_detail_live.ex
@@ -150,7 +150,7 @@ defmodule PhoenixKitCatalogue.Web.PdfDetailLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-6xl px-4 py-6 gap-4">
+    <div class="flex flex-col w-full px-4 py-6 gap-4">
       <div class="flex items-start justify-between gap-4">
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">

--- a/lib/phoenix_kit_catalogue/web/pdf_library_live.ex
+++ b/lib/phoenix_kit_catalogue/web/pdf_library_live.ex
@@ -236,7 +236,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-5xl px-4 py-6 gap-6">
+    <div class="flex flex-col w-full px-4 py-6 gap-6">
       <div class="flex items-center justify-between">
         <h2 class="text-xl font-semibold">
           {Gettext.gettext(PhoenixKitCatalogue.Gettext, "PDF library")}

--- a/test/activity_logging_test.exs
+++ b/test/activity_logging_test.exs
@@ -90,6 +90,65 @@ defmodule PhoenixKitCatalogue.ActivityLoggingTest do
     end
   end
 
+  describe "folder.* actions" do
+    test "create_folder logs folder.created with actor + name" do
+      {:ok, folder} = Catalogue.create_folder(%{name: "Brochures"}, actor_opts())
+
+      assert_activity_logged("folder.created",
+        resource_uuid: folder.uuid,
+        actor_uuid: @actor,
+        metadata_has: %{"name" => "Brochures"}
+      )
+    end
+
+    test "update_folder logs folder.updated on a real change" do
+      {:ok, folder} = Catalogue.create_folder(%{name: "Old"}, actor_opts())
+      {:ok, _} = Catalogue.update_folder(folder, %{name: "New"}, actor_opts())
+
+      assert_activity_logged("folder.updated", resource_uuid: folder.uuid, actor_uuid: @actor)
+    end
+
+    test "move_folder logs folder.moved carrying the destination parent" do
+      {:ok, parent} = Catalogue.create_folder(%{name: "Parent"}, actor_opts())
+      {:ok, child} = Catalogue.create_folder(%{name: "Child"}, actor_opts())
+      {:ok, _} = Catalogue.move_folder(child, parent.uuid, actor_opts())
+
+      assert_activity_logged("folder.moved",
+        resource_uuid: child.uuid,
+        actor_uuid: @actor,
+        metadata_has: %{"to_parent_uuid" => parent.uuid}
+      )
+    end
+
+    test "trash_folder + restore_folder log folder.trashed / folder.restored" do
+      {:ok, folder} = Catalogue.create_folder(%{name: "Temp"}, actor_opts())
+      {:ok, _} = Catalogue.trash_folder(folder, actor_opts())
+      {:ok, _} = Catalogue.restore_folder(folder, actor_opts())
+
+      assert_activity_logged("folder.trashed", resource_uuid: folder.uuid, actor_uuid: @actor)
+      assert_activity_logged("folder.restored", resource_uuid: folder.uuid, actor_uuid: @actor)
+    end
+
+    test "reorder_folders logs folder.reordered" do
+      {:ok, a} = Catalogue.create_folder(%{name: "A"}, actor_opts())
+      {:ok, b} = Catalogue.create_folder(%{name: "B"}, actor_opts())
+      assert :ok = Catalogue.reorder_folders([a.uuid, b.uuid], actor_opts())
+
+      assert_activity_logged("folder.reordered", actor_uuid: @actor)
+    end
+
+    test "move_catalogue_to_folder logs catalogue.moved_to_folder", %{catalogue: cat} do
+      {:ok, folder} = Catalogue.create_folder(%{name: "Filed"}, actor_opts())
+      {:ok, _} = Catalogue.move_catalogue_to_folder(cat, folder.uuid, actor_opts())
+
+      assert_activity_logged("catalogue.moved_to_folder",
+        resource_uuid: cat.uuid,
+        actor_uuid: @actor,
+        metadata_has: %{"to_folder_uuid" => folder.uuid}
+      )
+    end
+  end
+
   describe "item.* actions" do
     test "create_item logs item.created with actor", %{catalogue: cat} do
       {:ok, item} =
@@ -222,6 +281,16 @@ defmodule PhoenixKitCatalogue.ActivityLoggingTest do
 
       assert_receive {:catalogue_data_changed, :item, _uuid, parent}
       assert parent == cat.uuid
+    end
+
+    test "create_folder broadcasts {:folder, uuid, nil}", %{catalogue: _cat} do
+      {:ok, folder} = Catalogue.create_folder(%{name: "F"}, actor_opts())
+
+      # Folders are module-global, so there's no catalogue parent to thread —
+      # the index LV reloads its whole tree on any :folder event.
+      assert_receive {:catalogue_data_changed, :folder, uuid, parent}
+      assert uuid == folder.uuid
+      assert parent == nil
     end
   end
 

--- a/test/catalogue/pdf_library_test.exs
+++ b/test/catalogue/pdf_library_test.exs
@@ -349,7 +349,10 @@ defmodule PhoenixKitCatalogue.Catalogue.PdfLibraryTest do
           unit: "piece"
         })
 
-      {:ok, file: file, pdf: pdf, item: item}
+      # NB: don't expose `file:` — `:file` is a reserved ExUnit context
+      # key (test-metadata) and setting it raises. The tests only need
+      # the pdf + item anyway.
+      {:ok, pdf: pdf, item: item}
     end
 
     test "literal search finds matching pages grouped under the PDF", %{item: item, pdf: pdf} do

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -2470,6 +2470,237 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
     end
   end
 
+  describe "item sort opts on paged list fns" do
+    test "list_items_for_category_paged/2 sorts by name asc/desc" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      create_item(%{name: "Cherry", category_uuid: category.uuid})
+      create_item(%{name: "Apple", category_uuid: category.uuid})
+      create_item(%{name: "Banana", category_uuid: category.uuid})
+
+      asc =
+        category.uuid
+        |> Catalogue.list_items_for_category_paged(sort_by: :name, sort_dir: :asc)
+        |> Enum.map(& &1.name)
+
+      desc =
+        category.uuid
+        |> Catalogue.list_items_for_category_paged(sort_by: :name, sort_dir: :desc)
+        |> Enum.map(& &1.name)
+
+      assert asc == ["Apple", "Banana", "Cherry"]
+      assert desc == ["Cherry", "Banana", "Apple"]
+    end
+
+    test "list_items_for_category_paged/2 sorts by base_price" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      create_item(%{name: "Mid", base_price: Decimal.new("50"), category_uuid: category.uuid})
+      create_item(%{name: "Low", base_price: Decimal.new("10"), category_uuid: category.uuid})
+      create_item(%{name: "High", base_price: Decimal.new("99"), category_uuid: category.uuid})
+
+      names =
+        category.uuid
+        |> Catalogue.list_items_for_category_paged(sort_by: :base_price, sort_dir: :asc)
+        |> Enum.map(& &1.name)
+
+      assert names == ["Low", "Mid", "High"]
+    end
+
+    test "list_items_for_category_paged/2 defaults to :position order" do
+      cat = create_catalogue()
+      category = create_category(cat)
+      create_item(%{name: "Zed", position: 0, category_uuid: category.uuid})
+      create_item(%{name: "Alpha", position: 1, category_uuid: category.uuid})
+
+      names =
+        category.uuid
+        |> Catalogue.list_items_for_category_paged()
+        |> Enum.map(& &1.name)
+
+      assert names == ["Zed", "Alpha"]
+    end
+
+    test "list_uncategorized_items_paged/2 honors :sort_by" do
+      cat = create_catalogue()
+      create_item(%{name: "Yak", catalogue_uuid: cat.uuid})
+      create_item(%{name: "Ant", catalogue_uuid: cat.uuid})
+
+      names =
+        cat.uuid
+        |> Catalogue.list_uncategorized_items_paged(sort_by: :name, sort_dir: :asc)
+        |> Enum.map(& &1.name)
+
+      assert names == ["Ant", "Yak"]
+    end
+  end
+
+  describe "reorder_items_by/5" do
+    setup do
+      cat = create_catalogue()
+      category = create_category(cat)
+      {:ok, catalogue: cat, category: category}
+    end
+
+    defp item_positions(category_uuid) do
+      category_uuid
+      |> Catalogue.list_items_for_category_paged(sort_by: :position, sort_dir: :asc)
+      |> Enum.map(&{&1.name, &1.position})
+    end
+
+    # Stamps a distinct `inserted_at` (seconds ago). `inserted_at` is
+    # second-precision and UUIDv7 is random within a millisecond, so
+    # same-instant fixtures have no deterministic creation order — back-
+    # date them so `:created_*` reorders are pinnable.
+    defp backdate_item(item, seconds_ago) do
+      ts = DateTime.utc_now() |> DateTime.add(-seconds_ago, :second) |> DateTime.truncate(:second)
+
+      Repo.update_all(
+        from(i in PhoenixKitCatalogue.Schemas.Item, where: i.uuid == ^item.uuid),
+        set: [inserted_at: ts]
+      )
+
+      item
+    end
+
+    test ":all + :name_asc reindexes the whole scope 1..N alphabetically", ctx do
+      create_item(%{name: "Cherry", category_uuid: ctx.category.uuid})
+      create_item(%{name: "Apple", category_uuid: ctx.category.uuid})
+      create_item(%{name: "Banana", category_uuid: ctx.category.uuid})
+
+      assert :ok =
+               Catalogue.reorder_items_by(ctx.catalogue.uuid, ctx.category.uuid, :name_asc, :all)
+
+      assert item_positions(ctx.category.uuid) == [{"Apple", 1}, {"Banana", 2}, {"Cherry", 3}]
+    end
+
+    test ":all + :name_desc reindexes reverse-alphabetically", ctx do
+      create_item(%{name: "Apple", category_uuid: ctx.category.uuid})
+      create_item(%{name: "Banana", category_uuid: ctx.category.uuid})
+
+      assert :ok =
+               Catalogue.reorder_items_by(ctx.catalogue.uuid, ctx.category.uuid, :name_desc, :all)
+
+      assert item_positions(ctx.category.uuid) == [{"Banana", 1}, {"Apple", 2}]
+    end
+
+    test ":all + :created_asc / :created_desc reindex by insertion order", ctx do
+      first = create_item(%{name: "First", category_uuid: ctx.category.uuid})
+      second = create_item(%{name: "Second", category_uuid: ctx.category.uuid})
+      third = create_item(%{name: "Third", category_uuid: ctx.category.uuid})
+
+      backdate_item(first, 3)
+      backdate_item(second, 2)
+      backdate_item(third, 1)
+
+      assert :ok =
+               Catalogue.reorder_items_by(
+                 ctx.catalogue.uuid,
+                 ctx.category.uuid,
+                 :created_asc,
+                 :all
+               )
+
+      assert item_positions(ctx.category.uuid) == [{"First", 1}, {"Second", 2}, {"Third", 3}]
+
+      assert :ok =
+               Catalogue.reorder_items_by(
+                 ctx.catalogue.uuid,
+                 ctx.category.uuid,
+                 :created_desc,
+                 :all
+               )
+
+      assert item_positions(ctx.category.uuid) == [{"Third", 1}, {"Second", 2}, {"First", 3}]
+      assert first.uuid
+    end
+
+    test ":all + :reverse flips the current position order", ctx do
+      create_item(%{name: "P0", position: 0, category_uuid: ctx.category.uuid})
+      create_item(%{name: "P1", position: 1, category_uuid: ctx.category.uuid})
+      create_item(%{name: "P2", position: 2, category_uuid: ctx.category.uuid})
+
+      assert :ok =
+               Catalogue.reorder_items_by(ctx.catalogue.uuid, ctx.category.uuid, :reverse, :all)
+
+      assert item_positions(ctx.category.uuid) == [{"P2", 1}, {"P1", 2}, {"P0", 3}]
+    end
+
+    test "subset permute on distinct positions reorders in place", ctx do
+      a = create_item(%{name: "Cherry", position: 1, category_uuid: ctx.category.uuid})
+      b = create_item(%{name: "Apple", position: 2, category_uuid: ctx.category.uuid})
+      c = create_item(%{name: "Banana", position: 3, category_uuid: ctx.category.uuid})
+
+      # Permute the three distinct-position rows by name asc: their
+      # position slots (1,2,3) get filled in alphabetical order.
+      assert :ok =
+               Catalogue.reorder_items_by(
+                 ctx.catalogue.uuid,
+                 ctx.category.uuid,
+                 :name_asc,
+                 [a.uuid, b.uuid, c.uuid]
+               )
+
+      assert item_positions(ctx.category.uuid) == [{"Apple", 1}, {"Banana", 2}, {"Cherry", 3}]
+    end
+
+    test "subset permute returns :duplicate_positions when rows share a position", ctx do
+      # Catalogue items default to position 0 — an unreordered scope has
+      # many rows at 0, so a subset permute can't assign distinct slots.
+      a = create_item(%{name: "A", category_uuid: ctx.category.uuid})
+      b = create_item(%{name: "B", category_uuid: ctx.category.uuid})
+
+      assert {:error, :duplicate_positions} =
+               Catalogue.reorder_items_by(
+                 ctx.catalogue.uuid,
+                 ctx.category.uuid,
+                 :name_asc,
+                 [a.uuid, b.uuid]
+               )
+    end
+
+    test "rejects uuids outside the scope", ctx do
+      other_cat = create_category(ctx.catalogue, %{name: "Other"})
+      mine = create_item(%{name: "Mine", position: 1, category_uuid: ctx.category.uuid})
+      foreign = create_item(%{name: "Foreign", position: 1, category_uuid: other_cat.uuid})
+
+      assert {:error, :uuids_outside_scope} =
+               Catalogue.reorder_items_by(
+                 ctx.catalogue.uuid,
+                 ctx.category.uuid,
+                 :name_asc,
+                 [mine.uuid, foreign.uuid]
+               )
+    end
+
+    test "rejects an invalid strategy", ctx do
+      create_item(%{name: "X", category_uuid: ctx.category.uuid})
+
+      assert {:error, :invalid_strategy} =
+               Catalogue.reorder_items_by(ctx.catalogue.uuid, ctx.category.uuid, :bogus, :all)
+    end
+
+    test "uncategorized scope is reachable via :uncategorized normalization", ctx do
+      create_item(%{name: "Loose B", catalogue_uuid: ctx.catalogue.uuid})
+      create_item(%{name: "Loose A", catalogue_uuid: ctx.catalogue.uuid})
+
+      assert :ok =
+               Catalogue.reorder_items_by(
+                 ctx.catalogue.uuid,
+                 :uncategorized,
+                 :name_asc,
+                 :all
+               )
+
+      names =
+        ctx.catalogue.uuid
+        |> Catalogue.list_uncategorized_items_paged(sort_by: :position, sort_dir: :asc)
+        |> Enum.map(& &1.name)
+
+      assert names == ["Loose A", "Loose B"]
+    end
+  end
+
   # ═══════════════════════════════════════════════════════════════════
   # Active counts
   # ═══════════════════════════════════════════════════════════════════

--- a/test/catalogue_test.exs
+++ b/test/catalogue_test.exs
@@ -4253,4 +4253,37 @@ defmodule PhoenixKitCatalogue.CatalogueTest do
       assert length(Catalogue.list_deleted_items_for_catalogue(cat.uuid, limit: 2)) == 2
     end
   end
+
+  describe "item_status_counts_for_category/1 and _for_uncategorized/1" do
+    test "group a category's items by status (drives the per-status tabs)" do
+      cat = create_catalogue()
+      category = create_category(cat, %{name: "Shelf"})
+
+      create_item(%{name: "a1", category_uuid: category.uuid, status: "active"})
+      create_item(%{name: "a2", category_uuid: category.uuid, status: "active"})
+      create_item(%{name: "i1", category_uuid: category.uuid, status: "inactive"})
+      create_item(%{name: "d1", category_uuid: category.uuid, status: "discontinued"})
+      create_item(%{name: "x1", category_uuid: category.uuid, status: "deleted"})
+
+      counts = Catalogue.item_status_counts_for_category(category.uuid)
+
+      assert counts["active"] == 2
+      assert counts["inactive"] == 1
+      assert counts["discontinued"] == 1
+      assert counts["deleted"] == 1
+    end
+
+    test "uncategorized counts cover the catalogue's loose items by status" do
+      cat = create_catalogue()
+      create_item(%{name: "u1", catalogue_uuid: cat.uuid, status: "active"})
+      create_item(%{name: "u2", catalogue_uuid: cat.uuid, status: "discontinued"})
+
+      counts = Catalogue.item_status_counts_for_uncategorized(cat.uuid)
+
+      assert counts["active"] == 1
+      assert counts["discontinued"] == 1
+      # Absent statuses simply have no key (group_by), not a zero.
+      assert Map.get(counts, "inactive", 0) == 0
+    end
+  end
 end

--- a/test/folders_test.exs
+++ b/test/folders_test.exs
@@ -24,17 +24,21 @@ defmodule PhoenixKitCatalogue.FoldersTest do
   # ═══════════════════════════════════════════════════════════════════
 
   describe "list_folder_tree/1" do
-    test "returns folders with depth in DFS (position, name) order" do
+    test "returns folders depth-first, newest-first within each level" do
+      # `create_folder` front-inserts (see `front_folder_position/1`): a
+      # new folder sorts to the top of its level so it's immediately
+      # visible. So at the root, b (created after a) comes first; then the
+      # DFS descends a's subtree.
       a = create_folder(%{name: "A"})
       b = create_folder(%{name: "B"})
       a1 = create_folder(%{name: "A1", parent_uuid: a.uuid})
       a1x = create_folder(%{name: "A1x", parent_uuid: a1.uuid})
 
       assert tree_uuids() == [
+               {b.uuid, 0},
                {a.uuid, 0},
                {a1.uuid, 1},
-               {a1x.uuid, 2},
-               {b.uuid, 0}
+               {a1x.uuid, 2}
              ]
     end
 

--- a/test/folders_test.exs
+++ b/test/folders_test.exs
@@ -1,0 +1,248 @@
+defmodule PhoenixKitCatalogue.FoldersTest do
+  use PhoenixKitCatalogue.DataCase, async: true
+
+  alias PhoenixKitCatalogue.Catalogue
+  alias PhoenixKitCatalogue.Schemas.Folder
+
+  # ── Helpers ──────────────────────────────────────────────────────
+
+  defp create_folder(attrs) do
+    {:ok, f} = Catalogue.create_folder(Map.merge(%{name: "Folder"}, attrs))
+    f
+  end
+
+  defp create_catalogue(attrs) do
+    {:ok, c} = Catalogue.create_catalogue(Map.merge(%{name: "Catalogue"}, attrs))
+    c
+  end
+
+  defp tree_uuids(opts \\ []),
+    do: Catalogue.list_folder_tree(opts) |> Enum.map(fn {f, d} -> {f.uuid, d} end)
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Tree + depth
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "list_folder_tree/1" do
+    test "returns folders with depth in DFS (position, name) order" do
+      a = create_folder(%{name: "A"})
+      b = create_folder(%{name: "B"})
+      a1 = create_folder(%{name: "A1", parent_uuid: a.uuid})
+      a1x = create_folder(%{name: "A1x", parent_uuid: a1.uuid})
+
+      assert tree_uuids() == [
+               {a.uuid, 0},
+               {a1.uuid, 1},
+               {a1x.uuid, 2},
+               {b.uuid, 0}
+             ]
+    end
+
+    test ":active mode excludes deleted folders" do
+      a = create_folder(%{name: "A"})
+      {:ok, _} = Catalogue.trash_folder(a)
+
+      assert tree_uuids(mode: :active) == []
+    end
+
+    test "child of a trashed parent orphan-promotes to root in active mode" do
+      parent = create_folder(%{name: "Parent"})
+      child = create_folder(%{name: "Child", parent_uuid: parent.uuid})
+      {:ok, _} = Catalogue.trash_folder(parent)
+
+      # Parent is gone from the active set; child surfaces at root (depth 0).
+      assert tree_uuids(mode: :active) == [{child.uuid, 0}]
+    end
+
+    test ":exclude_subtree_of drops a folder and its descendants" do
+      a = create_folder(%{name: "A"})
+      a1 = create_folder(%{name: "A1", parent_uuid: a.uuid})
+      _a1x = create_folder(%{name: "A1x", parent_uuid: a1.uuid})
+      b = create_folder(%{name: "B"})
+
+      uuids =
+        Catalogue.list_folder_tree(exclude_subtree_of: a.uuid)
+        |> Enum.map(fn {f, _} -> f.uuid end)
+
+      assert uuids == [b.uuid]
+    end
+
+    test "folder_uuids_with_children/1 flags only parents" do
+      a = create_folder(%{name: "A"})
+      _a1 = create_folder(%{name: "A1", parent_uuid: a.uuid})
+      b = create_folder(%{name: "B"})
+
+      with_children = Catalogue.folder_uuids_with_children()
+      assert MapSet.member?(with_children, a.uuid)
+      refute MapSet.member?(with_children, b.uuid)
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Move + cycle guard + position
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "move_folder/3" do
+    test "moves a folder under a new parent and appends position" do
+      a = create_folder(%{name: "A"})
+      b = create_folder(%{name: "B"})
+      b1 = create_folder(%{name: "B1", parent_uuid: b.uuid})
+      mover = create_folder(%{name: "Mover"})
+
+      {:ok, moved} = Catalogue.move_folder(mover, b.uuid)
+      assert moved.parent_uuid == b.uuid
+      # Appended after the existing child b1 (position 1) → position 2.
+      assert moved.position == b1.position + 1
+      refute moved.parent_uuid == a.uuid
+    end
+
+    test "rejects a move into the folder's own subtree (cycle)" do
+      a = create_folder(%{name: "A"})
+      a1 = create_folder(%{name: "A1", parent_uuid: a.uuid})
+
+      assert {:error, :cycle} = Catalogue.move_folder(a, a1.uuid)
+      assert {:error, :cycle} = Catalogue.move_folder(a, a.uuid)
+    end
+
+    test "rejects a move into a trashed folder" do
+      a = create_folder(%{name: "A"})
+      dead = create_folder(%{name: "Dead"})
+      {:ok, _} = Catalogue.trash_folder(dead)
+
+      assert {:error, :folder_trashed} = Catalogue.move_folder(a, dead.uuid)
+    end
+
+    test "rejects a move into a missing folder" do
+      a = create_folder(%{name: "A"})
+      assert {:error, :folder_not_found} = Catalogue.move_folder(a, Ecto.UUID.generate())
+    end
+
+    test "no-op when parent is unchanged" do
+      a = create_folder(%{name: "A"})
+      assert {:ok, ^a} = Catalogue.move_folder(a, a.parent_uuid)
+    end
+  end
+
+  describe "reorder_folders/2" do
+    test "writes 1..N positions in the given order within a level" do
+      a = create_folder(%{name: "A"})
+      b = create_folder(%{name: "B"})
+      c = create_folder(%{name: "C"})
+
+      assert :ok = Catalogue.reorder_folders([c.uuid, a.uuid, b.uuid])
+
+      assert Catalogue.get_folder(c.uuid).position == 1
+      assert Catalogue.get_folder(a.uuid).position == 2
+      assert Catalogue.get_folder(b.uuid).position == 3
+    end
+  end
+
+  describe "restore_folder/2" do
+    test "restores under the prior parent when it is still active" do
+      parent = create_folder(%{name: "Parent"})
+      child = create_folder(%{name: "Child", parent_uuid: parent.uuid})
+      {:ok, _} = Catalogue.trash_folder(child)
+
+      {:ok, restored} = Catalogue.restore_folder(Catalogue.get_folder(child.uuid))
+      assert restored.status == "active"
+      assert restored.parent_uuid == parent.uuid
+    end
+
+    test "restores to root when the prior parent is gone/trashed" do
+      parent = create_folder(%{name: "Parent"})
+      child = create_folder(%{name: "Child", parent_uuid: parent.uuid})
+      {:ok, _} = Catalogue.trash_folder(child)
+      {:ok, _} = Catalogue.trash_folder(parent)
+
+      {:ok, restored} = Catalogue.restore_folder(Catalogue.get_folder(child.uuid))
+      assert restored.status == "active"
+      assert restored.parent_uuid == nil
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Catalogue ↔ folder
+  # ═══════════════════════════════════════════════════════════════════
+
+  describe "move_catalogue_to_folder/3" do
+    test "files a catalogue into a folder and appends position" do
+      folder = create_folder(%{name: "F"})
+      existing = create_catalogue(%{name: "Existing"})
+      {:ok, _} = Catalogue.move_catalogue_to_folder(existing, folder.uuid)
+      cat = create_catalogue(%{name: "Cat"})
+
+      {:ok, moved} = Catalogue.move_catalogue_to_folder(cat, folder.uuid)
+      assert moved.folder_uuid == folder.uuid
+      assert moved.position == Catalogue.get_catalogue(existing.uuid).position + 1
+    end
+
+    test ":unfiled / nil files to root" do
+      folder = create_folder(%{name: "F"})
+      cat = create_catalogue(%{name: "Cat"})
+      {:ok, filed} = Catalogue.move_catalogue_to_folder(cat, folder.uuid)
+
+      {:ok, unfiled} = Catalogue.move_catalogue_to_folder(filed, :unfiled)
+      assert unfiled.folder_uuid == nil
+    end
+
+    test "rejects filing into a trashed folder" do
+      dead = create_folder(%{name: "Dead"})
+      {:ok, _} = Catalogue.trash_folder(dead)
+      cat = create_catalogue(%{name: "Cat"})
+
+      assert {:error, :folder_trashed} = Catalogue.move_catalogue_to_folder(cat, dead.uuid)
+    end
+
+    test "no-op (no write) when already in the target folder" do
+      folder = create_folder(%{name: "F"})
+      cat = create_catalogue(%{name: "Cat"})
+      {:ok, filed} = Catalogue.move_catalogue_to_folder(cat, folder.uuid)
+
+      assert {:ok, same} = Catalogue.move_catalogue_to_folder(filed, folder.uuid)
+      assert same.updated_at == filed.updated_at
+    end
+  end
+
+  describe "catalogues_by_folder/1 + list_catalogues(folder_uuid:)" do
+    test "groups catalogues by folder; orphans (trashed folder) promote to root" do
+      folder = create_folder(%{name: "F"})
+      root_cat = create_catalogue(%{name: "Root"})
+      filed = create_catalogue(%{name: "Filed"})
+      {:ok, filed} = Catalogue.move_catalogue_to_folder(filed, folder.uuid)
+
+      grouped = Catalogue.catalogues_by_folder()
+      assert Enum.map(grouped[folder.uuid] || [], & &1.uuid) == [filed.uuid]
+      assert root_cat.uuid in Enum.map(grouped[nil] || [], & &1.uuid)
+
+      # Trash the folder → its catalogue orphan-promotes to root.
+      {:ok, _} = Catalogue.trash_folder(folder)
+      grouped2 = Catalogue.catalogues_by_folder()
+      assert grouped2[folder.uuid] == nil
+      assert filed.uuid in Enum.map(grouped2[nil] || [], & &1.uuid)
+    end
+
+    test "list_catalogues(folder_uuid:) filters strictly (no promotion)" do
+      folder = create_folder(%{name: "F"})
+      filed = create_catalogue(%{name: "Filed"})
+      {:ok, _} = Catalogue.move_catalogue_to_folder(filed, folder.uuid)
+      _root = create_catalogue(%{name: "Root"})
+
+      assert Catalogue.list_catalogues(folder_uuid: folder.uuid) |> Enum.map(& &1.uuid) == [
+               filed.uuid
+             ]
+
+      unfiled = Catalogue.list_catalogues(folder_uuid: :unfiled) |> Enum.map(& &1.name)
+      assert "Root" in unfiled
+      refute "Filed" in unfiled
+    end
+  end
+
+  describe "changeset guards" do
+    test "rejects a self-parent at the changeset level" do
+      folder = create_folder(%{name: "A"})
+      cs = Folder.changeset(folder, %{parent_uuid: folder.uuid})
+      refute cs.valid?
+      assert %{parent_uuid: ["folder cannot be its own parent"]} = errors_on(cs)
+    end
+  end
+end

--- a/test/phoenix_kit_catalogue_test.exs
+++ b/test/phoenix_kit_catalogue_test.exs
@@ -216,7 +216,9 @@ defmodule PhoenixKitCatalogueTest do
 
   describe "version/0" do
     test "returns version string" do
-      assert PhoenixKitCatalogue.version() == "0.1.17"
+      # Assert the shape, not a pinned literal — the version is bumped on
+      # every release and a hardcoded value goes stale immediately.
+      assert PhoenixKitCatalogue.version() =~ ~r/^\d+\.\d+\.\d+/
     end
   end
 

--- a/test/smart_pricing_test.exs
+++ b/test/smart_pricing_test.exs
@@ -357,14 +357,14 @@ defmodule PhoenixKitCatalogue.SmartPricingTest do
       end
     end
 
-    test "non-exact float qty is accepted; carries Decimal.from_float imprecision" do
-      # Pins the moduledoc's "Numeric precision for `:qty`" caveat:
-      # `1.1` has no exact binary representation. Floats are accepted
-      # (no crash, no validation rejection) but
-      # `Decimal.from_float(1.1) != Decimal.new("1.1")` is the tax
-      # callers pay. This test pins both halves of the contract:
-      #   1. float qty does not crash and produces a price
-      #   2. `Decimal.from_float(1.1) != Decimal.new("1.1")`
+    test "non-exact float qty is accepted (no crash, produces a price)" do
+      # Pins the moduledoc's "Numeric precision for `:qty`" caveat: a float
+      # qty like `1.1` (no exact binary representation) is accepted — no
+      # crash, no validation rejection — and still produces a price. We do
+      # NOT pin the exact `Decimal.from_float/1` round-trip: its
+      # representation is library-version-dependent and not part of this
+      # function's contract. Callers needing cent-exact billing pass
+      # `Decimal.t()` or `integer()` per the moduledoc.
       kitchen = standard_catalogue()
       services = smart_catalogue()
       panel = standard_item(kitchen, %{base_price: Decimal.new("100")})
@@ -378,12 +378,6 @@ defmodule PhoenixKitCatalogue.SmartPricingTest do
 
       # Float input is accepted; no raise, no validation rejection.
       assert %Decimal{} = out_float.smart_price
-
-      # The conversion tax: Decimal.from_float(1.1) ≠ Decimal.new("1.1").
-      # Callers needing cent-exact billing must pass `Decimal.t()` or
-      # `integer()` per the moduledoc.
-      refute Decimal.equal?(Decimal.from_float(1.1), Decimal.new("1.1"))
-      assert Decimal.compare(Decimal.from_float(1.1), Decimal.new("1.1")) == :gt
     end
   end
 

--- a/test/support/live_case.ex
+++ b/test/support/live_case.ex
@@ -35,6 +35,7 @@ defmodule PhoenixKitCatalogue.LiveCase do
     end
   end
 
+  alias Ecto.Adapters.SQL
   alias Ecto.Adapters.SQL.Sandbox
   alias PhoenixKitCatalogue.Test.Repo, as: TestRepo
 
@@ -46,7 +47,63 @@ defmodule PhoenixKitCatalogue.LiveCase do
       Phoenix.ConnTest.build_conn()
       |> Plug.Test.init_test_session(%{})
 
-    {:ok, conn: conn}
+    {:ok, conn: conn, scope: build_admin_scope()}
+  end
+
+  @doc """
+  Builds a minimal authenticated admin scope for tests that assert on the
+  *actor* of an activity-log entry. Inserts a real `phoenix_kit_users` row
+  (cheap — a pre-computed dummy hash, no bcrypt) so the activity log's
+  `actor_uuid` resolves, and wraps it in the `%{user: %{uuid: ...}}` shape
+  `PhoenixKitCatalogue.Web.Helpers.actor_uuid/1` reads. Pipe it onto the
+  conn with `with_scope/2` before `live/2`.
+  """
+  def build_admin_scope do
+    uuid = UUIDv7.generate()
+    email = "lv-test-#{System.unique_integer([:positive])}@example.com"
+
+    SQL.query!(
+      TestRepo,
+      """
+      INSERT INTO phoenix_kit_users
+        (uuid, email, hashed_password, account_type, is_active, inserted_at, updated_at)
+      VALUES ($1, $2, $3, 'person', true, NOW(), NOW())
+      """,
+      [
+        Ecto.UUID.dump!(uuid),
+        email,
+        "$2b$12$0000000000000000000000000000000000000000000000000000."
+      ]
+    )
+
+    %{user: %{uuid: uuid}}
+  end
+
+  @doc """
+  Stashes a scope's user UUID into the conn session so the test
+  live_session's `:assign_test_current_user` on_mount assigns
+  `phoenix_kit_current_user` — letting the LV resolve a non-nil
+  `actor_uuid` for activity logging. Use as `conn |> with_scope(scope) |>
+  live(path)`.
+  """
+  def with_scope(conn, %{user: %{uuid: uuid}}) do
+    Plug.Conn.put_session(conn, "pk_current_user_uuid", uuid)
+  end
+
+  @doc """
+  on_mount callback wired into the test live_session. Assigns
+  `phoenix_kit_current_user` from the session when `with_scope/2` set it;
+  otherwise leaves assigns untouched so tests that don't opt in behave
+  exactly as before (anonymous actor).
+  """
+  def on_mount(:assign_test_current_user, _params, session, socket) do
+    case session do
+      %{"pk_current_user_uuid" => uuid} when is_binary(uuid) ->
+        {:cont, Phoenix.Component.assign(socket, :phoenix_kit_current_user, %{uuid: uuid})}
+
+      _ ->
+        {:cont, socket}
+    end
   end
 
   @doc """

--- a/test/support/test_router.ex
+++ b/test/support/test_router.ex
@@ -27,7 +27,9 @@ defmodule PhoenixKitCatalogue.Test.Router do
   scope "/en/admin/catalogue", PhoenixKitCatalogue.Web do
     pipe_through(:browser)
 
-    live_session :catalogue_test, layout: {PhoenixKitCatalogue.Test.Layouts, :app} do
+    live_session :catalogue_test,
+      on_mount: {PhoenixKitCatalogue.LiveCase, :assign_test_current_user},
+      layout: {PhoenixKitCatalogue.Test.Layouts, :app} do
       # Catalogues / Manufacturers / Suppliers — CataloguesLive owns
       # all three tabs.
       live("/", CataloguesLive, :index)
@@ -57,6 +59,11 @@ defmodule PhoenixKitCatalogue.Test.Router do
 
       # Events / activity feed
       live("/events", EventsLive, :index)
+
+      # PDF library (literal "/pdfs" prefix; declared before the "/:uuid"
+      # catch-all so it isn't swallowed by CatalogueDetailLive).
+      live("/pdfs", PdfLibraryLive, :index)
+      live("/pdfs/:uuid", PdfDetailLive, :show)
 
       # Catalogue detail (last so it doesn't swallow the static routes above)
       live("/:uuid", CatalogueDetailLive, :show)

--- a/test/web/catalogue_detail_branches_test.exs
+++ b/test/web/catalogue_detail_branches_test.exs
@@ -179,11 +179,13 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailBranchesTest do
 
       render_click(view, "request_bulk_delete_items", %{})
 
-      assert :sys.get_state(view.pid).socket.assigns.bulk_confirm == %{
-               kind: :items,
-               mode: :trash,
-               count: 2
-             }
+      confirm = :sys.get_state(view.pid).socket.assigns.bulk_confirm
+      assert confirm.kind == :items
+      assert confirm.mode == :trash
+      assert confirm.count == 2
+      # The captured selection is carried on the confirm so the apply
+      # step doesn't re-read the (client-side) selection.
+      assert Enum.sort(confirm.uuids) == Enum.sort([a.uuid, b.uuid])
 
       render_click(view, "confirm_bulk_action", %{})
 
@@ -240,53 +242,12 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailBranchesTest do
     end
   end
 
-  describe "expand_card per-card pagination" do
-    test "expand_card appends the next slice of items into a single card",
-         %{conn: conn, catalogue: cat} do
-      category = fixture_category(cat)
-      # @per_card is 25; create 30 so a single expand reaches the end.
-      for i <- 1..30 do
-        fixture_item(%{name: "I#{i}", category_uuid: category.uuid})
-      end
-
-      {:ok, view, first_html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
-      assert first_html =~ "Show 5 more"
-
-      render_click(view, "expand_card", %{"scope" => category.uuid})
-      :sys.get_state(view.pid)
-      assigns = :sys.get_state(view.pid).socket.assigns
-
-      [card] = Enum.filter(assigns.loaded_cards, &(&1.kind == :category))
-      assert length(card.items) == 30
-      assert MapSet.size(assigns.expanding_cards) == 0
-    end
-
-    test "expand_timeout while still expanding restores the button + flashes a retry message",
-         %{conn: conn, catalogue: cat} do
-      category = fixture_category(cat)
-      _ = fixture_item(%{name: "I", category_uuid: category.uuid})
-
-      {:ok, view, _html} = live(conn, "/en/admin/catalogue/#{cat.uuid}")
-
-      # Drop the in-flight :apply_expand message so the timeout
-      # branch fires (simulating a stuck mailbox / lost connection).
-      send(view.pid, {:expand_timeout, category.uuid})
-
-      # First mark the scope as expanding so the timeout branch
-      # actually fires.
-      :sys.replace_state(view.pid, fn state ->
-        socket = state.socket
-        new_assigns = Map.put(socket.assigns, :expanding_cards, MapSet.new([category.uuid]))
-        %{state | socket: %{socket | assigns: new_assigns}}
-      end)
-
-      send(view.pid, {:expand_timeout, category.uuid})
-      :sys.get_state(view.pid)
-
-      assigns = :sys.get_state(view.pid).socket.assigns
-      assert MapSet.size(assigns.expanding_cards) == 0
-    end
-  end
+  # The old per-card "expand_card" / "Show N more" mechanism (loaded_cards,
+  # expanding_cards, @per_card, expand_timeout) was removed when the detail
+  # page became a category drill-down: the root level now lists categories
+  # as bare drill-cards (no inline items), and a category's own items load
+  # via the core list-UI `load_more` toolkit at the category level. Coverage
+  # for the new mechanism lives in catalogue_detail_live_test.exs.
 
   describe "cross-tab live updates" do
     test "catalogue_card_refresh from another pid refreshes only the affected scope",
@@ -300,9 +261,11 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailBranchesTest do
       send(view.pid, {:catalogue_card_refresh, cat.uuid, category.uuid, nil, :ok, self()})
       :sys.get_state(view.pid)
 
-      # The handler ran (no crash) and the card still renders.
+      # The handler ran (no crash) and the level still renders. The root
+      # level shows category drill-cards (not inline item names), so assert
+      # the category card is present rather than the item name.
       html = render(view)
-      assert html =~ "Original"
+      assert html =~ category.name
     end
 
     test "catalogue_card_refresh from self() is ignored (no double-render)",

--- a/test/web/catalogue_detail_live_test.exs
+++ b/test/web/catalogue_detail_live_test.exs
@@ -1,8 +1,10 @@
 defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
   @moduledoc """
-  End-to-end tests for CatalogueDetailLive — infinite scroll paging,
-  view-mode toggle, search, item mutations preserving scroll, category
-  reorder/trash/restore/permanent_delete, not-found redirect.
+  End-to-end tests for CatalogueDetailLive — the category drill-down:
+  root landing (category cards + Uncategorized card), drilling into a
+  category (`?category=<uuid>`) to see its subcategories + own items,
+  the uncategorized bucket, per-level Active/Deleted, scoped search,
+  item/category mutations, orphan reachability, and not-found handling.
   """
   use PhoenixKitCatalogue.LiveCase
 
@@ -11,13 +13,24 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
   @base "/en/admin/catalogue"
 
   defp url(uuid), do: "#{@base}/#{uuid}"
+  defp cat_url(cat_uuid, category_uuid), do: "#{url(cat_uuid)}?category=#{category_uuid}"
+  defp uncat_url(cat_uuid), do: "#{url(cat_uuid)}?category=uncategorized"
+
+  # Character index of `needle` in `html` — for asserting relative
+  # render order of two item names.
+  defp position_of(html, needle) do
+    case :binary.match(html, needle) do
+      {idx, _len} -> idx
+      :nomatch -> flunk("expected #{inspect(needle)} in rendered HTML")
+    end
+  end
 
   # ─────────────────────────────────────────────────────────────────
-  # Mount / render
+  # Mount / root landing
   # ─────────────────────────────────────────────────────────────────
 
   describe "mount" do
-    test "renders catalogue name and header actions in active mode", %{conn: conn} do
+    test "renders catalogue name and header actions", %{conn: conn} do
       catalogue = fixture_catalogue(%{name: "Kitchen"})
 
       {:ok, _view, html} = live(conn, url(catalogue.uuid))
@@ -43,122 +56,158 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
     end
   end
 
-  # ─────────────────────────────────────────────────────────────────
-  # Infinite scroll
-  # ─────────────────────────────────────────────────────────────────
-
-  describe "infinite scroll" do
-    test "initial mount loads the first category's card", %{conn: conn} do
+  describe "root landing" do
+    test "shows root categories as drill cards and the catalogue-wide search", %{conn: conn} do
       catalogue = fixture_catalogue()
       cat_a = fixture_category(catalogue, %{name: "First", position: 0})
       _cat_b = fixture_category(catalogue, %{name: "Second", position: 1})
 
-      for i <- 1..3 do
-        fixture_item(%{name: "A#{i}", category_uuid: cat_a.uuid})
-      end
-
       {:ok, _view, html} = live(conn, url(catalogue.uuid))
 
       assert html =~ "First"
-      assert html =~ "A1"
-    end
-
-    test "every category renders eagerly with its own preview slice", %{conn: conn} do
-      # 2026-05-09: Items tab swapped infinite scroll for per-card
-      # expand (mirrors PdfSearchModal). All categories show on first
-      # render with a 25-item preview + per-card "Show N more" button.
-      catalogue = fixture_catalogue()
-      cat_a = fixture_category(catalogue, %{name: "First", position: 0})
-      cat_b = fixture_category(catalogue, %{name: "Second", position: 1})
-
-      fixture_item(%{name: "A only", category_uuid: cat_a.uuid})
-      fixture_item(%{name: "B only", category_uuid: cat_b.uuid})
-
-      {:ok, _view, html} = live(conn, url(catalogue.uuid))
-
-      assert html =~ "First"
-      assert html =~ "A only"
       assert html =~ "Second"
-      assert html =~ "B only"
+      # Each card is a drill link into the category.
+      assert html =~ "?category=#{cat_a.uuid}"
+      # The pencil keeps a one-click path to the edit form.
+      assert html =~ "/en/admin/catalogue/categories/#{cat_a.uuid}/edit"
+      # Root search is catalogue-wide.
+      assert html =~ "Search items by name, description, or SKU"
     end
 
-    test "expand_card loads more items into a single category", %{conn: conn} do
+    test "shows an Uncategorized drill card when there are categories + loose items",
+         %{conn: conn} do
       catalogue = fixture_catalogue()
-      category = fixture_category(catalogue)
-
-      # @per_card is 25 — create 30 so an expand is needed.
-      for i <- 1..30 do
-        fixture_item(%{
-          name: "Item #{String.pad_leading("#{i}", 3, "0")}",
-          category_uuid: category.uuid
-        })
-      end
-
-      {:ok, view, first_html} = live(conn, url(catalogue.uuid))
-
-      # First render: items 001..025 visible, "Show 5 more" button visible.
-      assert first_html =~ "Item 001"
-      assert first_html =~ "Item 025"
-      refute first_html =~ "Item 030"
-      assert first_html =~ "Show 5 more"
-
-      # `expand_card` is asynchronous: the event handler defers the
-      # actual fetch via send/2 + a recovery `expand_timeout` so the
-      # button can re-render in its loading state. Drain the LV's
-      # mailbox by issuing any synchronous pull (e.g. another render)
-      # — `:sys.get_state` waits for everything queued before it.
-      render_click(view, "expand_card", %{"scope" => category.uuid})
-      :sys.get_state(view.pid)
-      html_after = render(view)
-
-      assert html_after =~ "Item 026"
-      assert html_after =~ "Item 030"
-    end
-
-    test "Uncategorized renders eagerly when the catalogue has loose items", %{conn: conn} do
-      catalogue = fixture_catalogue()
-      cat_a = fixture_category(catalogue, %{name: "Cat A"})
-
-      fixture_item(%{name: "In Category", category_uuid: cat_a.uuid})
+      # A category must exist for the Uncategorized card to appear — with no
+      # categories the loose items render inline instead (see next test).
+      fixture_category(catalogue, %{name: "A Category"})
       fixture_item(%{name: "Loose Item", catalogue_uuid: catalogue.uuid})
 
       {:ok, _view, html} = live(conn, url(catalogue.uuid))
 
-      assert html =~ "Cat A"
-      assert html =~ "In Category"
       assert html =~ "Uncategorized"
-      assert html =~ "Loose Item"
+      assert html =~ "?category=uncategorized"
     end
 
-    test "category card shows the total item count, not the loaded count", %{conn: conn} do
+    test "with no categories, the catalogue's loose items render inline at root",
+         %{conn: conn} do
       catalogue = fixture_catalogue()
-      category = fixture_category(catalogue)
-
-      for i <- 1..30 do
-        fixture_item(%{name: "I#{i}", category_uuid: category.uuid})
-      end
+      fixture_item(%{name: "Loose Alpha", catalogue_uuid: catalogue.uuid})
 
       {:ok, _view, html} = live(conn, url(catalogue.uuid))
 
-      # Badge shows total (30), not the first preview slice (25).
-      assert html =~ "30 items"
+      # Items show directly — no redundant Uncategorized drill card to click.
+      assert html =~ "Loose Alpha"
+      refute html =~ "?category=uncategorized"
+    end
+
+    test "does NOT render category items inline at the root level", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue, %{name: "Cat A"})
+      fixture_item(%{name: "Deep Inside Item", category_uuid: category.uuid})
+
+      {:ok, _view, html} = live(conn, url(catalogue.uuid))
+
+      assert html =~ "Cat A"
+      # Categorised items only show once you drill into the category.
+      refute html =~ "Deep Inside Item"
+    end
+
+    test "no breadcrumb at the root level", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      fixture_category(catalogue, %{name: "Cat"})
+
+      {:ok, _view, html} = live(conn, url(catalogue.uuid))
+
+      refute html =~ "breadcrumbs"
     end
   end
 
   # ─────────────────────────────────────────────────────────────────
-  # View mode (active / deleted tabs)
+  # Drilling into a category
   # ─────────────────────────────────────────────────────────────────
 
-  describe "view_mode toggle" do
-    test "switch_view resets the cursor and reloads with deleted items", %{conn: conn} do
+  describe "drill into a category" do
+    test "shows the breadcrumb, the scoped search, and the category's own items", %{conn: conn} do
+      catalogue = fixture_catalogue(%{name: "Catalogue X"})
+      category = fixture_category(catalogue, %{name: "Hardware"})
+      fixture_item(%{name: "Hinge 90", category_uuid: category.uuid})
+
+      {:ok, _view, html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
+      # The breadcrumb is folded into the page title: catalogue name (a
+      # link back to root) ▸ current category name.
+      assert html =~ "Catalogue X"
+      assert html =~ "Hardware"
+      assert html =~ "Hinge 90"
+      # The breadcrumb root crumb patches back to the catalogue root.
+      assert html =~ ~s(href="#{url(catalogue.uuid)}")
+      # Search is scoped to this category.
+      assert html =~ "Search within this category"
+    end
+
+    test "shows subcategories as drill cards alongside the category's own items", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      parent = fixture_category(catalogue, %{name: "Parent"})
+      child = fixture_category(catalogue, %{name: "Child", parent_uuid: parent.uuid})
+      fixture_item(%{name: "Parent direct item", category_uuid: parent.uuid})
+
+      {:ok, _view, html} = live(conn, cat_url(catalogue.uuid, parent.uuid))
+
+      # Subcategory card (drillable) + the parent's own direct item.
+      assert html =~ "Child"
+      assert html =~ "?category=#{child.uuid}"
+      assert html =~ "Parent direct item"
+    end
+
+    test "an item in the level list links to its edit page", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      item = fixture_item(%{name: "Clickable item", category_uuid: category.uuid})
+
+      {:ok, _view, html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
+      assert html =~ ~s(href="/en/admin/catalogue/items/#{item.uuid}/edit")
+      assert html =~ "Clickable item"
+    end
+
+    test "a missing / foreign category bounces back to the root level", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      bogus = "00000000-0000-0000-0000-000000000000"
+
+      case live(conn, cat_url(catalogue.uuid, bogus)) do
+        {:ok, _view, html} -> assert html =~ "Add Category"
+        {:error, {:live_redirect, %{to: to}}} -> assert to =~ url(catalogue.uuid)
+      end
+    end
+  end
+
+  describe "uncategorized bucket" do
+    test "shows the catalogue's loose items", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      _categorised = fixture_category(catalogue, %{name: "Cat A"})
+      fixture_item(%{name: "Loose Item", catalogue_uuid: catalogue.uuid})
+
+      {:ok, _view, html} = live(conn, uncat_url(catalogue.uuid))
+
+      assert html =~ "Uncategorized"
+      assert html =~ "Loose Item"
+      assert html =~ "Search uncategorized items"
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Per-level Active / Deleted
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "view_mode toggle (per-level)" do
+    test "switch_view shows the current category's deleted items", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
       active = fixture_item(%{name: "Active item", category_uuid: category.uuid})
       deleted = fixture_item(%{name: "Deleted item", category_uuid: category.uuid})
       Catalogue.trash_item(deleted)
 
-      {:ok, view, html} = live(conn, url(catalogue.uuid))
-
+      {:ok, view, html} = live(conn, cat_url(catalogue.uuid, category.uuid))
       assert html =~ "Active item"
       refute html =~ "Deleted item"
 
@@ -168,7 +217,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       refute html_after =~ active.uuid
     end
 
-    test "Active tab badge shows the non-deleted item count", %{conn: conn} do
+    test "the toggle reflects the level's active + deleted counts", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
       fixture_item(%{name: "A", category_uuid: category.uuid})
@@ -176,8 +225,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       gone = fixture_item(%{name: "Gone", category_uuid: category.uuid})
       Catalogue.trash_item(gone)
 
-      {:ok, _view, html} = live(conn, url(catalogue.uuid))
-      # Active (2) and Deleted (1) tabs are present; check the Active count appears.
+      {:ok, _view, html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
       assert html =~ "Active"
       assert html =~ "(2)"
       assert html =~ "Deleted"
@@ -186,39 +235,33 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
   end
 
   # ─────────────────────────────────────────────────────────────────
-  # Item mutations (local updates — scroll is preserved)
+  # Item mutations (inside a category)
   # ─────────────────────────────────────────────────────────────────
 
   describe "item mutations" do
-    test "delete_item removes the item from the card without a full reload", %{conn: conn} do
+    test "delete_item removes the item and trashes it in the DB", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
       item = fixture_item(%{name: "Doomed", category_uuid: category.uuid})
       fixture_item(%{name: "Survivor", category_uuid: category.uuid})
 
-      {:ok, view, html} = live(conn, url(catalogue.uuid))
+      {:ok, view, html} = live(conn, cat_url(catalogue.uuid, category.uuid))
       assert html =~ "Doomed"
 
       html_after = render_click(view, "delete_item", %{"uuid" => item.uuid})
 
       refute html_after =~ "Doomed"
       assert html_after =~ "Survivor"
-      # DB reflects the trash (status = "deleted")
       assert Catalogue.get_item(item.uuid).status == "deleted"
     end
 
-    test "restore_item (from the Items tab Deleted view) marks the item active", %{conn: conn} do
-      # After restore, the deleted view auto-flips back to Active because
-      # `deleted_item_count` hits 0 — the restored item ends up visible
-      # in the active stream rather than removed from the page entirely.
-      # The behavioral pin is: the DB row is "active" and the page
-      # doesn't crash.
+    test "restore_item from the level's Deleted view marks the item active", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
       item = fixture_item(%{name: "Comeback", category_uuid: category.uuid})
       Catalogue.trash_item(item)
 
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
       html = render_click(view, "switch_view", %{"mode" => "deleted"})
       assert html =~ "Comeback"
 
@@ -228,19 +271,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       assert Process.alive?(view.pid)
     end
 
-    test "delete_item with a bogus uuid doesn't crash and leaves existing items untouched", %{
-      conn: conn
-    } do
+    test "delete_item with a bogus uuid doesn't crash", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
       survivor = fixture_item(%{name: "Survivor", category_uuid: category.uuid})
 
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
 
       html =
         render_click(view, "delete_item", %{"uuid" => "00000000-0000-0000-0000-000000000000"})
 
-      # Page still renders; survivor is still listed.
       assert html =~ "Survivor"
       assert Catalogue.get_item(survivor.uuid).status == "active"
     end
@@ -250,55 +290,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
   # Category mutations
   # ─────────────────────────────────────────────────────────────────
 
-  describe "clickable names" do
-    test "category name is a link to the category edit page in active mode", %{conn: conn} do
-      catalogue = fixture_catalogue()
-      category = fixture_category(catalogue, %{name: "Clickable category"})
-
-      {:ok, _view, html} = live(conn, url(catalogue.uuid))
-
-      expected_href = "/en/admin/catalogue/categories/#{category.uuid}/edit"
-      assert html =~ ~s(href="#{expected_href}")
-      assert html =~ "Clickable category"
-    end
-
-    test "category name renders without an edit link in the Categories tab Deleted view",
-         %{conn: conn} do
-      # Items tab no longer renders trashed categories at all (the
-      # "separate status" rule). The Categories tab Deleted view shows
-      # the category as a plain row with no edit link — restore /
-      # delete-forever buttons replace the per-card actions.
-      catalogue = fixture_catalogue()
-      category = fixture_category(catalogue, %{name: "Deleted category"})
-      Catalogue.trash_category(category)
-
-      {:ok, view, _html} = live(conn, url(catalogue.uuid) <> "?tab=categories")
-      html = render_click(view, "switch_view", %{"mode" => "deleted"})
-
-      assert html =~ "Deleted category"
-      # No edit link to the deleted category — only Restore + Delete Forever.
-      refute html =~ "/en/admin/catalogue/categories/#{category.uuid}/edit"
-    end
-
-    test "item name in the card body is a link to the item edit page", %{conn: conn} do
-      catalogue = fixture_catalogue()
-      category = fixture_category(catalogue)
-      item = fixture_item(%{name: "Clickable item", category_uuid: category.uuid})
-
-      {:ok, _view, html} = live(conn, url(catalogue.uuid))
-
-      expected_href = "/en/admin/catalogue/items/#{item.uuid}/edit"
-      assert html =~ ~s(href="#{expected_href}")
-      assert html =~ "Clickable item"
-    end
-  end
-
   describe "category mutations" do
-    test "request_trash_category removes the category card when the subtree is empty",
-         %{conn: conn} do
-      # `request_trash_category` (the renamed event) trashes directly
-      # when the subtree has no active items. With items it would
-      # open the disposition modal first; here both fixtures are empty.
+    test "request_trash_category removes an empty category card from the root", %{conn: conn} do
       catalogue = fixture_catalogue()
       cat_a = fixture_category(catalogue, %{name: "Trashable", position: 0})
       _cat_b = fixture_category(catalogue, %{name: "Staying", position: 1})
@@ -311,9 +304,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       assert html_after =~ "Staying"
     end
 
-    test "restore_category in deleted mode brings it back and auto-flips to active", %{
-      conn: conn
-    } do
+    test "restore_category brings a trashed category back", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue, %{name: "Brought Back"})
       Catalogue.trash_category(category)
@@ -322,68 +313,241 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       _deleted_html = render_click(view, "switch_view", %{"mode" => "deleted"})
 
       html_after = render_click(view, "restore_category", %{"uuid" => category.uuid})
-      # Either the category is now shown in the page (if we're still on
-      # deleted mode and there are other deleted things) or the view
-      # auto-flipped back to active. Either way it must now be visible.
       assert html_after =~ "Brought Back"
     end
 
-    # `move_category_up` / `move_category_down` events were removed
-    # when category reorder switched to drag-only via the SortableGrid
-    # hook. The new wire is the `reorder_categories` event the hook
-    # pushes; LV-test coverage of drag would need to drive SortableJS
-    # from a browser, out of scope for this fixture-driven stack.
+    test "a child restored under a still-trashed parent stays reachable at the root",
+         %{conn: conn} do
+      # restore_category/2 is non-cascading: restoring the child leaves the
+      # parent trashed. list_child_categories/3 orphan-promotes the child to
+      # the root so the drill-down can still reach it.
+      catalogue = fixture_catalogue()
+      parent = fixture_category(catalogue, %{name: "TrashedParent"})
+      child = fixture_category(catalogue, %{name: "OrphanChild", parent_uuid: parent.uuid})
+
+      # Trashing the parent cascades the subtree (parent + child → deleted).
+      Catalogue.trash_category(parent, items: :cascade)
+      # Restore only the child.
+      {:ok, _} = Catalogue.restore_category(Catalogue.get_category(child.uuid))
+
+      {:ok, _view, html} = live(conn, url(catalogue.uuid))
+
+      assert html =~ "OrphanChild"
+      assert html =~ "?category=#{child.uuid}"
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────
-  # Search
+  # Active item list: core List-UI toolkit (sort + reorder + bulk)
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "active item list — sort dropdown" do
+    test "sort_items changes the rendered order", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      fixture_item(%{name: "Cherry", position: 0, category_uuid: category.uuid})
+      fixture_item(%{name: "Apple", position: 1, category_uuid: category.uuid})
+
+      {:ok, view, html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+      # Manual (position) order: Cherry before Apple.
+      assert position_of(html, "Cherry") < position_of(html, "Apple")
+
+      html_after = render_change(view, "sort_items", %{"sort_by" => "name"})
+      # Name-asc order: Apple before Cherry.
+      assert position_of(html_after, "Apple") < position_of(html_after, "Cherry")
+    end
+
+    test "sort_items ignores an unknown field", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      fixture_item(%{name: "Solo", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+      html = render_change(view, "sort_items", %{"sort_by" => "evil; DROP"})
+
+      assert html =~ "Solo"
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  describe "active item list — strategy reorder modal" do
+    test "open → apply renumbers items by strategy", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      fixture_item(%{name: "Cherry", category_uuid: category.uuid})
+      fixture_item(%{name: "Apple", category_uuid: category.uuid})
+      fixture_item(%{name: "Banana", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
+      # Open the modal with no selection captured → "reorder all".
+      render_hook(view, "open_items_reorder_modal", %{"uuids" => []})
+      render_hook(view, "apply_items_reorder", %{"strategy" => "name_asc"})
+
+      positions =
+        category.uuid
+        |> Catalogue.list_items_for_category_paged(sort_by: :position, sort_dir: :asc)
+        |> Enum.map(&{&1.name, &1.position})
+
+      assert positions == [{"Apple", 1}, {"Banana", 2}, {"Cherry", 3}]
+    end
+
+    test "apply with a selected subset sharing positions flashes a normalise hint", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      a = fixture_item(%{name: "A", category_uuid: category.uuid})
+      b = fixture_item(%{name: "B", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
+      render_hook(view, "open_items_reorder_modal", %{"uuids" => [a.uuid, b.uuid]})
+      html = render_hook(view, "apply_items_reorder", %{"strategy" => "name_asc"})
+
+      assert html =~ "Reorder all"
+      # Positions untouched (both still 0).
+      assert Catalogue.get_item(a.uuid).position == 0
+      assert Catalogue.get_item(b.uuid).position == 0
+    end
+
+    test "apply with an unknown strategy asks for one", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      fixture_item(%{name: "X", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+      html = render_hook(view, "apply_items_reorder", %{"strategy" => "bogus"})
+
+      assert html =~ "Pick a strategy"
+    end
+  end
+
+  describe "active item list — DnD reorder (scope from socket)" do
+    test "reorder_items persists the dropped order using the current node scope", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      a = fixture_item(%{name: "A", position: 0, category_uuid: category.uuid})
+      b = fixture_item(%{name: "B", position: 1, category_uuid: category.uuid})
+      c = fixture_item(%{name: "C", position: 2, category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
+      # Drag C to the front. No catalogueUuid/categoryUuid in the payload —
+      # the handler must take scope from socket assigns.
+      render_hook(view, "reorder_items", %{
+        "ordered_ids" => [c.uuid, a.uuid, b.uuid],
+        "moved_id" => c.uuid
+      })
+
+      positions =
+        category.uuid
+        |> Catalogue.list_items_for_category_paged(sort_by: :position, sort_dir: :asc)
+        |> Enum.map(& &1.name)
+
+      assert positions == ["C", "A", "B"]
+    end
+  end
+
+  describe "active item list — bulk delete via captured uuids" do
+    test "request → confirm trashes the captured items", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      doomed = fixture_item(%{name: "Doomed", category_uuid: category.uuid})
+      survivor = fixture_item(%{name: "Survivor", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
+      # The toolbar pushes the client-captured uuids.
+      render_hook(view, "request_bulk_delete_items", %{"uuids" => [doomed.uuid]})
+      render_click(view, "confirm_bulk_action", %{})
+
+      assert Catalogue.get_item(doomed.uuid).status == "deleted"
+      assert Catalogue.get_item(survivor.uuid).status == "active"
+    end
+
+    test "bulk move via captured uuids uncategorizes the items", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+      item = fixture_item(%{name: "Mover", category_uuid: category.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+
+      render_hook(view, "request_bulk_move_items", %{"uuids" => [item.uuid]})
+      render_click(view, "confirm_bulk_move_items", %{})
+
+      assert Catalogue.get_item(item.uuid).category_uuid == nil
+    end
+  end
+
+  describe "active item list — load_more still pages" do
+    test "load_more appends the next page of items", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      category = fixture_category(catalogue)
+
+      for i <- 1..130 do
+        fixture_item(%{
+          name: "Item #{String.pad_leading("#{i}", 3, "0")}",
+          position: i,
+          category_uuid: category.uuid
+        })
+      end
+
+      {:ok, view, html} = live(conn, cat_url(catalogue.uuid, category.uuid))
+      # First page is 100 items.
+      assert html =~ "Item 100"
+      refute html =~ "Item 130"
+
+      html_after = render_hook(view, "load_more", %{})
+      assert html_after =~ "Item 130"
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Search (scoped per level)
   # ─────────────────────────────────────────────────────────────────
 
   describe "search" do
-    test "search shows matching items and hides the infinite-scroll cards", %{conn: conn} do
+    test "root search spans the whole catalogue", %{conn: conn} do
       catalogue = fixture_catalogue()
-      category = fixture_category(catalogue, %{name: "Hidden while searching"})
+      category = fixture_category(catalogue, %{name: "Some category"})
       fixture_item(%{name: "Oak panel", category_uuid: category.uuid})
       fixture_item(%{name: "Pine board", category_uuid: category.uuid})
 
       {:ok, view, _html} = live(conn, url(catalogue.uuid))
 
       render_change(view, "search", %{"query" => "oak"})
-      # Search runs via start_async — wait for handle_async to land before asserting.
       html_after = render_async(view)
 
-      # Search results visible
       assert html_after =~ "Oak panel"
-      # Pine board excluded from results
       refute html_after =~ "Pine board"
     end
 
-    test "empty search query falls back to normal paged view", %{conn: conn} do
+    test "search inside a category is scoped to that category", %{conn: conn} do
+      catalogue = fixture_catalogue()
+      cat_a = fixture_category(catalogue, %{name: "Cat A"})
+      cat_b = fixture_category(catalogue, %{name: "Cat B"})
+      fixture_item(%{name: "Oak in A", category_uuid: cat_a.uuid})
+      fixture_item(%{name: "Oak in B", category_uuid: cat_b.uuid})
+
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, cat_a.uuid))
+
+      render_change(view, "search", %{"query" => "oak"})
+      html_after = render_async(view)
+
+      assert html_after =~ "Oak in A"
+      refute html_after =~ "Oak in B"
+    end
+
+    test "clear_search restores the level view", %{conn: conn} do
       catalogue = fixture_catalogue()
       category = fixture_category(catalogue)
       fixture_item(%{name: "Only item", category_uuid: category.uuid})
 
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
-
-      render_change(view, "search", %{"query" => "anything"})
-      _after_search = render_async(view)
-      html_after = render_change(view, "search", %{"query" => ""})
-
-      # Back to the normal view
-      assert html_after =~ "Only item"
-    end
-
-    test "clear_search restores the paged view", %{conn: conn} do
-      catalogue = fixture_catalogue()
-      category = fixture_category(catalogue)
-      fixture_item(%{name: "Item", category_uuid: category.uuid})
-
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
       render_change(view, "search", %{"query" => "nothing matches"})
       _ = render_async(view)
       html_after = render_click(view, "clear_search", %{})
 
-      assert html_after =~ "Item"
+      assert html_after =~ "Only item"
     end
 
     test "shows a loading indicator for the first search before results land", %{conn: conn} do
@@ -391,39 +555,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLiveTest do
       category = fixture_category(catalogue)
       fixture_item(%{name: "Oak panel", category_uuid: category.uuid})
 
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
+      {:ok, view, _html} = live(conn, cat_url(catalogue.uuid, category.uuid))
       html_pending = render_change(view, "search", %{"query" => "oak"})
 
-      # While the async task is still running, the user sees a "Searching"
-      # indicator — not stale data or silence.
       assert html_pending =~ "Searching for"
       assert html_pending =~ "loading-spinner"
 
       html_after = render_async(view)
 
-      # Once the async lands, the spinner is gone and results are visible.
       refute html_after =~ "Searching for"
       assert html_after =~ "Oak panel"
-    end
-
-    test "dims previous results while a newer query is loading", %{conn: conn} do
-      catalogue = fixture_catalogue()
-      category = fixture_category(catalogue)
-      fixture_item(%{name: "Oak panel", category_uuid: category.uuid})
-      fixture_item(%{name: "Pine board", category_uuid: category.uuid})
-
-      {:ok, view, _html} = live(conn, url(catalogue.uuid))
-
-      # First search settles.
-      render_change(view, "search", %{"query" => "oak"})
-      _ = render_async(view)
-
-      # Second search fires — while pending, prior "oak" results are dimmed.
-      html_pending = render_change(view, "search", %{"query" => "pine"})
-
-      assert html_pending =~ "opacity-50"
-      # Spinner visible next to the summary
-      assert html_pending =~ "loading-spinner"
     end
   end
 end

--- a/test/web/components_test.exs
+++ b/test/web/components_test.exs
@@ -48,17 +48,6 @@ defmodule PhoenixKitCatalogue.Web.ComponentsTest do
   end
 
   # ─────────────────────────────────────────────────────────────────
-  # empty_state
-  # ─────────────────────────────────────────────────────────────────
-
-  describe "empty_state/1" do
-    test "renders a message" do
-      html = render_component(&empty_state/1, message: "Nothing here")
-      assert html =~ "Nothing here"
-    end
-  end
-
-  # ─────────────────────────────────────────────────────────────────
   # search_input
   # ─────────────────────────────────────────────────────────────────
 

--- a/test/web/pdf_library_live_test.exs
+++ b/test/web/pdf_library_live_test.exs
@@ -14,6 +14,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLiveTest do
   alias Ecto.Adapters.SQL
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Schemas.{Pdf, PdfExtraction}
+  alias PhoenixKitCatalogue.Test.Repo
 
   @lib_path "/en/admin/catalogue/pdfs"
   @detail_path "/en/admin/catalogue/pdfs"
@@ -99,7 +100,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLiveTest do
       assert html =~ "PDF library"
       assert html =~ "kitchen.pdf"
       # Active filter shows upload zone
-      assert html =~ "Drop PDF files here or click to upload"
+      assert html =~ "Drag files here or click to browse"
       assert html =~ pdf.original_filename
     end
 
@@ -111,7 +112,7 @@ defmodule PhoenixKitCatalogue.Web.PdfLibraryLiveTest do
       html = view |> element("button", "Trash") |> render_click()
 
       assert html =~ trashed.original_filename
-      refute html =~ "Drop PDF files here or click to upload"
+      refute html =~ "Drag files here or click to browse"
     end
   end
 


### PR DESCRIPTION
> ⚠ **Depends on core PR BeamLabEU/phoenix_kit#570 (V123).** This branch needs the V123 migration (catalogue folders + dropping the global unique `cat_items.sku` index). Until a core release ships V123, the hex pin (`~> 1.7`) resolves to a core without `phoenix_kit_cat_folders`, so the integration suite can't build its schema and **CI will be red**. Do not merge before #570 lands and a V123 core release is published.

## Summary

Post-#25 work on the catalogue admin, plus a quality sweep that discovered the test suite had been silently uncompilable (so the feature work below had landed untested on a quietly-red `main`).

### Features
- **Catalogue folders** (`bffdd4f`) — inline nested folder tree-table on `/admin/catalogue` (Finder-style): disclosure chevrons, native drag-and-drop filing + an Actions "Move to folder", front-insertion so new folders surface at the top. Dedicated `phoenix_kit_cat_folders` table (core V123), unrelated to the media-folder system.
- **Detail drill-down rework** (`c4d3472`) — the catalogue detail page is now a category drill-down built on the core list-UI toolkit (sortable / bulk-select / load_more), replacing the old per-card expand mechanism.
- **Per-status item tabs** (`0213d3d`) — Active / Inactive / Discontinued / Deleted tabs on the detail page (empty Inactive hidden); discontinued items are no longer mixed into Active.
- **Full-width layout** (`8fef117`) — catalogue admin pages use the full-width container; the three redundant top tabs are replaced by a sidebar-driven header. Events truncation + PDF viewer route also fixed.

### Quality sweep
- **Folder PubSub + UX** (`fcfd485`) — folder mutations now fan out a `:folder` event so the tree refreshes across sessions (closing the "logged but not broadcast" gap); status-tab auto-flip restored (4-tab aware); `phx-disable-with` on folder actions; `move_*` credo cleanup.
- **Test-suite repair** (`edfe68c`, `7d3c7fd`) — the suite had been uncompilable since the PDF sweep (a `with_scope/2` helper that never existed). Added the missing LiveView scope test-infra + PDF routes, fixed the compile blockers and pre-rework test debt, and added folder activity-log / PubSub / status-count coverage.
- **De-brittled** the smart-pricing float-qty test (`f657555`) — assert behavior, not version-dependent `Decimal` internals.

### Housekeeping
`3e696e8` use core `<.empty_state>`; `d6e3bb4` migrate to `PhoenixKit.Utils.Values.blank_to_nil`; `2b8cd02` FOLLOW_UP.md for #25.

## Verification

- `phoenix_kit_catalogue` suite **green — 1089 tests, 0 failures** — against local core `dev` (V123) via a temporary `{:phoenix_kit, path: "../phoenix_kit", override: true}` (reverted before commit).
- `mix format` / `mix credo --strict` / `mix dialyzer` all clean.

## Test plan

- [x] Full suite green against local core `dev` (V123), incl. folders, per-status tabs, duplicate-SKU now accepted
- [x] `format` / `credo --strict` / `dialyzer` clean
- [ ] CI green — **blocked on core #570 + a V123 release** (the `~> 1.7` pin lacks V123)
- [ ] Browser smoke of folders tree / status tabs / full-width (pending core release)
