### PR TITLE
feat(item_picker): opt-in show_unit, format_unit, initial_query; opt-out highlight_selected

### DIFF
--- a/lib/phoenix_kit_catalogue/web/components.ex
+++ b/lib/phoenix_kit_catalogue/web/components.ex
@@ -1774,6 +1774,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
   attr(:page_size, :integer, default: 20)
   attr(:disabled, :boolean, default: false)
   attr(:format_price, :any, default: nil)
+  attr(:format_unit, :any, default: nil)
+  attr(:show_unit, :boolean, default: false)
+  attr(:highlight_selected, :boolean, default: true)
+  attr(:initial_query, :string, default: nil)
 
   def item_picker(assigns) do
     ~H"""
@@ -1792,6 +1796,10 @@ defmodule PhoenixKitCatalogue.Web.Components do
       page_size={@page_size}
       disabled={@disabled}
       format_price={@format_price}
+      format_unit={@format_unit}
+      show_unit={@show_unit}
+      highlight_selected={@highlight_selected}
+      initial_query={@initial_query}
     />
     """
   end

--- a/lib/phoenix_kit_catalogue/web/components/item_picker.ex
+++ b/lib/phoenix_kit_catalogue/web/components/item_picker.ex
@@ -58,6 +58,24 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
       returning a display string or `nil`. Defaults to a Decimal
       stringifier of `item_pricing(item).final_price`. Return `nil` to
       omit the price column entirely.
+    * `:show_unit` — when `true`, renders the item's measurement unit
+      (via `:format_unit`) as a small muted label next to the price in
+      each dropdown row. Defaults to `false` (no unit) so existing
+      consumers are unaffected.
+    * `:format_unit` — 1-arity function taking the item's unit string and
+      returning a display label (`""` to omit). Only used when
+      `:show_unit` is `true`. Defaults to a built-in mapping of common
+      abbreviations (`piece`→`pc`, `set`→`set`, `pair`→`pair`,
+      `sheet`→`sheet`, `m2`→`m²`, `running_meter`→`rm`; unknown strings
+      pass through). Supply your own to use a different unit vocabulary.
+    * `:highlight_selected` — when `true` (default), the input gets the
+      `input-primary` border while an item is selected. Pass `false` to
+      suppress that highlight. Default preserves existing behaviour.
+    * `:initial_query` — optional seed string for the search input. When
+      provided (and nothing is selected and the user hasn't typed), the
+      input is prefilled with this string and the dropdown opens with
+      matching results on first render. Fires once; subsequent updates
+      leave the query alone. Defaults to `nil` (no seeding).
 
   ### Keyboard / a11y
 
@@ -107,6 +125,11 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
        page_size: @default_page_size,
        disabled: false,
        format_price: nil,
+       format_unit: nil,
+       show_unit: false,
+       highlight_selected: true,
+       initial_query: nil,
+       seeded_initial_query: false,
        locale: "en"
      )}
   end
@@ -131,6 +154,30 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
       else
         locale = socket.assigns.locale
         assign(socket, :query, item_display_name(assigns[:selected_item], locale) || "")
+      end
+
+    # Opt-in: seed the input with an arbitrary search string the first time
+    # `initial_query` is provided, and run the search so results appear
+    # immediately. Only fires once (guarded by `:seeded_initial_query`) and
+    # only when nothing is selected and the user hasn't typed yet, so it never
+    # clobbers a real selection or mid-typing query.
+    initial_query = socket.assigns.initial_query
+
+    socket =
+      cond do
+        socket.assigns.seeded_initial_query ->
+          socket
+
+        is_binary(initial_query) and initial_query != "" and is_nil(incoming_uuid) and
+            String.trim(socket.assigns.query || "") == "" ->
+          socket
+          |> assign(:query, initial_query)
+          |> assign(:seeded_initial_query, true)
+          |> assign(:open, true)
+          |> run_search()
+
+        true ->
+          socket
       end
 
     {:ok, socket}
@@ -297,6 +344,24 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
     fun.(item)
   end
 
+  # Default measurement-unit label used when no `:format_unit` function is
+  # supplied. Common abbreviations (piece→pc, set→set, pair→pair, sheet→sheet,
+  # m2→m², running_meter→rm); `nil`/unknown collapses to "" so the column is
+  # omitted. Consumers with a different unit vocabulary pass their own
+  # `:format_unit` 1-arity function instead.
+  defp default_unit_label(nil), do: ""
+  defp default_unit_label("piece"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "pc")
+  defp default_unit_label("set"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "set")
+  defp default_unit_label("pair"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "pair")
+  defp default_unit_label("sheet"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "sheet")
+  defp default_unit_label("m2"), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "m²")
+
+  defp default_unit_label("running_meter"),
+    do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "rm")
+
+  defp default_unit_label(other) when is_binary(other), do: other
+  defp default_unit_label(_), do: ""
+
   defp default_format_price(%Item{} = item) do
     pricing = Catalogue.item_pricing(item)
 
@@ -324,6 +389,10 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
         :price_fun,
         assigns[:format_price] || (&default_format_price/1)
       )
+      |> assign(
+        :unit_fun,
+        assigns[:format_unit] || (&default_unit_label/1)
+      )
 
     ~H"""
     <div
@@ -349,7 +418,7 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
         phx-focus="open"
         class={[
           "input input-sm w-full pr-8",
-          @selected_item && "input-primary"
+          @highlight_selected and (@selected_item && "input-primary")
         ]}
       />
 
@@ -387,6 +456,8 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
           phx-value-uuid={item.uuid}
           phx-target={@myself}
         >
+          <% price = format_price_display(item, @price_fun) %>
+          <% unit = if @show_unit, do: @unit_fun.(item.unit), else: "" %>
           <div class="min-w-0 flex-1">
             <div class="font-medium text-sm truncate">
               {item_display_name(item, @locale)}
@@ -398,11 +469,13 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPicker do
               {item_breadcrumb(item, @locale)}
             </div>
           </div>
-          <div
-            :if={(price = format_price_display(item, @price_fun)) && price != ""}
-            class="text-sm font-medium ml-4 shrink-0"
-          >
-            {price}
+          <div :if={(price && price != "") or unit != ""} class="text-right ml-4 shrink-0">
+            <div :if={price && price != ""} class="text-sm font-medium">
+              {price}
+            </div>
+            <div :if={unit != ""} class="text-xs text-base-content/50">
+              {unit}
+            </div>
           </div>
         </li>
         <li

--- a/test/web/item_picker_test.exs
+++ b/test/web/item_picker_test.exs
@@ -26,10 +26,11 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPickerTest do
     }
   end
 
-  defp fake_item(uuid, name) do
+  defp fake_item(uuid, name, unit \\ "piece") do
     %Item{
       uuid: uuid,
       name: name,
+      unit: unit,
       base_price: Decimal.new("100.00"),
       markup_percentage: nil,
       discount_percentage: nil,
@@ -214,6 +215,68 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPickerTest do
     end
   end
 
+  describe "show_unit (opt-in unit column)" do
+    test "show_unit=true renders the mapped unit label in the row" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            show_unit: true,
+            options: [fake_item("item-1", "Oak Plank", "running_meter")],
+            has_more: false
+          })
+        )
+
+      assert html =~ "rm"
+    end
+
+    test "show_unit=true maps m2 to m²" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            show_unit: true,
+            options: [fake_item("item-1", "Glass Pane", "m2")],
+            has_more: false
+          })
+        )
+
+      assert html =~ "m²"
+    end
+
+    test "show_unit defaults to false and hides the unit (backward compatible)" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            options: [fake_item("item-1", "Oak Plank", "running_meter")],
+            has_more: false
+          })
+        )
+
+      refute html =~ ">rm<"
+    end
+
+    test "show_unit=true with nil unit omits the unit label" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            show_unit: true,
+            options: [fake_item("item-1", "Oak Plank", nil)],
+            has_more: false
+          })
+        )
+
+      # No unit row text leaks in; name still renders
+      assert html =~ "Oak Plank"
+    end
+  end
+
   describe "selected_item styling" do
     test "selected_item non-nil adds input-primary class" do
       item = fake_item("item-1", "Oak Plank")
@@ -234,6 +297,66 @@ defmodule PhoenixKitCatalogue.Web.Components.ItemPickerTest do
 
       refute html =~ "input-primary"
       refute html =~ ~s(phx-click="clear")
+    end
+
+    test "highlight_selected=false suppresses the primary border even when selected" do
+      item = fake_item("item-1", "Oak Plank")
+
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{selected_item: item, highlight_selected: false})
+        )
+
+      refute html =~ "input-primary"
+      # The selection itself is unaffected — the clear button still renders.
+      assert html =~ ~s(phx-click="clear")
+    end
+  end
+
+  describe "format_unit (custom unit labels)" do
+    test "format_unit overrides the default unit label" do
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{
+            open: true,
+            show_unit: true,
+            format_unit: fn "running_meter" -> "lm" end,
+            options: [fake_item("item-1", "Beam", "running_meter")],
+            has_more: false
+          })
+        )
+
+      assert html =~ "lm"
+      refute html =~ ">rm<"
+    end
+  end
+
+  # initial_query SEEDING here only covers the DB-free guard branches (the
+  # positive "search runs and prefills" path needs the catalogue Repo and lives
+  # in the integration suite). update/2 must never clobber a real selection or a
+  # blank input.
+  describe "initial_query seeding (guards)" do
+    test "does not clobber the input when an item is already selected" do
+      item = fake_item("item-1", "Oak Plank")
+
+      html =
+        render_component(
+          ItemPicker,
+          base_assigns(%{selected_item: item, initial_query: "ignored seed"})
+        )
+
+      # The selected item's name wins; the seed string is ignored.
+      assert html =~ "Oak Plank"
+      refute html =~ "ignored seed"
+    end
+
+    test "a blank seed leaves the input empty and the dropdown closed" do
+      html = render_component(ItemPicker, base_assigns(%{initial_query: ""}))
+
+      assert html =~ ~s(value="")
+      assert html =~ ~s(aria-expanded="false")
     end
   end
 end


### PR DESCRIPTION
## What

Adds four **backward-compatible** options to the `ItemPicker` combobox (and its `item_picker/1` wrapper). All defaults preserve current behaviour, so existing consumers are unaffected.

| Option | Default | Effect |
|---|---|---|
| `show_unit` | `false` | Render the item's measurement unit beside the price in each dropdown row. |
| `format_unit` | `nil` | 1-arity `unit -> label` function (mirrors the existing `format_price`). The built-in default maps common abbreviations (`piece`→`pc`, `m2`→`m²`, `running_meter`→`rm`, …); unknown strings pass through. Supply your own for a different unit vocabulary. |
| `highlight_selected` | `true` | Keep/suppress the `input-primary` border while an item is selected. Pass `false` to opt out. |
| `initial_query` | `nil` | Seed the search input and open matching results on first render. Fires once; never clobbers a real selection or a mid-typing query. |

## Why

A consuming app needed (a) the unit shown in dropdown rows, (b) the input pre-filled with a seed string (e.g. an imported line name) and searched on open, and (c) the ability to drop the primary-color highlight on always-rendered pickers. These are generally useful, so contributing upstream instead of forking the component.

## Backward compatibility

- `show_unit`, `format_unit`, `initial_query` are opt-in (off by default).
- `highlight_selected` defaults to `true`, preserving the existing selected-item highlight.
- The price/unit wrapper `<div>` is now guarded with `:if`, so no empty element is rendered for consumers not using `show_unit`.
- The wrapper `item_picker/1` forwards all four new attrs.

## Tests

Added render-shape tests (no DB): `highlight_selected={false}` suppression, `format_unit` override, and the `initial_query` guard branches (suppressed when an item is selected; blank seed is a no-op). The positive seeding path (which runs a DB search) is exercised by the consuming app's integration suite.
