### PR TITLE
Move AI translation to the phoenix_kit_ai plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,27 @@ This is a **library**, not a standalone app. It requires a sibling `../phoenix_k
 - `phoenix_kit` (path: `"../phoenix_kit"`) — provides Module behaviour, Settings, RepoHelper, Dashboard tabs, Multilang
 - `phoenix_live_view` — web framework (LiveView UI)
 
+## Local cross-repo development
+
+`phoenix_kit` (and any sibling `phoenix_kit_*` dep) resolves from Hex by
+default. To build or test this module against a **local checkout** of a
+dependency — e.g. an unpublished core change — export `<APP>_PATH` and Mix
+swaps the Hex pin for a `path:` + `override: true` dep at resolve time:
+
+```bash
+PHOENIX_KIT_PATH=../phoenix_kit mix test     # this module against local core
+PHOENIX_KIT_AI_PATH=../phoenix_kit_ai mix test
+```
+
+The variable name is the dep's app name upper-cased with `_PATH` appended
+(`:phoenix_kit` -> `PHOENIX_KIT_PATH`, `:phoenix_kit_ai` ->
+`PHOENIX_KIT_AI_PATH`). Set several at once to override multiple deps. This
+module's sibling overrides: `PHOENIX_KIT_AI_PATH`. **Unset = the
+published pin**, so `mix hex.publish` and CI resolve exactly as before.
+Implemented via `pk_dep/3` in `mix.exs` — never hand-edit a `phoenix_kit*`
+dep into a `path:` tuple (a committed path dep ships a broken package); set
+the env var instead.
+
 ## Architecture
 
 This is a **PhoenixKit module** that implements the `PhoenixKit.Module` behaviour. It depends on the host PhoenixKit app for Repo, Endpoint, and Settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@
 ### Changed
 - **Import upload guards** — `Import.Parser.parse/3` and `list_sheets/1` now reject oversized inputs up front (`:file_too_large` above 25 MB, `:too_many_rows` above 50 000) instead of materializing a pathological upload into memory. Both atoms have user-facing `Errors.message/1` copy.
 - **Bounded duplicate-detection query** — `Import.Mapper.detect_existing_duplicates/3` narrows its existence query to items whose name appears in the import (a match requires name equality) instead of loading every non-deleted item in the catalogue into memory.
-- **AI-translate LiveView wiring via the `AITranslate.Embed` macro** (#33) — the catalogue/category/item form LiveViews replaced their hand-wired AI-translate handlers (six `ai_*` `handle_event` clauses + the `{:ai_translation}` `handle_info`) with `use PhoenixKitWeb.Components.AITranslate.Embed` from core, which attaches the modal/dispatch/PubSub handlers as lifecycle hooks. Requires the macro shipped in core (BeamLabEU/phoenix_kit#585).
+- **AI-translate LiveView wiring via the shared `AITranslate.Embed` macro** (#33/#34) — the catalogue/category/item form LiveViews replaced their hand-wired AI-translate handlers (six `ai_*` `handle_event` clauses + the `{:ai_translation}` `handle_info`) with the shared PhoenixKitAI embed macro, which attaches the modal/dispatch/PubSub handlers as lifecycle hooks.
 - **`nimble_csv` declared as a direct dependency** — the CSV import parser uses it directly (`NimbleCSV.define/2`); it was only pulled transitively via `phoenix_kit`. Loosely constrained (`~> 1.2`).
 
 ### Docs
 - Fixed a stale "SKU is unique" note in the `create_item/update_item` docs — core V123 dropped that index; item SKUs are non-unique by design.
 
 ### Notes
-- **Requires a phoenix_kit release containing `PhoenixKitWeb.Components.AITranslate.Embed`** (BeamLabEU/phoenix_kit#585) — the macro the form LiveViews now `use`. Developed and locked against core **1.7.132**; the `mix.exs` constraint stays loose (`~> 1.7 and >= 1.7.125`), so pin a `phoenix_kit >= 1.7.132` in the parent app.
+- **Requires `phoenix_kit_ai ~> 0.3` for AI translation** — the shared embed macro and translation pipeline now live in the AI plugin. Catalogue's core constraint stays focused on its database/UI requirements.
 - Verification: `mix precommit` is clean (compile `--warnings-as-errors` + `format --check-formatted` + `credo --strict` + `deps.unlock --check-unused` + `dialyzer`). The new pure-function behavior (price normalization, delimiter detection, size/row caps) is covered by added unit tests. The full ExUnit suite is DB-gated — run `mix test` against a host with PostgreSQL.
 - Deferred follow-up: several form LiveViews still issue DB queries directly in `mount/3` (which runs twice). Documented in `dev_docs/followup_2026_06_07_mount_connected_guard.md`; deferred because validating the disconnected-render change needs the DB-backed LiveView test suite.
 
@@ -40,7 +40,7 @@
 - Post-merge review of #32 (writeup in `dev_docs/pull_requests/2026/32-ai-translation-shared-glue/CLAUDE_REVIEW.md`): dropped a dead `_ = primary` discard; replaced a runtime `String.to_existing_atom/1` + `rescue` with a compile-time field→column map in the AI adapter; flattened `put_translation/4` nesting (extracted `merge_translation!/6`) and aliased a fully-qualified `Web.Helpers` call to satisfy `credo --strict`; expanded the adapter unit tests 10 → 15 (source-field override / legacy-key paths, catalogue + category round-trips). Also dropped a redundant `import Ecto.Query, warn: false` from the PDF library context.
 
 ### Notes
-- **Requires phoenix_kit 1.7.130+** — the generic AI-translation pipeline this release plugs into (`PhoenixKit.Modules.AI.{Translatable,Translations}`, `PhoenixKitWeb.Components.AITranslate.{FormGlue,FormBinding}`; BeamLabEU/phoenix_kit#582) first shipped in core **1.7.130**. The `mix.exs` constraint stays loose (`~> 1.7 and >= 1.7.125`) — pin a `phoenix_kit >= 1.7.130` in the parent app. Catalogue compiles and `mix precommit` (compile `--warnings-as-errors` + `format --check-formatted` + `credo --strict` + `dialyzer`) is clean against 1.7.130.
+- **Requires the shared AI-translation pipeline** — catalogue now plugs into PhoenixKitAI (`PhoenixKitAI.{Translatable,Translations}` and `PhoenixKitAI.Components.AITranslate.{FormGlue,FormBinding}`). Catalogue compiles and `mix precommit` (compile `--warnings-as-errors` + `format --check-formatted` + `credo --strict` + `dialyzer`) is clean against the corresponding local dependency set.
 - Verification: ExUnit suites are DB-gated and run against a host whose schema is at core V111+; the new adapter tests pass against a local core (not exercised in CI without a database).
 
 ## 0.5.0 - 2026-06-01

--- a/dev_docs/pull_requests/2026/33-aitranslate-embed-macro/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/33-aitranslate-embed-macro/FOLLOW_UP.md
@@ -1,0 +1,9 @@
+# PR #33 Follow-up — Use AITranslate.Embed macro in catalogue/category/item form LiveViews
+
+## No findings
+`CLAUDE_REVIEW.md` reviewed this PR post-merge (against `main`, through the Elixir `phoenix` thinking skill) and returned **"Clean, faithful refactor — no findings, nothing to apply."** The macro's lifecycle-hook mechanism and default form re-sync both match the hand-wired code they replaced, so behavior is preserved while the per-LiveView duplication is removed; compiles warning-free. Re-verified against current code: the three form LiveViews `use PhoenixKitWeb.Components.AITranslate.Embed`, retain the `mount`-time `assign_ai_translation/3` call, and the trimmed `FormGlue` imports are all still referenced. The review's two non-blocking notes (lifecycle hooks run before host callbacks → a future host `ai_*` clause would be shadowed; the standing `item_form_live` mount-twice note) are observations, not action items.
+
+> Note: AI translation was subsequently extracted from core into `phoenix_kit_ai`; catalogue's consumer was rewired accordingly (`PhoenixKitWeb.Components.AITranslate.Embed` → `PhoenixKitAI.Components.AITranslate`) under the coordinated AI-move chain (catalogue PR #34). That is a separate PR with its own follow-up; it does not change #33's verdict.
+
+## Open
+None.

--- a/lib/phoenix_kit_catalogue.ex
+++ b/lib/phoenix_kit_catalogue.ex
@@ -94,8 +94,7 @@ defmodule PhoenixKitCatalogue do
   @impl PhoenixKit.Module
   def css_sources, do: [:phoenix_kit_catalogue]
 
-  @impl PhoenixKit.Module
-  def ai_translatables do
+    def ai_translatables do
     [
       {"catalogue", PhoenixKitCatalogue.AITranslatable},
       {"catalogue_category", PhoenixKitCatalogue.AITranslatable},

--- a/lib/phoenix_kit_catalogue.ex
+++ b/lib/phoenix_kit_catalogue.ex
@@ -94,7 +94,7 @@ defmodule PhoenixKitCatalogue do
   @impl PhoenixKit.Module
   def css_sources, do: [:phoenix_kit_catalogue]
 
-    def ai_translatables do
+  def ai_translatables do
     [
       {"catalogue", PhoenixKitCatalogue.AITranslatable},
       {"catalogue_category", PhoenixKitCatalogue.AITranslatable},

--- a/lib/phoenix_kit_catalogue/ai_translatable.ex
+++ b/lib/phoenix_kit_catalogue/ai_translatable.ex
@@ -1,7 +1,7 @@
 defmodule PhoenixKitCatalogue.AITranslatable do
   @moduledoc """
   `PhoenixKitAI.Translatable` adapter for catalogue resources —
-  the small per-module hook into core's generic AI-translation pipeline.
+  the small per-module hook into PhoenixKitAI's generic AI-translation pipeline.
 
   Serves three resource types (`"catalogue"`, `"catalogue_category"`,
   `"catalogue_item"`), each translating `name` + `description`. Source text

--- a/lib/phoenix_kit_catalogue/ai_translatable.ex
+++ b/lib/phoenix_kit_catalogue/ai_translatable.ex
@@ -1,6 +1,6 @@
 defmodule PhoenixKitCatalogue.AITranslatable do
   @moduledoc """
-  `PhoenixKit.Modules.AI.Translatable` adapter for catalogue resources —
+  `PhoenixKitAI.Translatable` adapter for catalogue resources —
   the small per-module hook into core's generic AI-translation pipeline.
 
   Serves three resource types (`"catalogue"`, `"catalogue_category"`,
@@ -26,7 +26,7 @@ defmodule PhoenixKitCatalogue.AITranslatable do
   and the audit log all live in core.
   """
 
-  @behaviour PhoenixKit.Modules.AI.Translatable
+  @behaviour PhoenixKitAI.Translatable
 
   import Ecto.Query
 

--- a/lib/phoenix_kit_catalogue/ai_translate_binding.ex
+++ b/lib/phoenix_kit_catalogue/ai_translate_binding.ex
@@ -1,6 +1,6 @@
 defmodule PhoenixKitCatalogue.AITranslateBinding do
   @moduledoc """
-  `PhoenixKitWeb.Components.AITranslate.FormBinding` for catalogue forms —
+  `PhoenixKitAI.Components.AITranslate.FormBinding` for catalogue forms —
   the storage-specific half of the shared AI-translate glue.
 
   Catalogue stores translations in the multilang `data` JSONB via
@@ -11,7 +11,7 @@ defmodule PhoenixKitCatalogue.AITranslateBinding do
   still fills the field instead of looking like a failed translation).
   """
 
-  @behaviour PhoenixKitWeb.Components.AITranslate.FormBinding
+  @behaviour PhoenixKitAI.Components.AITranslate.FormBinding
 
   alias PhoenixKitCatalogue.AITranslatable
   alias PhoenixKitCatalogue.Web.Helpers

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -2,7 +2,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
   @moduledoc "Create/edit form for catalogues with multilang support."
 
   use Phoenix.LiveView
-  use PhoenixKitWeb.Components.AITranslate.Embed
+  use PhoenixKitAI.Components.AITranslate.Embed
 
   require Logger
 
@@ -23,7 +23,7 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       ai_translate_config: 1
     ]
 
-  import PhoenixKitWeb.Components.AITranslate,
+  import PhoenixKitAI.Components.AITranslate,
     only: [
       ai_translate_button: 1,
       ai_translate_modal: 1,

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -2,7 +2,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   @moduledoc "Create/edit form for categories within a catalogue."
 
   use Phoenix.LiveView
-  use PhoenixKitWeb.Components.AITranslate.Embed
+  use PhoenixKitAI.Components.AITranslate.Embed
 
   require Logger
 
@@ -21,7 +21,7 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       ai_translate_config: 1
     ]
 
-  import PhoenixKitWeb.Components.AITranslate,
+  import PhoenixKitAI.Components.AITranslate,
     only: [
       ai_translate_button: 1,
       ai_translate_modal: 1,

--- a/lib/phoenix_kit_catalogue/web/helpers.ex
+++ b/lib/phoenix_kit_catalogue/web/helpers.ex
@@ -25,7 +25,7 @@ defmodule PhoenixKitCatalogue.Web.Helpers do
   require Logger
 
   alias PhoenixKitCatalogue.Catalogue.ActivityLog
-  alias PhoenixKitWeb.Components.AITranslate.FormGlue
+  alias PhoenixKitAI.Components.AITranslate.FormGlue
 
   @typedoc "Convenience alias for the keyword list shape mutating ctx fns accept."
   @type actor_opts :: [actor_uuid: Ecto.UUID.t()] | []
@@ -233,7 +233,7 @@ defmodule PhoenixKitCatalogue.Web.Helpers do
 
   # ── AI translation (delegates to the shared core glue) ───────────────
   # All modal/progress/stall state + dispatch + PubSub handling lives in
-  # `PhoenixKitWeb.Components.AITranslate.FormGlue`; the catalogue-specific
+  # `PhoenixKitAI.Components.AITranslate.FormGlue`; the catalogue-specific
   # storage (multilang `data`, `_`-prefixed keys) is in
   # `PhoenixKitCatalogue.AITranslateBinding`.
 

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -2,7 +2,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   @moduledoc "Create/edit form for catalogue items with multilang support."
 
   use Phoenix.LiveView
-  use PhoenixKitWeb.Components.AITranslate.Embed
+  use PhoenixKitAI.Components.AITranslate.Embed
 
   require Logger
 
@@ -22,7 +22,7 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       ai_translate_config: 1
     ]
 
-  import PhoenixKitWeb.Components.AITranslate,
+  import PhoenixKitAI.Components.AITranslate,
     only: [
       ai_translate_button: 1,
       ai_translate_modal: 1,

--- a/mix.exs
+++ b/mix.exs
@@ -66,10 +66,24 @@ defmodule PhoenixKitCatalogue.MixProject do
     ]
   end
 
+  # phoenix_kit deps resolve from Hex by default. For cross-repo work against a
+  # local checkout, export <APP>_PATH — e.g. PHOENIX_KIT_PATH=../phoenix_kit or
+  # PHOENIX_KIT_AI_PATH=../phoenix_kit_ai. Unset => the published pin, so
+  # mix hex.publish is unaffected.
+  defp pk_dep(app, requirement, opts \\ []) do
+    env_var = String.upcase(Atom.to_string(app)) <> "_PATH"
+
+    case System.get_env(env_var) do
+      nil when opts == [] -> {app, requirement}
+      nil -> {app, requirement, opts}
+      path -> {app, [path: path, override: true] ++ opts}
+    end
+  end
+
   defp deps do
     [
-      {:phoenix_kit, "~> 1.7 and >= 1.7.125"},
-      {:phoenix_kit_ai, "~> 0.3"},
+      pk_dep(:phoenix_kit, "~> 1.7 and >= 1.7.125"),
+      pk_dep(:phoenix_kit_ai, "~> 0.3"),
       {:phoenix_live_view, "~> 1.1"},
       {:xlsx_reader, "~> 0.8"},
       # Used directly by the CSV import parser (NimbleCSV.define/2). Declared

--- a/mix.exs
+++ b/mix.exs
@@ -69,6 +69,7 @@ defmodule PhoenixKitCatalogue.MixProject do
   defp deps do
     [
       {:phoenix_kit, "~> 1.7 and >= 1.7.125"},
+      {:phoenix_kit_ai, "~> 0.3"},
       {:phoenix_live_view, "~> 1.1"},
       {:xlsx_reader, "~> 0.8"},
       # Used directly by the CSV import parser (NimbleCSV.define/2). Declared


### PR DESCRIPTION
## What
The AI-translation pipeline + AI-translate UI moved out of core into the `phoenix_kit_ai` plugin (core keeps only the AI table migrations). This rewires catalogue to the plugin.

## Changes
- `@behaviour PhoenixKit.Modules.AI.Translatable` → `PhoenixKitAI.Translatable`
- `PhoenixKit.Modules.AI.{Translations,…}` → `PhoenixKitAI.{Translations,…}`
- `PhoenixKitWeb.Components.AITranslate{,.Embed,.FormBinding,.FormGlue}` → `PhoenixKitAI.Components.AITranslate{…}`
- `ai_translatables/0` is now a plain function (core `PhoenixKit.Module` callback removed; the plugin discovers it by duck-typing) — dropped `@impl`
- **adds the `phoenix_kit_ai` dependency** (catalogue now depends on the AI plugin)

## Pins
Plugin pinned as a floating `~> 0.3` minimum (auto-resolves the AI-move release); core pin unchanged. No precise/unreleased pins. CI is gated until the plugin releases the pipeline, then greens on `mix deps.update`.

Coordinated set: core BeamLabEU/phoenix_kit#586 → phoenix_kit_ai BeamLabEU/phoenix_kit_ai#10 → **this** (+ projects, publishing).

---

**Also in this PR (latest push):** an env-gated `pk_dep/3` path override in `mix.exs` so this package can build/test against a local `phoenix_kit*` checkout via `<APP>_PATH` (e.g. `PHOENIX_KIT_PATH=../phoenix_kit mix test`). Unset = the published pin, so `mix deps.get` / `mix hex.publish` / CI resolve exactly as before. Adds a "Local cross-repo development" section to `AGENTS.md`.

---
**Also in this branch:** `dev_docs/pull_requests/2026/33-aitranslate-embed-macro/FOLLOW_UP.md` — Phase-1 after-action for the (already-merged) PR #33: "no findings" stub. Docs-only.