### PR TITLE
Move catalogue admin headers into the global admin header bar

### DIFF
--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -17,7 +17,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   require Logger
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
   import PhoenixKitWeb.Components.Core.Pagination, only: [load_more: 1]
@@ -81,6 +80,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     "created_asc" => :created_asc,
     "reverse" => :reverse
   }
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(%{"uuid" => uuid}, _session, socket) do
@@ -1927,58 +1936,63 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col w-full px-4 py-6 gap-6">
-      <%!-- Loading state --%>
-      <div :if={is_nil(@catalogue)} class="flex justify-center py-12">
-        <span class="loading loading-spinner loading-lg"></span>
-      </div>
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      current_path={assigns[:url_path] || Paths.index()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col w-full px-4 py-6 gap-6">
+        <%!-- Loading state --%>
+        <div :if={is_nil(@catalogue)} class="flex justify-center py-12">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
 
-      <div :if={@catalogue} class="flex flex-col gap-6">
-        <%!-- Header --%>
-        <%!-- The title doubles as the breadcrumb trail: at root it's just
-             the catalogue name; drilled in it's `Catalogue › … › Current`
-             with the ancestors as muted patch links and the current node
-             as the bold end. `@breadcrumb` is trimmed to the active
-             ancestor chain in Active mode, so an orphan never links to a
-             deleted ancestor. --%>
-        <.admin_page_header>
-          <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content flex flex-wrap items-center gap-x-2 gap-y-1">
-            <%= if @current_category == nil do %>
-              {@catalogue.name}
-            <% else %>
-              <.link
-                patch={Paths.catalogue_detail(@catalogue.uuid)}
-                class="font-normal text-base-content/50 hover:text-primary"
-              >
-                {@catalogue.name}
-              </.link>
-              <%= for cat <- @breadcrumb do %>
-                <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+        <div :if={@catalogue} class="flex flex-col gap-6">
+          <%!-- In-body header: breadcrumb when drilled into a category
+               (catalogue name now lives in the global admin header); action
+               buttons whenever the view is active. --%>
+          <div
+            :if={@view_mode == "active" or @current_category != nil}
+            class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3"
+          >
+            <div :if={@current_category != nil} class="min-w-0">
+              <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content flex flex-wrap items-center gap-x-2 gap-y-1">
                 <.link
-                  patch={Paths.category_browse(@catalogue.uuid, cat.uuid)}
+                  patch={Paths.catalogue_detail(@catalogue.uuid)}
                   class="font-normal text-base-content/50 hover:text-primary"
                 >
-                  {cat.name}
+                  {@catalogue.name}
                 </.link>
-              <% end %>
-              <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
-              <span class="truncate">{current_node_label(@current_category)}</span>
-            <% end %>
-          </h1>
-          <:actions :if={@view_mode == "active"}>
-            <.link navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-outline btn-sm">
-              <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
-            </.link>
-            <.link navigate={Paths.item_new(@catalogue.uuid)} class="btn btn-primary btn-sm">
-              <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Item")}
-            </.link>
-            <.link navigate={Paths.catalogue_edit(@catalogue.uuid)} class="btn btn-ghost btn-sm">
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
-            </.link>
-          </:actions>
-        </.admin_page_header>
+                <%= for cat <- @breadcrumb do %>
+                  <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+                  <.link
+                    patch={Paths.category_browse(@catalogue.uuid, cat.uuid)}
+                    class="font-normal text-base-content/50 hover:text-primary"
+                  >
+                    {cat.name}
+                  </.link>
+                <% end %>
+                <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+                <span class="truncate">{current_node_label(@current_category)}</span>
+              </h1>
+            </div>
+            <div :if={@view_mode == "active"} class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
+              <.link navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-outline btn-sm">
+                <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
+              </.link>
+              <.link navigate={Paths.item_new(@catalogue.uuid)} class="btn btn-primary btn-sm">
+                <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Item")}
+              </.link>
+              <.link navigate={Paths.catalogue_edit(@catalogue.uuid)} class="btn btn-ghost btn-sm">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+              </.link>
+            </div>
+          </div>
 
-        <div :if={@catalogue.description} class="-mt-4">
+          <div :if={@catalogue.description} class="-mt-4">
           <p class="text-base-content/60">
             {@catalogue.description}
           </p>
@@ -2462,7 +2476,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         item={@pdf_search_item}
         show={@show_pdf_search}
       />
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -7,7 +7,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.MultilangForm
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
@@ -45,6 +44,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     "markup_percentage" => :markup_percentage,
     "discount_percentage" => :discount_percentage
   }
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -298,7 +307,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       )
 
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update catalogue details and settings.")}
+      current_path={assigns[:url_path] || Paths.index()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
       <%!-- Media selector — folder-scoped featured-image picker.
            Reconfigured per open; the Files tab below hosts the
            inline dropzone for everything else. --%>
@@ -312,9 +330,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
         scope_folder_id={@files_folder_uuid}
         phoenix_kit_current_user={assigns[:phoenix_kit_current_user]}
       />
-
-      <%!-- Header --%>
-      <.admin_page_header back={Paths.index()} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update catalogue details and settings.")} />
 
       <%!-- Tab strip — each panel stays in the DOM (toggled by `hidden`)
            so the multilang wrapper + any user input don't lose state
@@ -709,7 +724,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
         confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -17,8 +17,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   import PhoenixKitWeb.Components.Core.TableDefault
   import PhoenixKitWeb.Components.Core.TableRowMenu
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
-
   import PhoenixKitCatalogue.Web.Components
 
   import PhoenixKitCatalogue.Web.Helpers,
@@ -29,6 +27,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   alias PhoenixKitCatalogue.Paths
 
   @per_page 100
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(_params, _session, socket) do
@@ -105,6 +113,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturers")
 
   defp tab_title(:suppliers), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Suppliers")
+
+  defp tab_path(:index), do: Paths.index()
+  defp tab_path(:manufacturers), do: Paths.manufacturers()
+  defp tab_path(:suppliers), do: Paths.suppliers()
 
   # Graceful handler for a delete event that fires while `confirm_delete`
   # is nil (e.g. someone pushed the event without first opening the
@@ -918,11 +930,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col w-full px-4 py-6 gap-6">
-      <%!-- Navigation between Catalogues / Manufacturers / Suppliers lives in
-           the admin sidebar; the page just titles the current view. --%>
-      <.admin_page_header title={tab_title(@active_tab)}>
-        <:actions>
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={tab_title(@active_tab)}
+      current_path={assigns[:url_path] || tab_path(@active_tab)}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col w-full px-4 py-6 gap-6">
+        <div class="flex flex-wrap items-center justify-end gap-2 mb-2">
           <button
             :if={@active_tab == :index && @catalogue_view_mode == "active"}
             type="button"
@@ -942,10 +959,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <.link :if={@active_tab == :suppliers} navigate={Paths.supplier_new()} class="btn btn-primary btn-sm">
             {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Supplier")}
           </.link>
-        </:actions>
-      </.admin_page_header>
+        </div>
 
-      <%!-- Global search (only on catalogues tab). While a tree row is being
+        <%!-- Global search (only on catalogues tab). While a tree row is being
            dragged, the CatalogueTreeDnD hook swaps the search bar for the
            "move to root" drop target in-place, so the layout doesn't jump. --%>
       <div :if={@active_tab == :index} class="relative">
@@ -1119,10 +1135,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           </div>
         </form>
       </.modal>
-    </div>
+      </div>
 
-    <script>
-      window.PhoenixKitHooks = window.PhoenixKitHooks || {};
+      <script>
+        window.PhoenixKitHooks = window.PhoenixKitHooks || {};
       window.PhoenixKitHooks.InfiniteScroll = window.PhoenixKitHooks.InfiniteScroll || {
         mounted() {
           this.intersecting = false;
@@ -1296,7 +1312,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           this.clearAll();
         }
       };
-    </script>
+      </script>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -7,7 +7,6 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.MultilangForm
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
@@ -36,6 +35,16 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   alias PhoenixKitCatalogue.Schemas.Category
 
   @translatable_fields ["name", "description"]
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -371,7 +380,16 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       )
 
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new category to organize items within this catalogue."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update category details and ordering.")}
+      current_path={assigns[:url_path] || Paths.catalogue_detail(@catalogue_uuid)}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
       <%!-- Media selector — folder-scoped featured-image picker.
            No inline files grid on Category forms; featured image only. --%>
       <.live_component
@@ -384,9 +402,6 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         scope_folder_id={@files_folder_uuid}
         phoenix_kit_current_user={assigns[:phoenix_kit_current_user]}
       />
-
-      <%!-- Header --%>
-      <.admin_page_header back={Paths.catalogue_detail(@catalogue_uuid)} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new category to organize items within this catalogue."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update category details and ordering.")} />
 
       <%!-- Featured image — opens the scoped picker. Uuid stored on
            `category.data["featured_image_uuid"]`. The folder is lazily
@@ -597,7 +612,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/events_live.ex
+++ b/lib/phoenix_kit_catalogue/web/events_live.ex
@@ -19,6 +19,16 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
 
   @per_page 20
 
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -253,13 +263,20 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   @impl true
   def render(assigns) do
     ~H"""
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Events")}
+      page_subtitle={
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue") <>
+          " · " <>
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Events: %{count}", count: @total)
+      }
+      current_path={assigns[:url_path] || Paths.events()}
+      current_locale={assigns[:current_locale]}
+    >
     <div class="flex flex-col w-full px-4 py-6 gap-4">
-      <div class="flex items-center justify-between">
-        <div class="text-sm text-base-content/60">
-          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} events", count: @total)}
-        </div>
-      </div>
-
       <%!-- Filters --%>
       <div class="bg-base-200 rounded-lg p-3">
         <.form for={%{}} phx-change="filter" class="flex flex-wrap gap-3 items-end">
@@ -413,6 +430,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
         }
       };
     </script>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -7,7 +7,6 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.MultilangForm
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
@@ -52,6 +51,16 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     "category_uuid" => :category_uuid,
     "manufacturer_uuid" => :manufacturer_uuid
   }
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -683,25 +692,28 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       )
 
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
-      <%!-- Header --%>
-      <.admin_page_header
-        back={if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index()}
-        title={@page_title}
-        subtitle={
-          if @action == :new,
-            do:
-              Gettext.gettext(
-                PhoenixKitCatalogue.Gettext,
-                "Add a new product or material to the catalogue."
-              ),
-            else:
-              Gettext.gettext(
-                PhoenixKitCatalogue.Gettext,
-                "Update item details, pricing, and classification."
-              )
-        }
-      />
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={
+        if @action == :new,
+          do:
+            Gettext.gettext(
+              PhoenixKitCatalogue.Gettext,
+              "Add a new product or material to the catalogue."
+            ),
+          else:
+            Gettext.gettext(
+              PhoenixKitCatalogue.Gettext,
+              "Update item details, pricing, and classification."
+            )
+      }
+      current_path={assigns[:url_path] || (if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index())}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
 
       <%!-- PDF search button — visible on edit only. Opens a modal that
            searches the PDF library for any page mentioning the item's
@@ -1408,7 +1420,8 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           </div>
         </div>
       </details>
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -5,7 +5,6 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
 
   require Logger
 
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
@@ -16,6 +15,16 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Manufacturer
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -180,13 +189,16 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
-      <%!-- Header --%>
-      <.admin_page_header
-        back={Paths.manufacturers()}
-        title={@page_title}
-        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new manufacturer to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update manufacturer details and supplier links.")}
-      />
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new manufacturer to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update manufacturer details and supplier links.")}
+      current_path={assigns[:url_path] || Paths.manufacturers()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
@@ -312,7 +324,8 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
           </div>
         </div>
       </.form>
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -5,7 +5,6 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
 
   require Logger
 
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
@@ -16,6 +15,16 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Supplier
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -175,13 +184,16 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
-      <%!-- Header --%>
-      <.admin_page_header
-        back={Paths.suppliers()}
-        title={@page_title}
-        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new supplier to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update supplier details and manufacturer links.")}
-      />
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new supplier to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update supplier details and manufacturer links.")}
+      current_path={assigns[:url_path] || Paths.suppliers()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
@@ -300,7 +312,8 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
           </div>
         </div>
       </.form>
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -675,6 +675,9 @@ msgstr ""
 msgid "All events loaded"
 msgstr ""
 
+msgid "Events: %{count}"
+msgstr ""
+
 msgid "Danger Zone"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -670,6 +670,9 @@ msgstr "Map Columns"
 msgid "All events loaded"
 msgstr "All events loaded"
 
+msgid "Events: %{count}"
+msgstr "Events: %{count}"
+
 msgid "Danger Zone"
 msgstr "Danger Zone"
 

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -670,6 +670,9 @@ msgstr "Vastenda veerud"
 msgid "All events loaded"
 msgstr "Kõik sündmused laaditud"
 
+msgid "Events: %{count}"
+msgstr "Sündmusi: %{count}"
+
 msgid "Danger Zone"
 msgstr "Ohutsoon"
 

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -670,6 +670,9 @@ msgstr "Сопоставление столбцов"
 msgid "All events loaded"
 msgstr "Все события загружены"
 
+msgid "Events: %{count}"
+msgstr "Событий: %{count}"
+
 msgid "Danger Zone"
 msgstr "Опасная зона"
 


### PR DESCRIPTION
## Summary

Moves the catalogue admin page headers into the **global admin header bar** (breadcrumb), adopting the `/admin/media` self-wrap pattern across all 8 catalogue admin LiveViews.

## What changes

- Each catalogue admin LiveView opts out of the auto admin-chrome layout via an `on_mount` that resets `socket.private[:live_layout]` to `:app`, then wraps `render/1` in `LayoutWrapper.app_layout` so the page **title/subtitle land in the global admin header** instead of an in-content `<.admin_page_header>`.
- Action buttons and the rich catalogue breadcrumb relocate to **in-body toolbars**.
- **Events tab**: the header subtitle now reads `"<module> · Events: <count>"`. This replaces a broken inline counter that called plain `Gettext.gettext/3` on a plural msgid (which always returned the Russian singular form). The new `"Events: %{count}"` label sidesteps plural agreement and is translated for `en` / `ru` / `et`.

## Scope

LiveViews touched: catalogue detail, catalogue form, catalogues index, category form, events, item form, manufacturer form, supplier form. Plus gettext (`default.pot` + `en`/`ru`/`et` `.po`).

This is a focused, self-contained UI refactor — no schema, context, or routing changes.
