### PR TITLE
Use AITranslate.Embed macro in catalogue/category/item form LiveViews

### DIFF
--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -2,6 +2,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
   @moduledoc "Create/edit form for catalogues with multilang support."
 
   use Phoenix.LiveView
+  use PhoenixKitWeb.Components.AITranslate.Embed
 
   require Logger
 
@@ -19,14 +20,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     only: [
       actor_opts: 1,
       assign_ai_translation: 3,
-      ai_translate_config: 1,
-      toggle_ai_modal: 1,
-      select_ai_endpoint: 2,
-      select_ai_prompt: 2,
-      select_ai_scope: 2,
-      generate_ai_prompt: 1,
-      dispatch_ai_translate: 2,
-      handle_ai_translation_event: 4
+      ai_translate_config: 1
     ]
 
   import PhoenixKitWeb.Components.AITranslate,
@@ -112,25 +106,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     |> assign(:form, to_form(changeset))
   end
 
+  # AI-translate modal events handled by `use ...AITranslate.Embed`.
   @impl true
-  def handle_event("ai_toggle_modal", _params, socket),
-    do: {:noreply, toggle_ai_modal(socket)}
-
-  def handle_event("ai_select_endpoint", %{"endpoint_uuid" => uuid}, socket),
-    do: {:noreply, select_ai_endpoint(socket, uuid)}
-
-  def handle_event("ai_select_prompt", %{"prompt_uuid" => uuid}, socket),
-    do: {:noreply, select_ai_prompt(socket, uuid)}
-
-  def handle_event("ai_select_scope", %{"scope" => scope}, socket),
-    do: {:noreply, select_ai_scope(socket, scope)}
-
-  def handle_event("ai_generate_prompt", _params, socket),
-    do: {:noreply, generate_ai_prompt(socket)}
-
-  def handle_event("ai_translate_lang", %{"lang" => lang}, socket),
-    do: {:noreply, dispatch_ai_translate(socket, lang)}
-
   def handle_event("switch_language", %{"lang" => lang_code}, socket) do
     {:noreply, handle_switch_language(socket, lang_code)}
   end
@@ -258,11 +235,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     {:noreply, assign(socket, :confirm_delete, false)}
   end
 
+  # {:ai_translation, ...} events folded into the form by `use ...AITranslate.Embed`.
   @impl true
-  def handle_info({:ai_translation, event, payload}, socket) do
-    {:noreply, handle_ai_translation_event(socket, event, payload, &assign_changeset/2)}
-  end
-
   def handle_info({:media_selected, file_uuids}, socket),
     do: Attachments.handle_media_selected(socket, file_uuids)
 

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -2,6 +2,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   @moduledoc "Create/edit form for categories within a catalogue."
 
   use Phoenix.LiveView
+  use PhoenixKitWeb.Components.AITranslate.Embed
 
   require Logger
 
@@ -17,14 +18,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
     only: [
       actor_opts: 1,
       assign_ai_translation: 3,
-      ai_translate_config: 1,
-      toggle_ai_modal: 1,
-      select_ai_endpoint: 2,
-      select_ai_prompt: 2,
-      select_ai_scope: 2,
-      generate_ai_prompt: 1,
-      dispatch_ai_translate: 2,
-      handle_ai_translation_event: 4
+      ai_translate_config: 1
     ]
 
   import PhoenixKitWeb.Components.AITranslate,
@@ -146,25 +140,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
     |> assign(:form, to_form(changeset))
   end
 
+  # AI-translate modal events handled by `use ...AITranslate.Embed`.
   @impl true
-  def handle_event("ai_toggle_modal", _params, socket),
-    do: {:noreply, toggle_ai_modal(socket)}
-
-  def handle_event("ai_select_endpoint", %{"endpoint_uuid" => uuid}, socket),
-    do: {:noreply, select_ai_endpoint(socket, uuid)}
-
-  def handle_event("ai_select_prompt", %{"prompt_uuid" => uuid}, socket),
-    do: {:noreply, select_ai_prompt(socket, uuid)}
-
-  def handle_event("ai_select_scope", %{"scope" => scope}, socket),
-    do: {:noreply, select_ai_scope(socket, scope)}
-
-  def handle_event("ai_generate_prompt", _params, socket),
-    do: {:noreply, generate_ai_prompt(socket)}
-
-  def handle_event("ai_translate_lang", %{"lang" => lang}, socket),
-    do: {:noreply, dispatch_ai_translate(socket, lang)}
-
   def handle_event("switch_language", %{"lang" => lang_code}, socket) do
     {:noreply, handle_switch_language(socket, lang_code)}
   end
@@ -332,11 +309,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
     {:noreply, assign(socket, :confirm_delete_all, false)}
   end
 
+  # {:ai_translation, ...} events folded into the form by `use ...AITranslate.Embed`.
   @impl true
-  def handle_info({:ai_translation, event, payload}, socket) do
-    {:noreply, handle_ai_translation_event(socket, event, payload, &assign_changeset/2)}
-  end
-
   def handle_info({:media_selected, file_uuids}, socket),
     do: Attachments.handle_media_selected(socket, file_uuids)
 

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -2,6 +2,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   @moduledoc "Create/edit form for catalogue items with multilang support."
 
   use Phoenix.LiveView
+  use PhoenixKitWeb.Components.AITranslate.Embed
 
   require Logger
 
@@ -18,14 +19,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     only: [
       actor_opts: 1,
       assign_ai_translation: 3,
-      ai_translate_config: 1,
-      toggle_ai_modal: 1,
-      select_ai_endpoint: 2,
-      select_ai_prompt: 2,
-      select_ai_scope: 2,
-      generate_ai_prompt: 1,
-      dispatch_ai_translate: 2,
-      handle_ai_translation_event: 4
+      ai_translate_config: 1
     ]
 
   import PhoenixKitWeb.Components.AITranslate,
@@ -308,23 +302,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     {:noreply, handle_switch_language(socket, lang_code)}
   end
 
-  def handle_event("ai_toggle_modal", _params, socket),
-    do: {:noreply, toggle_ai_modal(socket)}
-
-  def handle_event("ai_select_endpoint", %{"endpoint_uuid" => uuid}, socket),
-    do: {:noreply, select_ai_endpoint(socket, uuid)}
-
-  def handle_event("ai_select_prompt", %{"prompt_uuid" => uuid}, socket),
-    do: {:noreply, select_ai_prompt(socket, uuid)}
-
-  def handle_event("ai_select_scope", %{"scope" => scope}, socket),
-    do: {:noreply, select_ai_scope(socket, scope)}
-
-  def handle_event("ai_generate_prompt", _params, socket),
-    do: {:noreply, generate_ai_prompt(socket)}
-
-  def handle_event("ai_translate_lang", %{"lang" => lang}, socket),
-    do: {:noreply, dispatch_ai_translate(socket, lang)}
+  # AI-translate modal events handled by `use ...AITranslate.Embed`.
 
   def handle_event("switch_tab", %{"tab" => tab}, socket) do
     {:noreply, assign(socket, :current_tab, parse_tab(tab))}
@@ -515,11 +493,8 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
 
   # ── Attachments handle_info (delegated to Attachments module) ────
 
+  # {:ai_translation, ...} events folded into the form by `use ...AITranslate.Embed`.
   @impl true
-  def handle_info({:ai_translation, event, payload}, socket) do
-    {:noreply, handle_ai_translation_event(socket, event, payload, &assign_changeset/2)}
-  end
-
   def handle_info({:media_selected, file_uuids}, socket),
     do: Attachments.handle_media_selected(socket, file_uuids)
 


### PR DESCRIPTION
## ⚠️ Depends on core PR first

This commit `use`s `PhoenixKitWeb.Components.AITranslate.Embed`, a **new macro added in core** ([BeamLabEU/phoenix_kit#585](https://github.com/BeamLabEU/phoenix_kit/pull/585)). This branch will **not compile against the currently-published core** until:
1. core #585 is merged, **and**
2. a core Hex release containing the macro is cut, **and**
3. this repo's `phoenix_kit` pin is bumped to that release.

Do not merge before then.

## Summary

Replaces the 6 duplicated `ai_*` `handle_event` clauses + the `{:ai_translation}` `handle_info` across the catalogue, category, and item form LiveViews with `use PhoenixKitWeb.Components.AITranslate.Embed`. Trims `FormGlue` imports down to the helpers still used directly (`assign_ai_translation`, `ai_translate_config`, `actor_opts`); the `mount`-time `FormGlue.assign_ai_translation/4` call stays (resource is dynamic).

No version/CHANGELOG bump (release-cut handled separately).