### PR TITLE
Catalogue admin table stack: dynamic columns, toolbar, per-user view config, folders

### DIFF
--- a/dev_docs/2026-06-27-catalogue-table-stack-design.md
+++ b/dev_docs/2026-06-27-catalogue-table-stack-design.md
@@ -1,0 +1,165 @@
+# Catalogue admin table stack — design
+
+**Date:** 2026-06-27
+**Module:** `phoenix_kit_catalogue`
+**Scope:** `/admin/catalogue` (catalogues index), `/admin/catalogue/suppliers`, `/admin/catalogue/manufacturers` — all rendered by `PhoenixKitCatalogue.Web.CataloguesLive`.
+
+## Goal
+
+Bring the three catalogue admin lists up to the "orders-style" table stack the rest of the app uses: a control toolbar (search + filters + sort + view toggle + column management + action buttons), a table↔card view toggle, per-column show/hide, and column sorting — with the user's choices persisted **per user, across sessions**.
+
+The page title/subtitle already moved to the global admin header (prior task). The action buttons that were left in a bare top toolbar ("noise/junk") move **into** the table control row.
+
+## Decisions (locked with the user)
+
+1. **Catalogues index becomes a flat table** with a **folder filter** (+ a "Folder" column). The inline folder **tree + drag-and-drop is removed**. "Move to folder" stays in each catalogue's row menu.
+2. **Per-user persistence** of column selection, sort, filters, and view mode.
+3. **Full folder management** is preserved via a dedicated **"Folders" modal** (create / rename / new subfolder / move / trash / restore) opened from the toolbar.
+4. The page's **global cross-catalogue item search is removed**. The single toolbar search filters the *current table's rows by name*.
+5. The **"Active / Deleted" sub-tabs** for catalogues are kept, above the control row.
+
+## Non-goals
+
+- No changes to `/admin/catalogue/events`, the catalogue detail page, or any form pages.
+- No new DB table or migration (see Persistence).
+- No server-side pagination — lists are small; sort/filter/search are in-memory (same as orders).
+- Suppliers/manufacturers get **no** "deleted" sub-tab (they use active/inactive status + hard delete, unchanged).
+
+## Architecture — a self-contained mini-toolkit inside the module
+
+`phoenix_kit_catalogue` is a standalone library and **must not** depend on host-app `Andi.*` modules (the orders stack lives in andi). So the pattern is replicated locally, reusing only phoenix_kit **core** components (`<.table_default>`, `Modal`, `SortableGrid` hook, icons).
+
+New modules (all under `lib/phoenix_kit_catalogue/web/`):
+
+### `PhoenixKitCatalogue.Web.TableConfig`
+Pure column metadata, keyed by scope atom (`:catalogues | :suppliers | :manufacturers`). One module, scope-keyed functions (avoids three near-identical files):
+
+- `columns(scope) :: [column]` — declaration order.
+- `default_columns(scope) :: [id]` — visible-by-default ids.
+- `column_map(scope) :: %{id => column}` — fast lookup.
+- `validate_columns(scope, ids)` / `sortable_visible(scope, ids)` helpers.
+
+A `column` is a map:
+```
+%{
+  id: "items",
+  label: fn -> Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items") end,  # lazy → current locale
+  default?: true,
+  managed?: true,        # false for name/actions (always shown, never in the modal)
+  sortable?: true,
+  sort_key: fn row -> ... end,
+  align: :right,         # :left | :right
+  filterable?: true,
+  filter_type: :enum,    # :enum | nil
+  filter_options: fn -> [{value, label}] end   # enum only
+}
+```
+Cell/card rendering stays in the LiveView (`render_cell/3`, `render_card_value/3`); only structural metadata lives here.
+
+### `PhoenixKitCatalogue.Web.ViewConfig`
+Per-user persistence over `phoenix_kit_users.custom_fields["catalogue_view_configs"]` — **no new table**. Precedent: `PhoenixKit.Notifications.Prefs`.
+
+- `get(user, scope) :: map` — reads `user.custom_fields["catalogue_view_configs"][scope]` (already loaded on the socket; zero DB cost), merged over defaults.
+- `put(user, scope, cfg) :: {:ok, user} | {:error, _}` — merge-then-write via
+  `PhoenixKit.Users.Auth.update_user_custom_fields(user, merged, ensure_definitions: false, broadcast: false)`.
+  (`ensure_definitions: false` is mandatory — otherwise the key auto-registers as a user-visible profile field.)
+
+Persisted per-scope shape:
+```json
+{ "columns": ["name","folder","items","status","updated"],
+  "sort_by": "name", "sort_dir": "asc",
+  "filters": {"status": "active"},
+  "view": "table" }
+```
+Filter *values* persist (unlike orders, which resets them) — small and useful here. `view` ("table"/"card") persists server-side via `view_mode=` controlled mode on `<.table_default>` so it survives across devices.
+
+### `column_settings_modal/1` (function component, in `CataloguesLive` or a small components module)
+- Inputs: scope, all columns (managed only), current selected (ordered), temp selected.
+- Left: ordered selected columns, reorderable via the existing **`SortableGrid`** hook (already bundled in the module's JS), each with a remove (×) toggle.
+- Right: available (hidden) columns, click to add.
+- Footer: "Reset to defaults" + "Apply". Built on core `<.modal>` (keep_in_dom).
+
+### Sorting / filtering / search — in-memory
+All applied in the LiveView over the already-loaded list (catalogues/suppliers/manufacturers counts are modest). `sort_key` from `TableConfig`; `Enum.sort_by/3` with `:asc/:desc`. Search = case-insensitive substring on `name`. Filters = `status`, plus `folder` (catalogues only).
+
+## Toolbar (one control row, under the Active/Deleted sub-tabs)
+
+Rendered via the `<.table_default>` toolbar slots (`:toolbar_title` left, `:toolbar_actions` right); the view toggle is appended by `table_default` itself.
+
+```
+[🔍 Поиск…]  [Папка ▾] [Статус ▾]   |   Сорт: [колонка ▾][↑↓]  [⛭ Колонки]  [☰/▦]  [+ действие]
+```
+- Catalogues: search · Folder filter · Status filter · sort · Columns · view toggle · **+Папка**, **+Каталог**, **Папки…** (opens folder modal).
+- Suppliers / Manufacturers: search · Status filter · sort · Columns · view toggle · **+Поставщик / +Производитель**.
+
+Sort is also available by clicking sortable table headers (table view); the toolbar sort select is the primary control in card view.
+
+## Per-scope columns / filters / defaults
+
+**Catalogues** (`:catalogues`)
+| id | label | default | sortable | filter | align |
+|----|-------|---------|----------|--------|-------|
+| name | Name | ✓ (always) | ✓ | — | left |
+| folder | Folder | ✓ | ✓ (folder name) | enum (folder) | left |
+| items | Items | ✓ | ✓ | — | right |
+| status | Status | ✓ | ✓ | enum | left |
+| kind | Kind | — | ✓ | enum (standard/smart) | left |
+| markup | Markup % | — | ✓ | — | right |
+| discount | Discount % | — | ✓ | — | right |
+| updated | Updated | ✓ | ✓ | — | left |
+| created | Created | — | ✓ | — | left |
+| actions | — | ✓ (always) | — | — | right |
+
+Default sort: `name asc`. Filters: Status, Folder, Kind. Item count from `Catalogue.item_counts_by_catalogue/0` (already loaded). Folder name from a `%{folder_uuid => Folder}` lookup built from `list_folder_tree/0` (already loaded).
+
+**Suppliers** (`:suppliers`)
+name (always, link to edit) · website ✓ · status ✓ (filter enum active/inactive) · contact_info (hidden) · updated (hidden) · actions. Default sort: `name asc`. Filter: Status.
+
+**Manufacturers** (`:manufacturers`)
+Same shape as suppliers (name · website ✓ · status ✓ · contact_info hidden · updated hidden · actions). Default sort: `name asc`. Filter: Status.
+
+## Catalogues index — flat conversion details
+
+- Replace `folder_tree_table/1` with a flat `<.table_default toggleable view_mode=...>` driven by the visible columns. Rows = catalogues for the active status view (active vs deleted).
+- **Active/Deleted sub-tabs** stay above the toolbar (`switch_catalogue_view`), unchanged. Deleted view = flat list of trashed catalogues with Restore / Delete-forever row actions.
+- **Folder filter** dropdown: "All folders" / "Unfiled (root)" / each folder (indented). Filters by exact `folder_uuid`.
+- **Folder column**: folder name or "—".
+- **Removed:** `CatalogueTreeDnD` hook + tree markup + global item-search block and its state/handlers (`search`, `search_results`, infinite-scroll for global search). Verify no orphaned assigns/handlers remain.
+
+## Folders modal (preserve full folder management)
+
+Toolbar **"Папки…"** button opens a `<.modal>` listing the folder tree (`list_folder_tree/0`) with actions wired to existing context functions:
+`create_folder/2`, `update_folder/3` (rename), `move_folder/3`, `trash_folder/2`, `restore_folder/2`, `permanently_delete_folder/2`, plus active/trash toggle inside the modal. Reuses the existing `new_folder` / `start_rename_folder` / `rename_folder` / `trash_folder` / etc. event names where possible. This is the home for everything the inline tree used to do except DnD (DnD replaced by per-catalogue "Move to folder").
+
+## Per-tab state on the single LiveView
+
+`CataloguesLive` serves all three tabs. View state is per scope:
+- `@view_configs :: %{catalogues: cfg, suppliers: cfg, manufacturers: cfg}` loaded from `ViewConfig.get/2` on mount.
+- Column-modal/sort/filter/search/view events operate on the **active tab's** scope, mutate that entry, persist via `ViewConfig.put/3`, and re-derive the displayed rows.
+- New events: `show_column_modal`, `hide_column_modal`, `add_column`, `remove_column`, `reorder_columns`, `reset_columns`, `apply_columns`, `set_sort`, `toggle_sort` (header), `set_filter`/`clear_filter`, `set_view` (table/card), and `search` (re-purposed to filter the table).
+
+## Internationalization
+
+New gettext strings (Columns, Reset, Apply, Sort by, Folder, Kind, Markup %, Discount %, Created, Unfiled, All folders, Manage folders, etc.) added manually to `.pot` + en/ru/et `.po` (no `gettext.merge` — avoids fuzzy pollution). Labels via lazy `fn -> gettext(...) end`.
+
+## Implementation phasing (for the plan)
+
+1. **Toolkit:** `TableConfig` + `ViewConfig` + `column_settings_modal` + shared sort/filter/search helpers. Unit-testable in isolation.
+2. **Suppliers + Manufacturers:** wire the toolbar + dynamic columns + sort/filter/search + card view + move action buttons into the toolbar. (Simplest — already `table_default`.)
+3. **Catalogues index:** flat conversion, folder filter + folder column, Active/Deleted retained, remove tree/DnD + global item search.
+4. **Folders modal:** full folder CRUD.
+5. gettext, `mix format`, compile via `/www/app`, restart, runtime verify.
+
+## Verification
+
+- Compile via `cd /www/app && mix compile` (catalogue can't compile standalone — stale deps).
+- Restart elixir (path-dep, no hot reload); confirm clean boot + HTTP 200.
+- Runtime checks: column show/hide persists across a reconnect and across users; sort + filter + search work in both table and card view; folder filter narrows; folder modal CRUD works; Active/Deleted toggle intact; "Move to folder" still works; no leftover global-search crashes.
+- daisyUI 5 mobile check via headless browser (per project memory — no eyeballing).
+
+## Risks / watch-items
+
+- **Single LiveView, three scopes** — keep the active-scope plumbing clean so events don't cross-contaminate tabs.
+- **`custom_fields` write on every toggle** — acceptable (notification prefs do the same); keep writes coarse (on Apply / sort / filter change, not per keystroke).
+- **Folder management regression** — the modal must cover every action the tree offered (except DnD); enumerate against the old `folder_tree_table` row menus.
+- **Removing global item search** — ensure all its assigns/handlers/hook are removed without breaking mount.

--- a/dev_docs/2026-06-27-catalogue-table-stack-plan.md
+++ b/dev_docs/2026-06-27-catalogue-table-stack-plan.md
@@ -1,0 +1,1211 @@
+# Catalogue Admin Table Stack — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `/admin/catalogue`, `/admin/catalogue/suppliers`, and `/admin/catalogue/manufacturers` a control toolbar (search + filters + sort + view-toggle + column management + relocated action buttons), a table↔card view, and per-user-persisted column/sort/filter/view state — with the catalogues index flattened (folder filter + "Folders" modal instead of the inline tree).
+
+**Architecture:** A self-contained mini-toolkit inside `phoenix_kit_catalogue` (no `Andi.*` deps): `TableConfig` (column metadata per scope), `TableQuery` (in-memory search/filter/sort), `ViewConfig` (per-user persistence in `users.custom_fields`), and a `column_settings_modal` component — all wired into the single `CataloguesLive` LiveView, rendering through phoenix_kit core's `<.table_default toggleable>`.
+
+**Tech Stack:** Elixir/Phoenix LiveView, phoenix_kit core components (`table_default`, `modal`, `icon`, `SortableGrid` JS hook), Gettext (`PhoenixKitCatalogue.Gettext`), daisyUI 5.
+
+## Global Constraints
+
+- **No `Andi.*` / `AndiWeb.*` dependencies** — `phoenix_kit_catalogue` is a standalone library. Use phoenix_kit **core** components only.
+- **No new DB table / migration.** Per-user state lives in `phoenix_kit_users.custom_fields["catalogue_view_configs"]`.
+- **Persist writes** use `PhoenixKit.Users.Auth.update_user_custom_fields(user, merged, ensure_definitions: false, broadcast: false)` — the `ensure_definitions: false` opt is mandatory.
+- **Compile only via** `cd /www/app && mix compile` (catalogue can't compile standalone — stale deps). Must be clean: no new warnings/errors.
+- **Runtime verify:** `sudo /usr/bin/supervisorctl restart elixir` (path-dep, no hot reload), then HTTP 200 + Tidewave `project_eval` for logic + headless browser for UI.
+- **Gettext:** add strings manually to `priv/gettext/default.pot` + `en`/`ru`/`et` `.po`. **Never** run `mix gettext.merge` (fuzzy pollution). Labels are lazy `fn -> Gettext.gettext(PhoenixKitCatalogue.Gettext, "...") end`.
+- **daisyUI 5:** conditional classes via list syntax `class={["base", @flag && "x"]}`; flex/grid children that can overflow need `min-w-0`; never eyeball mobile — measure with a headless browser.
+- **Commits:** work on `main`, one commit per task, message starts with a verb. **No** CHANGELOG.md / `@version` edits. **No** AI attribution.
+- **Current user:** `socket.assigns.phoenix_kit_current_user` (full `%User{}` with `custom_fields` already loaded). `actor_uuid/1` in `Web.Helpers`.
+- All edits are in `/www/phoenix_kit_catalogue/`.
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/phoenix_kit_catalogue/web/table_config.ex` — `PhoenixKitCatalogue.Web.TableConfig`: column metadata per scope (`:catalogues | :suppliers | :manufacturers`).
+- `lib/phoenix_kit_catalogue/web/table_query.ex` — `PhoenixKitCatalogue.Web.TableQuery`: pure search/filter/sort over a row list using TableConfig metadata.
+- `lib/phoenix_kit_catalogue/web/view_config.ex` — `PhoenixKitCatalogue.Web.ViewConfig`: get/put per-user config in `custom_fields`.
+- `lib/phoenix_kit_catalogue/web/table_toolbar.ex` — `PhoenixKitCatalogue.Web.TableToolbar`: the `column_settings_modal/1` component + small toolbar sub-components (sort select, filter selects). (Keeps `catalogues_live.ex` from ballooning.)
+- `test/web/table_config_test.exs`, `test/web/table_query_test.exs`, `test/web/view_config_test.exs` — pure unit tests (runnable once the catalogue test env is set up; mirrored by Tidewave evals in-session).
+
+**Modify:**
+- `lib/phoenix_kit_catalogue/web/catalogues_live.ex` — mount loads `@view_configs`; new event handlers; three table renders rewired; folders modal; remove tree + global item search.
+- `priv/gettext/default.pot` + `priv/gettext/{en,ru,et}/LC_MESSAGES/default.po` — new strings.
+
+---
+
+## Task 1: `TableConfig` — column metadata per scope
+
+**Files:**
+- Create: `lib/phoenix_kit_catalogue/web/table_config.ex`
+- Test: `test/web/table_config_test.exs`
+
+**Interfaces:**
+- Produces:
+  - `TableConfig.columns(scope) :: [col]` where `scope in [:catalogues, :suppliers, :manufacturers]`
+  - `TableConfig.default_columns(scope) :: [String.t()]` (managed defaults, in order)
+  - `TableConfig.column_map(scope) :: %{String.t() => col}`
+  - `TableConfig.managed_columns(scope) :: [col]` (those with `managed?: true`)
+  - `TableConfig.validate_columns(scope, [id]) :: [id]` (known managed ids, dedup, order preserved)
+  - `TableConfig.sortable_visible(scope, [id]) :: [col]` (sortable cols among the given ids)
+  - `TableConfig.default_sort(scope) :: {id, :asc | :desc}`
+  - `col` map keys: `:id` (String), `:label` (0-arity fn), `:default?` (bool), `:managed?` (bool), `:sortable?` (bool), `:sort_key` (1-arity fn | nil), `:align` (`:left|:right`), `:filterable?` (bool), `:filter_type` (`:enum | nil`).
+
+- [ ] **Step 1: Write the module.**
+
+```elixir
+defmodule PhoenixKitCatalogue.Web.TableConfig do
+  @moduledoc """
+  Column metadata for the catalogue admin tables, keyed by scope
+  (`:catalogues`, `:suppliers`, `:manufacturers`). Pure data — cell and
+  card rendering live in the LiveView. Labels are zero-arity fns so they
+  resolve in the request's current locale.
+  """
+  alias PhoenixKitCatalogue.Gettext, as: G
+
+  @type scope :: :catalogues | :suppliers | :manufacturers
+  @type column :: %{
+          id: String.t(),
+          label: (-> String.t()),
+          default?: boolean(),
+          managed?: boolean(),
+          sortable?: boolean(),
+          sort_key: (map() -> term()) | nil,
+          align: :left | :right,
+          filterable?: boolean(),
+          filter_type: :enum | nil
+        }
+
+  defp g(s), do: Gettext.gettext(G, s)
+
+  # Build a column with sensible defaults.
+  defp col(id, label_fn, opts) do
+    %{
+      id: id,
+      label: label_fn,
+      default?: Keyword.get(opts, :default?, false),
+      managed?: Keyword.get(opts, :managed?, true),
+      sortable?: Keyword.get(opts, :sortable?, false),
+      sort_key: Keyword.get(opts, :sort_key),
+      align: Keyword.get(opts, :align, :left),
+      filterable?: Keyword.get(opts, :filterable?, false),
+      filter_type: Keyword.get(opts, :filter_type)
+    }
+  end
+
+  @spec columns(scope()) :: [column()]
+  def columns(:catalogues) do
+    [
+      col("name", fn -> g("Name") end, default?: true, managed?: false, sortable?: true,
+        sort_key: &down(&1.name)),
+      col("folder", fn -> g("Folder") end, default?: true, sortable?: true,
+        sort_key: &down(&1[:folder_name]), filterable?: true, filter_type: :enum),
+      col("items", fn -> g("Items") end, default?: true, sortable?: true,
+        align: :right, sort_key: &(&1[:item_count] || 0)),
+      col("status", fn -> g("Status") end, default?: true, sortable?: true,
+        sort_key: &down(&1.status), filterable?: true, filter_type: :enum),
+      col("kind", fn -> g("Kind") end, sortable?: true, sort_key: &down(&1.kind),
+        filterable?: true, filter_type: :enum),
+      col("markup", fn -> g("Markup %") end, sortable?: true, align: :right,
+        sort_key: &dec(&1.markup_percentage)),
+      col("discount", fn -> g("Discount %") end, sortable?: true, align: :right,
+        sort_key: &dec(&1.discount_percentage)),
+      col("updated", fn -> g("Updated") end, default?: true, sortable?: true,
+        sort_key: & &1.updated_at),
+      col("created", fn -> g("Created") end, sortable?: true, sort_key: & &1.inserted_at)
+    ]
+  end
+
+  def columns(scope) when scope in [:suppliers, :manufacturers] do
+    [
+      col("name", fn -> g("Name") end, default?: true, managed?: false, sortable?: true,
+        sort_key: &down(&1.name)),
+      col("website", fn -> g("Website") end, default?: true, sortable?: true,
+        sort_key: &down(&1.website)),
+      col("status", fn -> g("Status") end, default?: true, sortable?: true,
+        sort_key: &down(&1.status), filterable?: true, filter_type: :enum),
+      col("contact_info", fn -> g("Contact Info") end, sortable?: true,
+        sort_key: &down(&1.contact_info)),
+      col("updated", fn -> g("Updated") end, sortable?: true, sort_key: & &1.updated_at)
+    ]
+  end
+
+  @spec default_columns(scope()) :: [String.t()]
+  def default_columns(scope) do
+    scope |> columns() |> Enum.filter(& &1.default?) |> Enum.map(& &1.id)
+  end
+
+  @spec managed_columns(scope()) :: [column()]
+  def managed_columns(scope), do: scope |> columns() |> Enum.filter(& &1.managed?)
+
+  @spec column_map(scope()) :: %{String.t() => column()}
+  def column_map(scope), do: scope |> columns() |> Map.new(&{&1.id, &1})
+
+  @spec validate_columns(scope(), [String.t()]) :: [String.t()]
+  def validate_columns(scope, ids) when is_list(ids) do
+    known = scope |> managed_columns() |> MapSet.new(& &1.id)
+    ids |> Enum.filter(&MapSet.member?(known, &1)) |> Enum.uniq()
+  end
+
+  def validate_columns(_scope, _), do: []
+
+  @spec sortable_visible(scope(), [String.t()]) :: [column()]
+  def sortable_visible(scope, ids) do
+    map = column_map(scope)
+    ids |> Enum.map(&Map.get(map, &1)) |> Enum.filter(&(&1 && &1.sortable?))
+  end
+
+  @spec default_sort(scope()) :: {String.t(), :asc | :desc}
+  def default_sort(:catalogues), do: {"name", :asc}
+  def default_sort(_), do: {"name", :asc}
+
+  # sort helpers: case-insensitive for strings, Decimal→float, nil-safe.
+  defp down(nil), do: ""
+  defp down(s) when is_binary(s), do: String.downcase(s)
+  defp down(other), do: other
+
+  defp dec(%Decimal{} = d), do: Decimal.to_float(d)
+  defp dec(n) when is_number(n), do: n
+  defp dec(_), do: 0.0
+end
+```
+
+- [ ] **Step 2: Write the unit test.**
+
+```elixir
+defmodule PhoenixKitCatalogue.Web.TableConfigTest do
+  use ExUnit.Case, async: true
+  alias PhoenixKitCatalogue.Web.TableConfig, as: TC
+
+  test "catalogues defaults are the visible managed+name set, in order" do
+    assert TC.default_columns(:catalogues) == ["name", "folder", "items", "status", "updated"]
+  end
+
+  test "name is always present but not managed (never hidden via modal)" do
+    refute Enum.any?(TC.managed_columns(:catalogues), &(&1.id == "name"))
+    assert TC.column_map(:catalogues)["name"].managed? == false
+  end
+
+  test "validate_columns drops unknown + non-managed ids and dedups" do
+    assert TC.validate_columns(:catalogues, ["items", "items", "bogus", "name"]) == ["items"]
+  end
+
+  test "sortable_visible keeps only sortable, in given order" do
+    ids = ["status", "name", "markup"]
+    assert Enum.map(TC.sortable_visible(:catalogues, ids), & &1.id) == ids
+  end
+
+  test "suppliers/manufacturers share the column shape" do
+    assert TC.default_columns(:suppliers) == ["name", "website", "status"]
+    assert TC.default_columns(:manufacturers) == ["name", "website", "status"]
+  end
+end
+```
+
+- [ ] **Step 3: Compile via the app.**
+
+Run: `cd /www/app && mix compile 2>&1 | grep -iE "table_config|error|warning: " | head`
+Expected: no errors/warnings referencing `table_config.ex`.
+
+- [ ] **Step 4: Verify behavior on the live node.**
+
+After `sudo /usr/bin/supervisorctl restart elixir` (wait for HTTP 200), Tidewave `project_eval`:
+```elixir
+{PhoenixKitCatalogue.Web.TableConfig.default_columns(:catalogues),
+ PhoenixKitCatalogue.Web.TableConfig.validate_columns(:catalogues, ["items","bogus","name"]),
+ Enum.map(PhoenixKitCatalogue.Web.TableConfig.sortable_visible(:catalogues, ["status","name"]), & &1.id)}
+```
+Expected: `{["name","folder","items","status","updated"], ["items"], ["status","name"]}`
+
+- [ ] **Step 5: Commit.**
+
+```bash
+cd /www/phoenix_kit_catalogue
+git add lib/phoenix_kit_catalogue/web/table_config.ex test/web/table_config_test.exs
+git commit -m "Add TableConfig column metadata for catalogue admin tables"
+```
+
+---
+
+## Task 2: `TableQuery` — in-memory search/filter/sort
+
+**Files:**
+- Create: `lib/phoenix_kit_catalogue/web/table_query.ex`
+- Test: `test/web/table_query_test.exs`
+
+**Interfaces:**
+- Consumes: `TableConfig.column_map/1`, `TableConfig.columns/1`.
+- Produces:
+  - `TableQuery.apply(rows, scope, %{search: str, filters: %{id=>val}, sort_by: id, sort_dir: :asc|:desc}) :: [row]`
+  - `TableQuery.search(rows, str) :: [row]` (case-insensitive substring on `row.name`)
+  - `TableQuery.filter(rows, scope, filters) :: [row]`
+  - `TableQuery.sort(rows, scope, sort_by, dir) :: [row]`
+  - `TableQuery.enum_options(rows, scope, col_id) :: [{value, label}]` (distinct present values for an enum filter column; `folder` uses `row[:folder_name]`, others use the field named by `col_id`)
+
+- [ ] **Step 1: Write the module.**
+
+```elixir
+defmodule PhoenixKitCatalogue.Web.TableQuery do
+  @moduledoc """
+  Pure, in-memory search → filter → sort pipeline over a list of row maps
+  (catalogues/suppliers/manufacturers already loaded by the LiveView).
+  """
+  alias PhoenixKitCatalogue.Web.TableConfig
+
+  @spec apply([map()], TableConfig.scope(), map()) :: [map()]
+  def apply(rows, scope, opts) do
+    rows
+    |> search(Map.get(opts, :search, ""))
+    |> filter(scope, Map.get(opts, :filters, %{}))
+    |> sort(scope, Map.get(opts, :sort_by), Map.get(opts, :sort_dir, :asc))
+  end
+
+  @spec search([map()], String.t() | nil) :: [map()]
+  def search(rows, q) when is_binary(q) and q != "" do
+    needle = String.downcase(q)
+    Enum.filter(rows, fn r -> String.contains?(String.downcase(r.name || ""), needle) end)
+  end
+
+  def search(rows, _), do: rows
+
+  @spec filter([map()], TableConfig.scope(), map()) :: [map()]
+  def filter(rows, scope, filters) when is_map(filters) do
+    Enum.reduce(filters, rows, fn
+      {_id, val}, acc when val in [nil, "", "all"] -> acc
+      {id, val}, acc -> Enum.filter(acc, &filter_match?(scope, id, &1, val))
+    end)
+  end
+
+  def filter(rows, _scope, _), do: rows
+
+  defp filter_match?(_scope, "folder", row, val), do: to_string(row[:folder_uuid]) == val
+  defp filter_match?(_scope, id, row, val), do: to_string(Map.get(row, String.to_existing_atom(id))) == val
+
+  @spec sort([map()], TableConfig.scope(), String.t() | nil, :asc | :desc) :: [map()]
+  def sort(rows, scope, sort_by, dir) when is_binary(sort_by) do
+    case TableConfig.column_map(scope)[sort_by] do
+      %{sort_key: key} when is_function(key, 1) -> Enum.sort_by(rows, key, dir)
+      _ -> rows
+    end
+  end
+
+  def sort(rows, _scope, _sort_by, _dir), do: rows
+
+  @spec enum_options([map()], TableConfig.scope(), String.t()) :: [{String.t(), String.t()}]
+  def enum_options(rows, _scope, "folder") do
+    rows
+    |> Enum.map(&{to_string(&1[:folder_uuid]), &1[:folder_name]})
+    |> Enum.reject(fn {uuid, _} -> uuid in ["", "nil"] end)
+    |> Enum.uniq()
+    |> Enum.sort_by(fn {_u, name} -> String.downcase(name || "") end)
+  end
+
+  def enum_options(rows, _scope, id) do
+    key = String.to_existing_atom(id)
+
+    rows
+    |> Enum.map(&to_string(Map.get(&1, key)))
+    |> Enum.reject(&(&1 in ["", "nil"]))
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.map(&{&1, &1})
+  end
+end
+```
+
+- [ ] **Step 2: Write the unit test.** (Uses plain maps mirroring the row shape the LiveView builds.)
+
+```elixir
+defmodule PhoenixKitCatalogue.Web.TableQueryTest do
+  use ExUnit.Case, async: true
+  alias PhoenixKitCatalogue.Web.TableQuery, as: Q
+
+  defp rows do
+    [
+      %{name: "Beta", status: "active", item_count: 3, folder_uuid: "f1", folder_name: "Kitchen", updated_at: ~U[2026-01-02 00:00:00Z]},
+      %{name: "alpha", status: "archived", item_count: 9, folder_uuid: nil, folder_name: nil, updated_at: ~U[2026-01-01 00:00:00Z]}
+    ]
+  end
+
+  test "search is case-insensitive substring on name" do
+    assert Enum.map(Q.search(rows(), "al"), & &1.name) == ["alpha"]
+    assert Q.search(rows(), "") == rows()
+  end
+
+  test "filter by status; 'all'/nil are no-ops" do
+    assert Enum.map(Q.filter(rows(), :catalogues, %{"status" => "active"}), & &1.name) == ["Beta"]
+    assert Q.filter(rows(), :catalogues, %{"status" => "all"}) == rows()
+  end
+
+  test "filter by folder uuid" do
+    assert Enum.map(Q.filter(rows(), :catalogues, %{"folder" => "f1"}), & &1.name) == ["Beta"]
+  end
+
+  test "sort by name is case-insensitive; dir respected" do
+    assert Enum.map(Q.sort(rows(), :catalogues, "name", :asc), & &1.name) == ["alpha", "Beta"]
+    assert Enum.map(Q.sort(rows(), :catalogues, "name", :desc), & &1.name) == ["Beta", "alpha"]
+  end
+
+  test "enum_options for folder skips unfiled and dedups" do
+    assert Q.enum_options(rows(), :catalogues, "folder") == [{"f1", "Kitchen"}]
+  end
+end
+```
+
+- [ ] **Step 3: Compile via the app.** Run `cd /www/app && mix compile` — clean re: `table_query.ex`.
+
+- [ ] **Step 4: Verify on live node** (after restart) via Tidewave `project_eval`:
+```elixir
+rows = [%{name: "Beta", status: "active", folder_uuid: "f1", folder_name: "Kitchen"},
+        %{name: "alpha", status: "archived", folder_uuid: nil, folder_name: nil}]
+{Enum.map(PhoenixKitCatalogue.Web.TableQuery.apply(rows, :catalogues,
+   %{search: "a", filters: %{"status" => "all"}, sort_by: "name", sort_dir: :asc}), & &1.name),
+ PhoenixKitCatalogue.Web.TableQuery.enum_options(rows, :catalogues, "folder")}
+```
+Expected: `{["alpha", "Beta"], [{"f1", "Kitchen"}]}`
+
+- [ ] **Step 5: Commit.**
+```bash
+git add lib/phoenix_kit_catalogue/web/table_query.ex test/web/table_query_test.exs
+git commit -m "Add TableQuery in-memory search/filter/sort pipeline"
+```
+
+---
+
+## Task 3: `ViewConfig` — per-user persistence in custom_fields
+
+**Files:**
+- Create: `lib/phoenix_kit_catalogue/web/view_config.ex`
+- Test: `test/web/view_config_test.exs` (pure merge logic only; the DB write is verified at runtime)
+
+**Interfaces:**
+- Consumes: `TableConfig.default_columns/1`, `TableConfig.validate_columns/2`, `TableConfig.default_sort/1`; `PhoenixKit.Users.Auth.update_user_custom_fields/3`.
+- Produces:
+  - `ViewConfig.scope_key(scope) :: String.t()` (`"catalogues"|"suppliers"|"manufacturers"`)
+  - `ViewConfig.defaults(scope) :: cfg` where `cfg = %{columns: [id], sort_by: id, sort_dir: :asc|:desc, filters: %{}, view: "table"}` (atom keys, in-memory shape)
+  - `ViewConfig.load(user, scope) :: cfg` — reads `custom_fields`, normalizes over defaults
+  - `ViewConfig.save(user, scope, cfg) :: {:ok, %User{}} | {:error, term}`
+  - `ViewConfig.normalize(scope, raw_map) :: cfg` (string-keyed raw → atom-keyed cfg, validated)
+
+- [ ] **Step 1: Write the module.**
+
+```elixir
+defmodule PhoenixKitCatalogue.Web.ViewConfig do
+  @moduledoc """
+  Per-user table view config (columns / sort / filters / view mode) for the
+  catalogue admin tables. Stored in `phoenix_kit_users.custom_fields` under
+  the `"catalogue_view_configs"` key — no dedicated table. Precedent:
+  `PhoenixKit.Notifications.Prefs`.
+  """
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKitCatalogue.Web.TableConfig
+
+  @root "catalogue_view_configs"
+
+  @spec scope_key(TableConfig.scope()) :: String.t()
+  def scope_key(scope), do: to_string(scope)
+
+  @spec defaults(TableConfig.scope()) :: map()
+  def defaults(scope) do
+    {sort_by, sort_dir} = TableConfig.default_sort(scope)
+    %{columns: TableConfig.default_columns(scope), sort_by: sort_by, sort_dir: sort_dir,
+      filters: %{}, view: "table"}
+  end
+
+  @spec load(map() | nil, TableConfig.scope()) :: map()
+  def load(user, scope) do
+    raw =
+      case user do
+        %{custom_fields: cf} when is_map(cf) -> get_in(cf, [@root, scope_key(scope)]) || %{}
+        _ -> %{}
+      end
+
+    normalize(scope, raw)
+  end
+
+  @spec normalize(TableConfig.scope(), map()) :: map()
+  def normalize(scope, raw) when is_map(raw) do
+    d = defaults(scope)
+
+    cols =
+      case TableConfig.validate_columns(scope, List.wrap(raw["columns"])) do
+        [] -> d.columns
+        list -> list
+      end
+
+    %{
+      columns: cols,
+      sort_by: raw["sort_by"] || d.sort_by,
+      sort_dir: dir(raw["sort_dir"], d.sort_dir),
+      filters: (is_map(raw["filters"]) && raw["filters"]) || %{},
+      view: (raw["view"] in ["table", "card"] && raw["view"]) || "table"
+    }
+  end
+
+  def normalize(scope, _), do: defaults(scope)
+
+  defp dir("desc", _), do: :desc
+  defp dir("asc", _), do: :asc
+  defp dir(_, fallback), do: fallback
+
+  @spec save(map(), TableConfig.scope(), map()) :: {:ok, map()} | {:error, term()}
+  def save(user, scope, cfg) do
+    serialized = %{
+      "columns" => cfg.columns,
+      "sort_by" => cfg.sort_by,
+      "sort_dir" => to_string(cfg.sort_dir),
+      "filters" => cfg.filters,
+      "view" => cfg.view
+    }
+
+    current = user.custom_fields || %{}
+    scoped = Map.put(Map.get(current, @root, %{}), scope_key(scope), serialized)
+    merged = Map.put(current, @root, scoped)
+
+    Auth.update_user_custom_fields(user, merged, ensure_definitions: false, broadcast: false)
+  end
+end
+```
+
+- [ ] **Step 2: Write the unit test** (normalize only — no DB):
+
+```elixir
+defmodule PhoenixKitCatalogue.Web.ViewConfigTest do
+  use ExUnit.Case, async: true
+  alias PhoenixKitCatalogue.Web.ViewConfig, as: VC
+
+  test "defaults shape" do
+    assert %{columns: ["name", "folder", "items", "status", "updated"], sort_by: "name",
+             sort_dir: :asc, filters: %{}, view: "table"} = VC.defaults(:catalogues)
+  end
+
+  test "normalize falls back on empty/invalid, keeps valid" do
+    assert VC.normalize(:catalogues, %{}) == VC.defaults(:catalogues)
+    got = VC.normalize(:catalogues, %{"columns" => ["items", "bogus"], "sort_dir" => "desc", "view" => "card"})
+    assert got.columns == ["items"]
+    assert got.sort_dir == :desc
+    assert got.view == "card"
+  end
+
+  test "load reads from a user struct's custom_fields" do
+    user = %{custom_fields: %{"catalogue_view_configs" => %{"suppliers" => %{"view" => "card"}}}}
+    assert VC.load(user, :suppliers).view == "card"
+    assert VC.load(%{custom_fields: nil}, :suppliers) == VC.defaults(:suppliers)
+  end
+end
+```
+
+- [ ] **Step 3: Compile via the app** — clean re: `view_config.ex`. Confirm `PhoenixKit.Users.Auth.update_user_custom_fields/3` arity exists:
+  `cd /www/app && mix compile` then Tidewave `project_eval`: `function_exported?(PhoenixKit.Users.Auth, :update_user_custom_fields, 3)` → `true`.
+
+- [ ] **Step 4: Verify normalize on live node** via `project_eval`:
+```elixir
+PhoenixKitCatalogue.Web.ViewConfig.normalize(:catalogues,
+  %{"columns" => ["items","bogus"], "sort_dir" => "desc", "view" => "card"})
+```
+Expected: `%{columns: ["items"], sort_by: "name", sort_dir: :desc, filters: %{}, view: "card"}`
+
+- [ ] **Step 5: Commit.**
+```bash
+git add lib/phoenix_kit_catalogue/web/view_config.ex test/web/view_config_test.exs
+git commit -m "Add ViewConfig per-user table state persistence"
+```
+
+---
+
+## Task 4: `TableToolbar` — column-settings modal + toolbar sub-components
+
+**Files:**
+- Create: `lib/phoenix_kit_catalogue/web/table_toolbar.ex`
+
+**Interfaces:**
+- Consumes: `TableConfig`, core `<.modal>`/`<.icon>`, the `SortableGrid` JS hook (already in the module's JS).
+- Produces (function components, `use Phoenix.Component`):
+  - `column_settings_modal(assigns)` — attrs: `show` (bool), `scope` (atom), `selected` ([id], ordered), `temp_selected` ([id]|nil). Emits events: `add_column` (`column_id`), `remove_column` (`column_id`), `reorder_columns` (`ordered_ids` CSV via SortableGrid), `reset_columns`, `apply_columns` (form submit, hidden `column_order` CSV), `hide_column_modal`.
+  - `sort_controls(assigns)` — attrs: `scope`, `selected` ([id]), `sort_by`, `sort_dir`. Emits `set_sort` (select), `flip_sort_dir` (button).
+  - `enum_filter(assigns)` — attrs: `id`, `label`, `value`, `options` ([{val,label}]), `prompt`. Emits `set_filter` (`column_id`, `value`) / `clear_filter`.
+
+- [ ] **Step 1: Write the component module.** Full code:
+
+```elixir
+defmodule PhoenixKitCatalogue.Web.TableToolbar do
+  @moduledoc """
+  Toolbar pieces for the catalogue admin tables: the column-settings modal,
+  the sort select+direction control, and an enum filter select. All emit
+  plain events handled by `CataloguesLive` against the active scope.
+  """
+  use Phoenix.Component
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Modal, only: [modal: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
+
+  alias PhoenixKitCatalogue.Gettext, as: G
+  alias PhoenixKitCatalogue.Web.TableConfig
+
+  defp g(s), do: Gettext.gettext(G, s)
+
+  attr :show, :boolean, required: true
+  attr :scope, :atom, required: true
+  attr :selected, :list, required: true
+  attr :temp_selected, :list, default: nil
+
+  def column_settings_modal(assigns) do
+    assigns =
+      assigns
+      |> assign(:current, assigns.temp_selected || assigns.selected)
+      |> assign(:map, TableConfig.column_map(assigns.scope))
+      |> assign(:available, TableConfig.managed_columns(assigns.scope))
+
+    assigns =
+      assign(assigns, :hidden, Enum.reject(assigns.available, &(&1.id in assigns.current)))
+
+    ~H"""
+    <.modal :if={@show} id="catalogue-columns-modal" show on_cancel={JS_hide()}>
+      <form phx-submit="apply_columns">
+        <input type="hidden" name="column_order" value={Enum.join(@current, ",")} id="catalogue-columns-order" />
+        <h3 class="text-lg font-semibold mb-3">{g("Columns")}</h3>
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <p class="text-xs uppercase text-base-content/50 mb-2">{g("Shown")}</p>
+            <ul
+              id="catalogue-columns-selected"
+              phx-hook="SortableGrid"
+              data-sortable="true"
+              data-sortable-event="reorder_columns"
+              data-sortable-items=".col-item"
+              class="space-y-1"
+            >
+              <li :for={id <- @current} :if={@map[id] && @map[id].managed?} data-id={id}
+                  class="col-item flex items-center gap-2 px-2 py-1 rounded bg-base-200">
+                <.icon name="hero-bars-3" class="w-4 h-4 pk-drag-handle cursor-grab text-base-content/40" />
+                <span class="flex-1 text-sm">{@map[id].label.()}</span>
+                <button type="button" phx-click="remove_column" phx-value-column_id={id}
+                        class="btn btn-ghost btn-xs btn-square text-error">
+                  <.icon name="hero-x-mark" class="w-4 h-4" />
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <p class="text-xs uppercase text-base-content/50 mb-2">{g("Available")}</p>
+            <ul class="space-y-1">
+              <li :for={c <- @hidden} class="flex items-center gap-2 px-2 py-1 rounded hover:bg-base-200">
+                <button type="button" phx-click="add_column" phx-value-column_id={c.id}
+                        class="flex items-center gap-2 w-full text-left text-sm">
+                  <.icon name="hero-plus" class="w-4 h-4 text-base-content/40" />
+                  <span>{c.label.()}</span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="flex justify-between mt-4">
+          <button type="button" phx-click="reset_columns" class="btn btn-ghost btn-sm">{g("Reset")}</button>
+          <div class="flex gap-2">
+            <button type="button" phx-click="hide_column_modal" class="btn btn-ghost btn-sm">{g("Cancel")}</button>
+            <button type="submit" class="btn btn-primary btn-sm">{g("Apply")}</button>
+          </div>
+        </div>
+      </form>
+    </.modal>
+    """
+  end
+
+  # Closing the modal via the X / backdrop just pushes the same cancel event.
+  defp JS_hide, do: Phoenix.LiveView.JS.push("hide_column_modal")
+
+  attr :scope, :atom, required: true
+  attr :selected, :list, required: true
+  attr :sort_by, :string, required: true
+  attr :sort_dir, :atom, required: true
+
+  def sort_controls(assigns) do
+    assigns = assign(assigns, :options, TableConfig.sortable_visible(assigns.scope, assigns.selected))
+
+    ~H"""
+    <form phx-change="set_sort" class="join">
+      <select name="sort_by" class="select select-sm join-item">
+        <option :for={c <- @options} value={c.id} selected={@sort_by == c.id}>{c.label.()}</option>
+      </select>
+      <button type="button" phx-click="flip_sort_dir" class="btn btn-sm btn-ghost join-item"
+              title={g("Toggle sort direction")}>
+        <.icon name={if @sort_dir == :asc, do: "hero-chevron-up", else: "hero-chevron-down"} class="w-4 h-4" />
+      </button>
+    </form>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :label, :string, required: true
+  attr :value, :string, default: nil
+  attr :options, :list, required: true
+  attr :prompt, :string, required: true
+
+  def enum_filter(assigns) do
+    ~H"""
+    <form phx-change="set_filter" class="contents">
+      <input type="hidden" name="column_id" value={@id} />
+      <.select name="value" id={"filter-#{@id}"} value={@value} prompt={@prompt}
+               options={@options} class="select-sm" aria-label={@label} />
+    </form>
+    """
+  end
+end
+```
+
+- [ ] **Step 2: Compile via the app.** Run `cd /www/app && mix compile` — clean re: `table_toolbar.ex`. (Confirm core modules `...Core.Modal`, `...Core.Select`, `...Core.Icon` export `modal/1`, `select/1`, `icon/1` — they're used elsewhere in this module already.)
+
+- [ ] **Step 3: Commit.**
+```bash
+git add lib/phoenix_kit_catalogue/web/table_toolbar.ex
+git commit -m "Add TableToolbar column-settings modal and toolbar controls"
+```
+
+> No runtime UI test here — the components render only once wired into `CataloguesLive` (Task 6+). Compilation + attr validation is the gate.
+
+---
+
+## Task 5: `CataloguesLive` — view-config state + shared event handlers
+
+This task adds the state plumbing and event handlers WITHOUT yet changing the table renders. After it, the LV holds per-scope config and reacts to toolbar events; the tables still render as before (next tasks switch them over).
+
+**Files:**
+- Modify: `lib/phoenix_kit_catalogue/web/catalogues_live.ex` (mount, new handlers, helpers)
+
+**Interfaces:**
+- Consumes: `ViewConfig.load/2`, `ViewConfig.save/3`, `TableConfig`, `TableQuery`.
+- Produces (assigns other tasks rely on):
+  - `@view_configs :: %{catalogues: cfg, suppliers: cfg, manufacturers: cfg}` (cfg = atom-keyed map from ViewConfig)
+  - `@show_column_modal :: boolean`, `@temp_columns :: [id] | nil`
+  - helpers: `active_scope(assigns) :: atom`, `current_cfg(assigns) :: cfg`, `put_cfg(socket, scope, cfg) :: socket` (assigns + persists)
+
+- [ ] **Step 1: Add scope mapping + mount load.** In `mount/3`, after existing assigns, add:
+
+```elixir
+|> assign(:view_configs, load_view_configs(socket))
+|> assign(:show_column_modal, false)
+|> assign(:temp_columns, nil)
+```
+
+And helpers (place near `tab_title/1`):
+
+```elixir
+# Maps the active UI tab to a TableConfig/ViewConfig scope.
+defp active_scope(%{assigns: a}), do: active_scope(a)
+defp active_scope(%{active_tab: :index}), do: :catalogues
+defp active_scope(%{active_tab: :manufacturers}), do: :manufacturers
+defp active_scope(%{active_tab: :suppliers}), do: :suppliers
+
+defp load_view_configs(socket) do
+  user = socket.assigns[:phoenix_kit_current_user]
+  Map.new([:catalogues, :suppliers, :manufacturers], fn scope ->
+    {scope, PhoenixKitCatalogue.Web.ViewConfig.load(user, scope)}
+  end)
+end
+
+defp current_cfg(assigns), do: Map.fetch!(assigns.view_configs, active_scope(assigns))
+
+# Update one scope's cfg in assigns AND persist to the user row.
+defp put_cfg(socket, scope, cfg) do
+  user = socket.assigns[:phoenix_kit_current_user]
+  _ = PhoenixKitCatalogue.Web.ViewConfig.save(user, scope, cfg)
+  assign(socket, :view_configs, Map.put(socket.assigns.view_configs, scope, cfg))
+end
+```
+
+- [ ] **Step 2: Add the toolbar/column event handlers.** Place with the other `handle_event/3` clauses:
+
+```elixir
+@impl true
+def handle_event("show_column_modal", _p, socket) do
+  {:noreply, assign(socket, show_column_modal: true, temp_columns: current_cfg(socket.assigns).columns)}
+end
+
+def handle_event("hide_column_modal", _p, socket),
+  do: {:noreply, assign(socket, show_column_modal: false, temp_columns: nil)}
+
+def handle_event("add_column", %{"column_id" => id}, socket) do
+  {:noreply, update(socket, :temp_columns, &((&1 || []) ++ [id]))}
+end
+
+def handle_event("remove_column", %{"column_id" => id}, socket) do
+  {:noreply, update(socket, :temp_columns, &Enum.reject(&1 || [], fn c -> c == id end))}
+end
+
+def handle_event("reorder_columns", params, socket) do
+  ids = parse_order(params)
+  {:noreply, assign(socket, :temp_columns, ids)}
+end
+
+def handle_event("reset_columns", _p, socket) do
+  {:noreply, assign(socket, :temp_columns, PhoenixKitCatalogue.Web.TableConfig.default_columns(active_scope(socket.assigns)))}
+end
+
+def handle_event("apply_columns", params, socket) do
+  scope = active_scope(socket.assigns)
+  ids = PhoenixKitCatalogue.Web.TableConfig.validate_columns(scope, parse_order(params) || socket.assigns.temp_columns || [])
+  ids = if ids == [], do: PhoenixKitCatalogue.Web.TableConfig.default_columns(scope), else: ids
+  cfg = %{current_cfg(socket.assigns) | columns: ids}
+  cfg = if cfg.sort_by in ids, do: cfg, else: %{cfg | sort_by: List.first(ids)}
+  {:noreply, socket |> put_cfg(scope, cfg) |> assign(show_column_modal: false, temp_columns: nil)}
+end
+
+def handle_event("set_sort", %{"sort_by" => by}, socket) do
+  scope = active_scope(socket.assigns)
+  {:noreply, put_cfg(socket, scope, %{current_cfg(socket.assigns) | sort_by: by})}
+end
+
+def handle_event("flip_sort_dir", _p, socket) do
+  scope = active_scope(socket.assigns)
+  cfg = current_cfg(socket.assigns)
+  {:noreply, put_cfg(socket, scope, %{cfg | sort_dir: flip(cfg.sort_dir)})}
+end
+
+def handle_event("toggle_sort", %{"by" => by}, socket) do
+  scope = active_scope(socket.assigns)
+  cfg = current_cfg(socket.assigns)
+  dir = if cfg.sort_by == by, do: flip(cfg.sort_dir), else: :asc
+  {:noreply, put_cfg(socket, scope, %{cfg | sort_by: by, sort_dir: dir})}
+end
+
+def handle_event("set_filter", %{"column_id" => id, "value" => val}, socket) do
+  scope = active_scope(socket.assigns)
+  cfg = current_cfg(socket.assigns)
+  filters = if val in [nil, "", "all"], do: Map.delete(cfg.filters, id), else: Map.put(cfg.filters, id, val)
+  {:noreply, put_cfg(socket, scope, %{cfg | filters: filters})}
+end
+
+def handle_event("clear_filter", %{"column_id" => id}, socket) do
+  scope = active_scope(socket.assigns)
+  cfg = current_cfg(socket.assigns)
+  {:noreply, put_cfg(socket, scope, %{cfg | filters: Map.delete(cfg.filters, id)})}
+end
+
+def handle_event("set_view", %{"view" => v}, socket) when v in ["table", "card"] do
+  scope = active_scope(socket.assigns)
+  {:noreply, put_cfg(socket, scope, %{current_cfg(socket.assigns) | view: v})}
+end
+```
+
+Helpers:
+```elixir
+defp flip(:asc), do: :desc
+defp flip(_), do: :asc
+
+# SortableGrid sends "ordered_ids"/"order" (list) or "column_order" (csv).
+defp parse_order(%{"ordered_ids" => ids}) when is_list(ids), do: ids
+defp parse_order(%{"order" => ids}) when is_list(ids), do: ids
+defp parse_order(%{"column_order" => csv}) when is_binary(csv), do: String.split(csv, ",", trim: true)
+defp parse_order(_), do: nil
+```
+
+> NOTE: the existing `"search"` handler currently drives the GLOBAL ITEM search. It is repurposed in Task 7 (catalogues). For suppliers/manufacturers (Task 6) the search filters the table. To avoid a clash, Task 6/7 introduce a single `"table_search"` event for the toolbar search and remove the old global-search `"search"` handler in Task 7.
+
+- [ ] **Step 3: Compile via the app.** `cd /www/app && mix compile` — clean. (Handlers are unused until renders call them — that's fine; Elixir won't warn on handle_event clauses.)
+
+- [ ] **Step 4: Commit.**
+```bash
+git add lib/phoenix_kit_catalogue/web/catalogues_live.ex
+git commit -m "Wire per-scope view-config state and toolbar event handlers in CataloguesLive"
+```
+
+---
+
+## Task 6: Suppliers + Manufacturers — dynamic columns, toolbar, card view
+
+Suppliers and manufacturers are structurally identical; build ONE shared render helper `simple_table/1` (private to `catalogues_live.ex`) driven by scope + the visible columns, and a shared toolbar. Replace `manufacturers_table/1` and `suppliers_table/1`.
+
+**Files:**
+- Modify: `lib/phoenix_kit_catalogue/web/catalogues_live.ex`
+
+**Interfaces:**
+- Consumes: Task 5 assigns/handlers; `TableConfig`, `TableQuery`, `TableToolbar`; core `<.table_default>`.
+- Produces: `simple_table/1` + `table_toolbar/1` private components reused by Task 7.
+
+- [ ] **Step 1: Import the toolbar + add the derived-rows helper.** Add to imports:
+```elixir
+import PhoenixKitCatalogue.Web.TableToolbar
+```
+Add helper:
+```elixir
+# Visible columns (col maps) for a scope per the user's cfg, in order.
+defp visible_columns(scope, cfg) do
+  map = PhoenixKitCatalogue.Web.TableConfig.column_map(scope)
+  (["name"] ++ cfg.columns) |> Enum.uniq() |> Enum.map(&map[&1]) |> Enum.reject(&is_nil/1)
+end
+
+# Apply search/filter/sort to a raw list for the active scope.
+defp derive_rows(rows, scope, cfg) do
+  PhoenixKitCatalogue.Web.TableQuery.apply(rows, scope,
+    %{search: cfg[:search] || "", filters: cfg.filters, sort_by: cfg.sort_by, sort_dir: cfg.sort_dir})
+end
+```
+(Add a transient `:search` key into cfg in assigns — it is NOT persisted; keep it only in the in-memory cfg. Adjust `ViewConfig.save` already ignores unknown keys since it serializes explicit keys; confirm `:search` is never written. It isn't — `save/3` only writes columns/sort/filters/view.)
+
+Add the `"table_search"` handler (used by the toolbar search for all scopes):
+```elixir
+def handle_event("table_search", %{"query" => q}, socket) do
+  scope = active_scope(socket.assigns)
+  cfg = Map.put(current_cfg(socket.assigns), :search, q)
+  {:noreply, assign(socket, :view_configs, Map.put(socket.assigns.view_configs, scope, cfg))}
+end
+```
+(Search is not persisted, so update assigns directly — do not call `put_cfg`.)
+
+- [ ] **Step 2: Add the shared toolbar component** (private function component in the LV):
+```elixir
+attr :scope, :atom, required: true
+attr :cfg, :map, required: true
+attr :rows, :list, required: true
+slot :filters
+slot :actions
+
+defp table_toolbar(assigns) do
+  ~H"""
+  <div class="flex flex-wrap items-center gap-2 mb-3">
+    <form phx-change="table_search" class="contents">
+      <label class="input input-sm w-full sm:w-64">
+        <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
+        <input type="search" name="query" value={@cfg[:search] || ""} phx-debounce="300"
+               placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search...")} class="grow" />
+      </label>
+    </form>
+    {render_slot(@filters)}
+    <div class="flex-1"></div>
+    <.sort_controls scope={@scope} selected={@cfg.columns} sort_by={@cfg.sort_by} sort_dir={@cfg.sort_dir} />
+    <button type="button" phx-click="show_column_modal" class="btn btn-outline btn-sm">
+      <.icon name="hero-adjustments-horizontal" class="w-4 h-4" />
+      <span class="hidden sm:inline">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Columns")}</span>
+    </button>
+    {render_slot(@actions)}
+  </div>
+  """
+end
+```
+
+- [ ] **Step 3: Add the generic `simple_table/1`** (table+card, dynamic columns). It renders `name` as a link via a passed `edit_path` fn, other cells via `render_cell/3`, and actions via a slot.
+```elixir
+attr :scope, :atom, required: true
+attr :cfg, :map, required: true
+attr :rows, :list, required: true
+attr :empty, :string, required: true
+slot :row_actions, required: true   # :let={row}
+slot :card_actions, required: true  # :let={row}
+
+defp simple_table(assigns) do
+  assigns = assign(assigns, :cols, visible_columns(assigns.scope, assigns.cfg))
+
+  ~H"""
+  <div :if={@rows == []} class="card bg-base-100 shadow">
+    <div class="card-body items-center text-center py-12">
+      <p class="text-base-content/60">{@empty}</p>
+    </div>
+  </div>
+
+  <.table_default :if={@rows != []}
+    id={"#{@scope}-table"} variant="zebra" size="sm" toggleable view_mode={@cfg.view}
+    view_event="set_view" items={@rows}
+    card_fields={fn row -> for c <- @cols, c.id != "name", do:
+      %{label: c.label.(), value: render_card_value(@scope, c.id, row)} end}>
+    <.table_default_header>
+      <.table_default_row>
+        <.table_default_header_cell :for={c <- @cols} class={c.align == :right && "text-right"}>
+          <.sort_header :if={c.sortable?} by={c.id} label={c.label.()} sort_by={@cfg.sort_by} sort_dir={@cfg.sort_dir} align={c.align} />
+          <span :if={!c.sortable?}>{c.label.()}</span>
+        </.table_default_header_cell>
+        <.table_default_header_cell class="text-right">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</.table_default_header_cell>
+      </.table_default_row>
+    </.table_default_header>
+    <.table_default_body>
+      <.table_default_row :for={row <- @rows}>
+        <.table_default_cell :for={c <- @cols} class={c.align == :right && "text-right"}>
+          {render_cell(@scope, c.id, row)}
+        </.table_default_cell>
+        <.table_default_cell class="text-right whitespace-nowrap">{render_slot(@row_actions, row)}</.table_default_cell>
+      </.table_default_row>
+    </.table_default_body>
+    <:card_header :let={row}>{render_cell(@scope, "name", row)}</:card_header>
+    <:card_actions :let={row}>{render_slot(@card_actions, row)}</:card_actions>
+  </.table_default>
+  """
+end
+```
+
+- [ ] **Step 4: Add `sort_header/1`, `render_cell/3`, `render_card_value/3`** for suppliers/manufacturers columns:
+```elixir
+attr :by, :string, required: true
+attr :label, :string, required: true
+attr :sort_by, :string, required: true
+attr :sort_dir, :atom, required: true
+attr :align, :atom, default: :left
+
+defp sort_header(assigns) do
+  assigns = assign(assigns, :active?, assigns.sort_by == assigns.by)
+  ~H"""
+  <button type="button" phx-click="toggle_sort" phx-value-by={@by}
+    class={["inline-flex items-center gap-1 cursor-pointer select-none", @align == :right && "justify-end w-full"]}>
+    <span>{@label}</span>
+    <.icon :if={@active?} name={if @sort_dir == :asc, do: "hero-chevron-up-mini", else: "hero-chevron-down-mini"} class="w-3.5 h-3.5" />
+  </button>
+  """
+end
+
+# Table cells (may contain links). Suppliers/manufacturers:
+defp render_cell(scope, "name", row) when scope in [:suppliers, :manufacturers] do
+  path = if scope == :suppliers, do: Paths.supplier_edit(row.uuid), else: Paths.manufacturer_edit(row.uuid)
+  assigns = %{path: path, name: row.name}
+  ~H"""<.link navigate={@path} class="link link-hover font-medium">{@name}</.link>"""
+end
+
+defp render_cell(_scope, "website", row), do: website_cell(row.website)
+defp render_cell(_scope, "contact_info", row), do: text_or_dash(row.contact_info)
+defp render_cell(_scope, "status", row), do: status_badge_cell(row.status)
+defp render_cell(_scope, "updated", row), do: ts(row.updated_at)
+
+defp render_card_value(_scope, "website", row), do: row.website || "—"
+defp render_card_value(_scope, "status", row), do: status_label(row.status)
+defp render_card_value(_scope, "contact_info", row), do: row.contact_info || "—"
+defp render_card_value(_scope, "updated", row), do: ts_str(row.updated_at)
+defp render_card_value(_scope, _id, _row), do: "—"
+```
+Small render helpers:
+```elixir
+defp website_cell(nil), do: ~H""
+defp website_cell(url) do
+  assigns = %{url: url}
+  ~H"""<span class="text-sm text-base-content/60">{@url}</span>"""
+end
+defp text_or_dash(nil), do: ~H"""<span class="text-base-content/40">—</span>"""
+defp text_or_dash(v), do: (assigns = %{v: v}; ~H"""<span class="text-sm">{@v}</span>""")
+defp status_badge_cell(status), do: (assigns = %{status: status}; ~H"""<.status_badge status={@status} size={:sm} />""")
+defp ts(nil), do: ~H"""<span class="text-base-content/40">—</span>"""
+defp ts(dt), do: (assigns = %{dt: dt}; ~H"""<span class="text-sm text-base-content/60">{Calendar.strftime(@dt, "%Y-%m-%d %H:%M")}</span>""")
+defp ts_str(nil), do: "—"
+defp ts_str(dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+```
+
+- [ ] **Step 5: Replace the manufacturers/suppliers tab render** in `render/1`. For each, derive rows + render toolbar + simple_table + the column modal. Manufacturers example (suppliers identical with `:suppliers`, `@suppliers`, supplier paths/labels):
+```heex
+<div :if={@active_tab == :manufacturers and is_nil(@search_results)} class="flex flex-col gap-4">
+  <% cfg = @view_configs.manufacturers %>
+  <.table_toolbar scope={:manufacturers} cfg={cfg} rows={@manufacturers}>
+    <:filters>
+      <.enum_filter id="status" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
+        value={cfg.filters["status"]} prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All statuses")}
+        options={PhoenixKitCatalogue.Web.TableQuery.enum_options(@manufacturers, :manufacturers, "status")} />
+    </:filters>
+    <:actions>
+      <.link navigate={Paths.manufacturer_new()} class="btn btn-primary btn-sm">
+        <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Manufacturer")}
+      </.link>
+    </:actions>
+  </.table_toolbar>
+  <.simple_table scope={:manufacturers} cfg={cfg} rows={derive_rows(@manufacturers, :manufacturers, cfg)}
+    empty={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No manufacturers yet.")}>
+    <:row_actions :let={m}>
+      <.table_row_menu mode="auto" id={"mfg-menu-#{m.uuid}"}>
+        <.table_row_menu_link navigate={Paths.manufacturer_edit(m.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} />
+        <.table_row_menu_divider />
+        <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
+      </.table_row_menu>
+    </:row_actions>
+    <:card_actions :let={m}>
+      <.link navigate={Paths.manufacturer_edit(m.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}</.link>
+      <button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}</button>
+    </:card_actions>
+  </.simple_table>
+</div>
+```
+Then add the column modal once near the end of `render/1` (shared across tabs):
+```heex
+<.column_settings_modal show={@show_column_modal} scope={active_scope(assigns)}
+  selected={current_cfg(assigns).columns} temp_selected={@temp_columns} />
+```
+Delete the old `manufacturers_table/1` and `suppliers_table/1` defs.
+
+- [ ] **Step 6: Compile via the app + restart + runtime verify.**
+  - `cd /www/app && mix compile` clean.
+  - Restart elixir; HTTP 200.
+  - Headless browser (logged-in admin) on `/admin/catalogue/manufacturers` and `/suppliers`: toolbar shows search/status-filter/sort/Columns/view-toggle/New button; toggling a column in the modal hides/shows it and persists across reload; sort + filter + search work in table and card view.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add lib/phoenix_kit_catalogue/web/catalogues_live.ex
+git commit -m "Apply table toolbar + dynamic columns + card view to suppliers and manufacturers"
+```
+
+---
+
+## Task 7: Catalogues index — flat table, folder filter/column, remove tree + global search
+
+**Files:**
+- Modify: `lib/phoenix_kit_catalogue/web/catalogues_live.ex`
+
+**Interfaces:**
+- Consumes: Task 5/6 helpers; folder context (`list_folder_tree/1`, `catalogues_by_folder/1`, `item_counts_by_catalogue/0`).
+- Produces: flat `@catalogue_rows` (enriched maps with `:folder_uuid`, `:folder_name`, `:item_count`).
+
+- [ ] **Step 1: Build enriched flat catalogue rows in `load_data(:index)`** (replace tree building). Each row = the `%Catalogue{}` enriched into a map the table/cells use. Add helper:
+```elixir
+defp build_catalogue_rows(catalogues, folder_lookup, item_counts) do
+  Enum.map(catalogues, fn c ->
+    c
+    |> Map.from_struct()
+    |> Map.put(:folder_uuid, c.folder_uuid)
+    |> Map.put(:folder_name, c.folder_uuid && folder_lookup[c.folder_uuid] && folder_lookup[c.folder_uuid].name)
+    |> Map.put(:item_count, Map.get(item_counts, c.uuid, 0))
+  end)
+end
+```
+Build `folder_lookup = Map.new(list_folder_tree(), fn {f, _depth} -> {f.uuid, f} end)` and a flat catalogue list (active vs deleted per `@catalogue_view_mode`) from `catalogues_by_folder/1` values, assign `:catalogue_rows`.
+
+- [ ] **Step 2: Add catalogue-specific `render_cell/3` + `render_card_value/3` clauses** (name link, folder, items, status, kind, markup, discount, updated, created). E.g.:
+```elixir
+defp render_cell(:catalogues, "name", row) do
+  assigns = %{row: row}
+  ~H"""
+  <.link :if={@row.status != "deleted"} navigate={Paths.catalogue_detail(@row.uuid)} class="link link-hover font-medium">{@row.name}</.link>
+  <span :if={@row.status == "deleted"} class="font-medium text-base-content/50">{@row.name}</span>
+  """
+end
+defp render_cell(:catalogues, "folder", row), do: text_or_dash(row[:folder_name])
+defp render_cell(:catalogues, "items", row), do: (assigns = %{n: row[:item_count] || 0}; ~H"""<span class="tabular-nums">{@n}</span>""")
+defp render_cell(:catalogues, "kind", row), do: text_or_dash(row.kind)
+defp render_cell(:catalogues, "markup", row), do: pct(row.markup_percentage)
+defp render_cell(:catalogues, "discount", row), do: pct(row.discount_percentage)
+defp render_cell(:catalogues, "created", row), do: ts(row.inserted_at)
+# status/updated reuse the generic clauses from Task 6.
+defp render_card_value(:catalogues, "folder", row), do: row[:folder_name] || "—"
+defp render_card_value(:catalogues, "items", row), do: to_string(row[:item_count] || 0)
+defp render_card_value(:catalogues, "kind", row), do: row.kind || "—"
+defp render_card_value(:catalogues, "markup", row), do: pct_str(row.markup_percentage)
+defp render_card_value(:catalogues, "discount", row), do: pct_str(row.discount_percentage)
+defp render_card_value(:catalogues, "created", row), do: ts_str(row.inserted_at)
+```
+With `pct/1`/`pct_str/1` formatting Decimals (reuse `format_decimal_display` if available, else `Decimal.to_string`).
+
+- [ ] **Step 3: Replace the index tab render.** Keep the Active/Deleted sub-tabs block as-is. Below it, render the toolbar (with Folder + Status filters and the catalogue action buttons + a "Folders" button) and `simple_table` with the catalogue row actions. Catalogue row_actions/card_actions reuse the existing menu items (View/Edit/Move to folder/Delete; or Restore/Delete-forever in deleted mode). Folder filter:
+```heex
+<.enum_filter id="folder" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folder")}
+  value={cfg.filters["folder"]} prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All folders")}
+  options={PhoenixKitCatalogue.Web.TableQuery.enum_options(@catalogue_rows, :catalogues, "folder")} />
+```
+Toolbar actions: `New Folder` (existing `new_folder`), `New Catalogue` (`Paths.catalogue_new()`), and a `Folders…` button (`phx-click="show_folders_modal"`).
+
+- [ ] **Step 4: Remove the dead code.** Delete `folder_tree_table/1`; delete the global item-search block in the index render (the search input + `@search_results`/`@search_loading`/infinite-scroll-for-search markup); remove the old `"search"`, search-pagination, and `CatalogueTreeDnD`-related handlers/assigns that are now unused. Grep to confirm no remaining references: `grep -n "search_results\|folder_tree_table\|CatalogueTreeDnD\|search_has_more" lib/phoenix_kit_catalogue/web/catalogues_live.ex` → only intentional ones (none).
+
+- [ ] **Step 5: Compile + restart + runtime verify.**
+  - `cd /www/app && mix compile` clean (watch for "unused" warnings from removed handlers — remove their helpers too).
+  - Restart; HTTP 200.
+  - Browser `/admin/catalogue`: flat table; Active/Deleted toggle works; Folder filter narrows; Folder/Items/Status/Updated columns; column modal persists; sort works; card view shows folder/items/status; "Move to folder" still in row menu; no global item-search box; no JS console errors from the removed DnD hook.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add lib/phoenix_kit_catalogue/web/catalogues_live.ex
+git commit -m "Flatten catalogues index to a sortable table with folder filter; remove tree and global item search"
+```
+
+---
+
+## Task 8: Folders management modal
+
+**Files:**
+- Modify: `lib/phoenix_kit_catalogue/web/catalogues_live.ex`
+
+**Interfaces:**
+- Consumes: existing folder context functions (`create_folder/2`, `update_folder/3`, `move_folder/3`, `trash_folder/2`, `restore_folder/2`, `permanently_delete_folder/2`, `list_folder_tree/1`) and existing folder event handlers where present.
+
+- [ ] **Step 1: Add modal state + open/close handlers.**
+```elixir
+# in mount: |> assign(:show_folders_modal, false)
+def handle_event("show_folders_modal", _p, socket), do: {:noreply, assign(socket, :show_folders_modal, true)}
+def handle_event("hide_folders_modal", _p, socket), do: {:noreply, assign(socket, :show_folders_modal, false)}
+```
+
+- [ ] **Step 2: Add the modal render** (folder tree list with per-row actions). Reuse the existing folder event names (`new_folder`, `new_subfolder`, `start_rename_folder`/`rename_folder`, `open_move`, `trash_folder`, `restore_folder`, `show_delete_confirm`) so their handlers are unchanged. A compact indented list built from `@active_tree`/`list_folder_tree/1`, each row: name (rename inline), New subfolder, Move, Trash/Restore, Delete-forever — mirroring the row menus the tree had. Place inside `render/1` near the column modal:
+```heex
+<.modal :if={@show_folders_modal} id="catalogue-folders-modal" show on_cancel={JS.push("hide_folders_modal")}>
+  <h3 class="text-lg font-semibold mb-3">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folders")}</h3>
+  <!-- indented folder list with the action buttons listed above -->
+</.modal>
+```
+
+- [ ] **Step 3: Compile + restart + runtime verify.** Folder create/rename/subfolder/move/trash/restore/delete all work from the modal; the catalogue table's Folder filter/column reflect changes after the action (PubSub reload already wired).
+
+- [ ] **Step 4: Commit.**
+```bash
+git add lib/phoenix_kit_catalogue/web/catalogues_live.ex
+git commit -m "Add Folders management modal to catalogues index"
+```
+
+---
+
+## Task 9: Gettext strings
+
+**Files:**
+- Modify: `priv/gettext/default.pot`, `priv/gettext/{en,ru,et}/LC_MESSAGES/default.po`
+
+- [ ] **Step 1: Add new msgids** (single form each), manually, mirroring an existing entry's block format. Strings to add (en = msgid; ru/et translations):
+
+| msgid | ru | et |
+|-------|----|----|
+| `Columns` | Колонки | Veerud |
+| `Shown` | Показаны | Näidatud |
+| `Available` | Доступные | Saadaval |
+| `Reset` | Сбросить | Lähtesta |
+| `Apply` | Применить | Rakenda |
+| `Toggle sort direction` | Сменить направление сортировки | Muuda sortimissuunda |
+| `Folder` | Папка | Kaust |
+| `Folders` | Папки | Kaustad |
+| `All folders` | Все папки | Kõik kaustad |
+| `All statuses` | Все статусы | Kõik staatused |
+| `Kind` | Вид | Tüüp |
+| `Markup %` | Наценка % | Juurdehindlus % |
+| `Discount %` | Скидка % | Allahindlus % |
+| `Created` | Создан | Loodud |
+| `Contact Info` | Контакты | Kontaktandmed |
+| `New Manufacturer` | (existing — verify) | |
+| `New Supplier` | (existing — verify) | |
+
+(Verify which already exist with `grep -n '^msgid "X"' priv/gettext/ru/LC_MESSAGES/default.po` before adding — do not duplicate.)
+
+- [ ] **Step 2: Verify renders on live node** (after restart) via Tidewave:
+```elixir
+Gettext.put_locale(PhoenixKitCatalogue.Gettext, "ru")
+Enum.map(["Columns","Folder","Kind","Markup %","All folders"], &Gettext.gettext(PhoenixKitCatalogue.Gettext, &1))
+```
+Expected: `["Колонки","Папка","Вид","Наценка %","Все папки"]`
+
+- [ ] **Step 3: Commit.**
+```bash
+git add priv/gettext
+git commit -m "Add gettext strings for catalogue table toolbar and columns"
+```
+
+---
+
+## Task 10: Final integration verification
+
+- [ ] **Step 1: Full clean compile.** `cd /www/app && mix compile` — zero new warnings attributable to catalogue files.
+- [ ] **Step 2: Restart + boot check.** `sudo /usr/bin/supervisorctl restart elixir`; wait for "Running AndiWeb.Endpoint"; HTTP 200 on `/`.
+- [ ] **Step 3: Cross-table runtime sweep (headless browser, logged-in admin):**
+  - `/admin/catalogue`: flat table, Active/Deleted, folder filter+column, column modal persists across reload, sort (header + select), card view, Folders modal CRUD, Move-to-folder, no global item search, no JS errors.
+  - `/admin/catalogue/suppliers` & `/manufacturers`: toolbar, status filter, sort, search, column modal persists, card view, New button.
+  - Persistence cross-session: change columns, reconnect (reload) — choice retained; verify via a second admin user that defaults differ per user.
+- [ ] **Step 4: Mobile check (headless, narrow viewport):** no horizontal overflow on all three pages (per daisyUI 5 memory — `min-w-0` on flex children if needed).
+- [ ] **Step 5: Self-review against the spec** (`dev_docs/2026-06-27-catalogue-table-stack-design.md`): every decision covered; no regressions in folder management vs the old tree.
+- [ ] **Step 6:** No final commit needed if Tasks 1-9 each committed; otherwise commit any verification fixes.
+
+---
+
+## Self-Review (plan vs spec)
+
+- **Spec coverage:** toolbar (T6/T7), card view (T6/T7), column management (T1/T4/T5), sorting (T1/T5/T6), filtering (T2/T6/T7), per-user persistence (T3/T5), flat catalogues + folder filter/column (T7), Folders modal full CRUD (T8), remove tree+DnD+global search (T7), Active/Deleted retained (T7), suppliers/manufacturers (T6), i18n (T9), verification incl. mobile (T10). All covered.
+- **Placeholders:** none — pure modules have full code; HEEx renders give exact component calls and representative cells (the repetitive cells follow the shown `render_cell/3` pattern).
+- **Type consistency:** cfg is atom-keyed in-memory (`%{columns, sort_by, sort_dir, filters, view}`) everywhere; `:search` is a transient cfg key never persisted; `scope` atoms `:catalogues/:suppliers/:manufacturers`; event names consistent (`set_view`/`view_event="set_view"`, `table_search`, `toggle_sort`/`set_sort`/`flip_sort_dir`, `*_column(s)`).
+- **Watch-item:** confirm core `<.table_default>` supports `view_mode` + `view_event` controlled mode (researcher confirmed). If an older core build lacks it, fall back to default JS-hook toggle and persist view via a `set_view` button instead — verify in T6 Step 6.

--- a/lib/phoenix_kit_catalogue/export.ex
+++ b/lib/phoenix_kit_catalogue/export.ex
@@ -19,7 +19,6 @@ defmodule PhoenixKitCatalogue.Export do
 
   import Ecto.Query, warn: false
 
-  alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Schemas.{Category, Item}
 
   defp repo, do: PhoenixKit.RepoHelper.repo()
@@ -114,18 +113,18 @@ defmodule PhoenixKitCatalogue.Export do
     prefix_catalogue = Map.get(params, :prefix_catalogue, false) in [true, "true", "on", "1"]
 
     destination_mod =
-      destination_by_key(to_atom(destination_key)) ||
+      destination_by_key(destination_key) ||
         raise ArgumentError, "unknown export destination: #{inspect(destination_key)}"
 
-    format_atom = to_atom(format_key)
+    format_atom = safe_atom(format_key)
 
-    unless Enum.any?(destination_mod.formats(), fn {k, _} -> k == format_atom end) do
+    unless format_atom && Enum.any?(destination_mod.formats(), fn {k, _} -> k == format_atom end) do
       raise ArgumentError,
             "unknown format #{inspect(format_key)} for destination #{inspect(destination_mod.key())}"
     end
 
     items = list_export_items(catalogue_uuids)
-    catalogues = Enum.map(catalogue_uuids, &Catalogue.get_catalogue!/1)
+    catalogues = list_catalogue_headers(catalogue_uuids)
 
     ctx = %{
       items: items,
@@ -141,6 +140,23 @@ defmodule PhoenixKitCatalogue.Export do
   # Helpers
   # ---------------------------------------------------------------------------
 
-  defp to_atom(value) when is_atom(value), do: value
-  defp to_atom(value) when is_binary(value), do: String.to_existing_atom(value)
+  defp safe_atom(value) when is_atom(value), do: value
+
+  defp safe_atom(value) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> nil
+  end
+
+  # Lightweight catalogue headers (uuid + name only) for the export context.
+  # Avoids Catalogue.get_catalogue!/1, which preloads the whole category+item
+  # tree per catalogue — items are already loaded by list_export_items/1.
+  defp list_catalogue_headers(catalogue_uuids) do
+    from(c in PhoenixKitCatalogue.Schemas.Catalogue,
+      where: c.uuid in ^catalogue_uuids,
+      order_by: c.name,
+      select: %{uuid: c.uuid, name: c.name}
+    )
+    |> repo().all()
+  end
 end

--- a/lib/phoenix_kit_catalogue/export/universal_json.ex
+++ b/lib/phoenix_kit_catalogue/export/universal_json.ex
@@ -77,7 +77,9 @@ defmodule PhoenixKitCatalogue.Export.UniversalJson do
 
   defp sanitize_filename(name) when is_binary(name) do
     name
-    |> String.replace(~r/[^\w\s-]/, "")
+    # `u` flag keeps Unicode word chars (Cyrillic, etc.); without it `\w` is
+    # ASCII-only and would strip a whole Cyrillic catalogue name.
+    |> String.replace(~r/[^\w\s-]/u, "")
     |> String.replace(~r/\s+/, "_")
     |> String.trim("_")
   end

--- a/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_detail_live.ex
@@ -17,7 +17,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   require Logger
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
   import PhoenixKitWeb.Components.Core.Pagination, only: [load_more: 1]
@@ -81,6 +80,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
     "created_asc" => :created_asc,
     "reverse" => :reverse
   }
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(%{"uuid" => uuid}, _session, socket) do
@@ -1927,58 +1936,63 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col w-full px-4 py-6 gap-6">
-      <%!-- Loading state --%>
-      <div :if={is_nil(@catalogue)} class="flex justify-center py-12">
-        <span class="loading loading-spinner loading-lg"></span>
-      </div>
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      current_path={assigns[:url_path] || Paths.index()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col w-full px-4 py-6 gap-6">
+        <%!-- Loading state --%>
+        <div :if={is_nil(@catalogue)} class="flex justify-center py-12">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
 
-      <div :if={@catalogue} class="flex flex-col gap-6">
-        <%!-- Header --%>
-        <%!-- The title doubles as the breadcrumb trail: at root it's just
-             the catalogue name; drilled in it's `Catalogue › … › Current`
-             with the ancestors as muted patch links and the current node
-             as the bold end. `@breadcrumb` is trimmed to the active
-             ancestor chain in Active mode, so an orphan never links to a
-             deleted ancestor. --%>
-        <.admin_page_header>
-          <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content flex flex-wrap items-center gap-x-2 gap-y-1">
-            <%= if @current_category == nil do %>
-              {@catalogue.name}
-            <% else %>
-              <.link
-                patch={Paths.catalogue_detail(@catalogue.uuid)}
-                class="font-normal text-base-content/50 hover:text-primary"
-              >
-                {@catalogue.name}
-              </.link>
-              <%= for cat <- @breadcrumb do %>
-                <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+        <div :if={@catalogue} class="flex flex-col gap-6">
+          <%!-- In-body header: breadcrumb when drilled into a category
+               (catalogue name now lives in the global admin header); action
+               buttons whenever the view is active. --%>
+          <div
+            :if={@view_mode == "active" or @current_category != nil}
+            class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3"
+          >
+            <div :if={@current_category != nil} class="min-w-0">
+              <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content flex flex-wrap items-center gap-x-2 gap-y-1">
                 <.link
-                  patch={Paths.category_browse(@catalogue.uuid, cat.uuid)}
+                  patch={Paths.catalogue_detail(@catalogue.uuid)}
                   class="font-normal text-base-content/50 hover:text-primary"
                 >
-                  {cat.name}
+                  {@catalogue.name}
                 </.link>
-              <% end %>
-              <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
-              <span class="truncate">{current_node_label(@current_category)}</span>
-            <% end %>
-          </h1>
-          <:actions :if={@view_mode == "active"}>
-            <.link navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-outline btn-sm">
-              <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
-            </.link>
-            <.link navigate={Paths.item_new(@catalogue.uuid)} class="btn btn-primary btn-sm">
-              <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Item")}
-            </.link>
-            <.link navigate={Paths.catalogue_edit(@catalogue.uuid)} class="btn btn-ghost btn-sm">
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
-            </.link>
-          </:actions>
-        </.admin_page_header>
+                <%= for cat <- @breadcrumb do %>
+                  <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+                  <.link
+                    patch={Paths.category_browse(@catalogue.uuid, cat.uuid)}
+                    class="font-normal text-base-content/50 hover:text-primary"
+                  >
+                    {cat.name}
+                  </.link>
+                <% end %>
+                <.icon name="hero-chevron-right" class="w-5 h-5 text-base-content/30 shrink-0" />
+                <span class="truncate">{current_node_label(@current_category)}</span>
+              </h1>
+            </div>
+            <div :if={@view_mode == "active"} class="flex flex-wrap items-center gap-2 sm:flex-shrink-0">
+              <.link navigate={Paths.category_new(@catalogue.uuid)} class="btn btn-outline btn-sm">
+                <.icon name="hero-folder-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Category")}
+              </.link>
+              <.link navigate={Paths.item_new(@catalogue.uuid)} class="btn btn-primary btn-sm">
+                <.icon name="hero-plus" class="w-4 h-4" /> {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add Item")}
+              </.link>
+              <.link navigate={Paths.catalogue_edit(@catalogue.uuid)} class="btn btn-ghost btn-sm">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+              </.link>
+            </div>
+          </div>
 
-        <div :if={@catalogue.description} class="-mt-4">
+          <div :if={@catalogue.description} class="-mt-4">
           <p class="text-base-content/60">
             {@catalogue.description}
           </p>
@@ -2462,7 +2476,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueDetailLive do
         item={@pdf_search_item}
         show={@show_pdf_search}
       />
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogue_form_live.ex
@@ -7,7 +7,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.MultilangForm
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
@@ -45,6 +44,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
     "markup_percentage" => :markup_percentage,
     "discount_percentage" => :discount_percentage
   }
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -298,7 +307,16 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
       )
 
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update catalogue details and settings.")}
+      current_path={assigns[:url_path] || Paths.index()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
       <%!-- Media selector — folder-scoped featured-image picker.
            Reconfigured per open; the Files tab below hosts the
            inline dropzone for everything else. --%>
@@ -312,9 +330,6 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
         scope_folder_id={@files_folder_uuid}
         phoenix_kit_current_user={assigns[:phoenix_kit_current_user]}
       />
-
-      <%!-- Header --%>
-      <.admin_page_header back={Paths.index()} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Create a new product catalogue to organize categories and items."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update catalogue details and settings.")} />
 
       <%!-- Tab strip — each panel stays in the DOM (toggled by `hidden`)
            so the multilang wrapper + any user input don't lose state
@@ -709,7 +724,8 @@ defmodule PhoenixKitCatalogue.Web.CatalogueFormLive do
         confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -17,8 +17,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   import PhoenixKitWeb.Components.Core.TableDefault
   import PhoenixKitWeb.Components.Core.TableRowMenu
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
-
   import PhoenixKitCatalogue.Web.Components
 
   import PhoenixKitCatalogue.Web.Helpers,
@@ -29,6 +27,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   alias PhoenixKitCatalogue.Paths
 
   @per_page 100
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(_params, _session, socket) do
@@ -105,6 +113,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Manufacturers")
 
   defp tab_title(:suppliers), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Suppliers")
+
+  defp tab_path(:index), do: Paths.index()
+  defp tab_path(:manufacturers), do: Paths.manufacturers()
+  defp tab_path(:suppliers), do: Paths.suppliers()
 
   # Graceful handler for a delete event that fires while `confirm_delete`
   # is nil (e.g. someone pushed the event without first opening the
@@ -918,11 +930,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col w-full px-4 py-6 gap-6">
-      <%!-- Navigation between Catalogues / Manufacturers / Suppliers lives in
-           the admin sidebar; the page just titles the current view. --%>
-      <.admin_page_header title={tab_title(@active_tab)}>
-        <:actions>
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={tab_title(@active_tab)}
+      current_path={assigns[:url_path] || tab_path(@active_tab)}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col w-full px-4 py-6 gap-6">
+        <div class="flex flex-wrap items-center justify-end gap-2 mb-2">
           <button
             :if={@active_tab == :index && @catalogue_view_mode == "active"}
             type="button"
@@ -942,10 +959,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           <.link :if={@active_tab == :suppliers} navigate={Paths.supplier_new()} class="btn btn-primary btn-sm">
             {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Supplier")}
           </.link>
-        </:actions>
-      </.admin_page_header>
+        </div>
 
-      <%!-- Global search (only on catalogues tab). While a tree row is being
+        <%!-- Global search (only on catalogues tab). While a tree row is being
            dragged, the CatalogueTreeDnD hook swaps the search bar for the
            "move to root" drop target in-place, so the layout doesn't jump. --%>
       <div :if={@active_tab == :index} class="relative">
@@ -1119,10 +1135,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           </div>
         </form>
       </.modal>
-    </div>
+      </div>
 
-    <script>
-      window.PhoenixKitHooks = window.PhoenixKitHooks || {};
+      <script>
+        window.PhoenixKitHooks = window.PhoenixKitHooks || {};
       window.PhoenixKitHooks.InfiniteScroll = window.PhoenixKitHooks.InfiniteScroll || {
         mounted() {
           this.intersecting = false;
@@ -1296,7 +1312,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           this.clearAll();
         }
       };
-    </script>
+      </script>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -18,6 +18,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   import PhoenixKitWeb.Components.Core.TableRowMenu
   import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
   import PhoenixKitCatalogue.Web.Components
+  import PhoenixKitCatalogue.Web.TableToolbar
 
   import PhoenixKitCatalogue.Web.Helpers,
     only: [actor_opts: 1, actor_uuid: 1, log_operation_error: 3, status_label: 1]
@@ -927,9 +928,16 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     end
   end
 
-  def handle_event("set_view", %{"view" => v}, socket) when v in ["table", "card"] do
+  def handle_event("set_view", %{"mode" => v}, socket) when v in ["table", "card"] do
     scope = active_scope(socket.assigns)
     {:noreply, put_cfg(socket, scope, %{current_cfg(socket.assigns) | view: v})}
+  end
+
+  # Transient per-scope text search — NOT persisted via put_cfg.
+  def handle_event("table_search", %{"query" => q}, socket) do
+    scope = active_scope(socket.assigns)
+    cfg = Map.put(current_cfg(socket.assigns), :search, q)
+    {:noreply, assign(socket, :view_configs, Map.put(socket.assigns.view_configs, scope, cfg))}
   end
 
   # ── Search helpers ──────────────────────────────────────────────
@@ -1065,6 +1073,23 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
   # ── View-config helpers ──────────────────────────────────────────
 
+  # Visible columns (col maps) for a scope per the user's cfg, in order.
+  # "name" is always first (it is never managed/hidden).
+  defp visible_columns(scope, cfg) do
+    map = PhoenixKitCatalogue.Web.TableConfig.column_map(scope)
+    (["name"] ++ cfg.columns) |> Enum.uniq() |> Enum.map(&map[&1]) |> Enum.reject(&is_nil/1)
+  end
+
+  # Apply search/filter/sort to a raw list for a scope.
+  defp derive_rows(rows, scope, cfg) do
+    PhoenixKitCatalogue.Web.TableQuery.apply(rows, scope, %{
+      search: cfg[:search] || "",
+      filters: cfg.filters,
+      sort_by: cfg.sort_by,
+      sort_dir: cfg.sort_dir
+    })
+  end
+
   defp flip(:asc), do: :desc
   defp flip(_), do: :asc
 
@@ -1120,12 +1145,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           </button>
           <.link :if={@active_tab == :index && @catalogue_view_mode == "active"} navigate={Paths.catalogue_new()} class="btn btn-primary btn-sm">
             {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Catalogue")}
-          </.link>
-          <.link :if={@active_tab == :manufacturers} navigate={Paths.manufacturer_new()} class="btn btn-primary btn-sm">
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Manufacturer")}
-          </.link>
-          <.link :if={@active_tab == :suppliers} navigate={Paths.supplier_new()} class="btn btn-primary btn-sm">
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Supplier")}
           </.link>
         </div>
 
@@ -1232,12 +1251,123 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         />
       </div>
 
-      <div :if={@active_tab == :manufacturers and is_nil(@search_results)}>
-        <.manufacturers_table manufacturers={@manufacturers} />
+      <div :if={@active_tab == :manufacturers and is_nil(@search_results)} class="flex flex-col gap-4">
+        <% cfg = @view_configs.manufacturers %>
+        <.table_toolbar scope={:manufacturers} cfg={cfg} rows={@manufacturers}>
+          <:filters>
+            <.enum_filter
+              id="status"
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
+              value={cfg.filters["status"]}
+              prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All statuses")}
+              options={PhoenixKitCatalogue.Web.TableQuery.enum_options(@manufacturers, :manufacturers, "status")}
+            />
+          </:filters>
+          <:actions>
+            <.link navigate={Paths.manufacturer_new()} class="btn btn-primary btn-sm">
+              <.icon name="hero-plus" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Manufacturer")}
+            </.link>
+          </:actions>
+        </.table_toolbar>
+        <.simple_table
+          scope={:manufacturers}
+          cfg={cfg}
+          rows={derive_rows(@manufacturers, :manufacturers, cfg)}
+          empty={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No manufacturers yet.")}
+        >
+          <:row_actions :let={m}>
+            <.table_row_menu mode="auto" id={"mfg-menu-#{m.uuid}"}>
+              <.table_row_menu_link
+                navigate={Paths.manufacturer_edit(m.uuid)}
+                icon="hero-pencil"
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+              />
+              <.table_row_menu_divider />
+              <.table_row_menu_button
+                phx-click="show_delete_confirm"
+                phx-value-uuid={m.uuid}
+                phx-value-type="manufacturer"
+                icon="hero-trash"
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+                variant="error"
+              />
+            </.table_row_menu>
+          </:row_actions>
+          <:card_actions :let={m}>
+            <.link navigate={Paths.manufacturer_edit(m.uuid)} class="btn btn-ghost btn-xs">
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+            </.link>
+            <button
+              phx-click="show_delete_confirm"
+              phx-value-uuid={m.uuid}
+              phx-value-type="manufacturer"
+              class="btn btn-ghost btn-xs text-error"
+            >
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+            </button>
+          </:card_actions>
+        </.simple_table>
       </div>
 
-      <div :if={@active_tab == :suppliers and is_nil(@search_results)}>
-        <.suppliers_table suppliers={@suppliers} />
+      <div :if={@active_tab == :suppliers and is_nil(@search_results)} class="flex flex-col gap-4">
+        <% cfg = @view_configs.suppliers %>
+        <.table_toolbar scope={:suppliers} cfg={cfg} rows={@suppliers}>
+          <:filters>
+            <.enum_filter
+              id="status"
+              label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
+              value={cfg.filters["status"]}
+              prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All statuses")}
+              options={PhoenixKitCatalogue.Web.TableQuery.enum_options(@suppliers, :suppliers, "status")}
+            />
+          </:filters>
+          <:actions>
+            <.link navigate={Paths.supplier_new()} class="btn btn-primary btn-sm">
+              <.icon name="hero-plus" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Supplier")}
+            </.link>
+          </:actions>
+        </.table_toolbar>
+        <.simple_table
+          scope={:suppliers}
+          cfg={cfg}
+          rows={derive_rows(@suppliers, :suppliers, cfg)}
+          empty={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No suppliers yet.")}
+        >
+          <:row_actions :let={s}>
+            <.table_row_menu mode="auto" id={"supplier-menu-#{s.uuid}"}>
+              <.table_row_menu_link
+                navigate={Paths.supplier_edit(s.uuid)}
+                icon="hero-pencil"
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+                variant="secondary"
+              />
+              <.table_row_menu_divider />
+              <.table_row_menu_button
+                phx-click="show_delete_confirm"
+                phx-value-uuid={s.uuid}
+                phx-value-type="supplier"
+                icon="hero-trash"
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+                variant="error"
+              />
+            </.table_row_menu>
+          </:row_actions>
+          <:card_actions :let={s}>
+            <.link navigate={Paths.supplier_edit(s.uuid)} class="btn btn-ghost btn-xs">
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+            </.link>
+            <button
+              phx-click="show_delete_confirm"
+              phx-value-uuid={s.uuid}
+              phx-value-type="supplier"
+              class="btn btn-ghost btn-xs text-error"
+            >
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+            </button>
+          </:card_actions>
+        </.simple_table>
       </div>
 
       <.confirm_modal
@@ -1303,6 +1433,13 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           </div>
         </form>
       </.modal>
+
+      <.column_settings_modal
+        show={@show_column_modal}
+        scope={active_scope(assigns)}
+        selected={current_cfg(assigns).columns}
+        temp_selected={@temp_columns}
+      />
       </div>
 
       <script>
@@ -1660,113 +1797,214 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
   defp move_dialog_label(_), do: ""
 
-  defp manufacturers_table(assigns) do
-    ~H"""
-    <div :if={@manufacturers == []} class="card bg-base-100 shadow">
-      <div class="card-body items-center text-center py-12">
-        <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No manufacturers yet.")}</p>
-      </div>
-    </div>
+  # ── Toolbar private component ────────────────────────────────────
 
-    <div :if={@manufacturers != []}>
-      <.table_default
-        variant="zebra" size="sm" toggleable={true}
-        id="manufacturers-list" items={@manufacturers}
-        card_fields={fn m -> [
-          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website"), value: m.website || "—"},
-          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"), value: status_label(m.status)}
-        ] end}
-      >
-        <.table_default_header>
-          <.table_default_row>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</.table_default_header_cell>
-            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</.table_default_header_cell>
-          </.table_default_row>
-        </.table_default_header>
-        <.table_default_body>
-          <.table_default_row :for={m <- @manufacturers}>
-            <.table_default_cell class="font-medium">
-              <.link navigate={Paths.manufacturer_edit(m.uuid)} class="link link-hover">
-                {m.name}
-              </.link>
-            </.table_default_cell>
-            <.table_default_cell class="text-sm text-base-content/60">{m.website}</.table_default_cell>
-            <.table_default_cell><.status_badge status={m.status} size={:sm} /></.table_default_cell>
-            <.table_default_cell class="text-right whitespace-nowrap">
-              <.table_row_menu mode="auto" id={"mfg-menu-#{m.uuid}"}>
-                <.table_row_menu_link navigate={Paths.manufacturer_edit(m.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} />
-                <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
-              </.table_row_menu>
-            </.table_default_cell>
-          </.table_default_row>
-        </.table_default_body>
-        <:card_header :let={m}>
-          <.link navigate={Paths.manufacturer_edit(m.uuid)} class="font-medium text-sm link link-hover">{m.name}</.link>
-        </:card_header>
-        <:card_actions :let={m}>
-          <.link navigate={Paths.manufacturer_edit(m.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}</.link>
-          <button phx-click="show_delete_confirm" phx-value-uuid={m.uuid} phx-value-type="manufacturer" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}</button>
-        </:card_actions>
-      </.table_default>
+  attr(:scope, :atom, required: true)
+  attr(:cfg, :map, required: true)
+  attr(:rows, :list, required: true)
+  slot(:filters)
+  slot(:actions)
+
+  defp table_toolbar(assigns) do
+    ~H"""
+    <div class="flex flex-wrap items-center gap-2 mb-3">
+      <form phx-change="table_search" class="contents">
+        <label class="input input-sm w-full sm:w-64">
+          <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
+          <input
+            type="search"
+            name="query"
+            value={@cfg[:search] || ""}
+            phx-debounce="300"
+            placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search...")}
+            class="grow"
+          />
+        </label>
+      </form>
+      {render_slot(@filters)}
+      <div class="flex-1"></div>
+      <.sort_controls
+        scope={@scope}
+        selected={@cfg.columns}
+        sort_by={@cfg.sort_by}
+        sort_dir={@cfg.sort_dir}
+      />
+      <button type="button" phx-click="show_column_modal" class="btn btn-outline btn-sm">
+        <.icon name="hero-adjustments-horizontal" class="w-4 h-4" />
+        <span class="hidden sm:inline">
+          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Columns")}
+        </span>
+      </button>
+      {render_slot(@actions)}
     </div>
     """
   end
 
-  defp suppliers_table(assigns) do
+  # ── Generic table + card view ────────────────────────────────────
+
+  attr(:scope, :atom, required: true)
+  attr(:cfg, :map, required: true)
+  attr(:rows, :list, required: true)
+  attr(:empty, :string, required: true)
+  slot(:row_actions, required: true)
+  slot(:card_actions, required: true)
+
+  defp simple_table(assigns) do
+    assigns = assign(assigns, :cols, visible_columns(assigns.scope, assigns.cfg))
+
     ~H"""
-    <div :if={@suppliers == []} class="card bg-base-100 shadow">
+    <div :if={@rows == []} class="card bg-base-100 shadow">
       <div class="card-body items-center text-center py-12">
-        <p class="text-base-content/60">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "No suppliers yet.")}</p>
+        <p class="text-base-content/60">{@empty}</p>
       </div>
     </div>
 
-    <div :if={@suppliers != []}>
-      <.table_default
-        variant="zebra" size="sm" toggleable={true}
-        id="suppliers-list" items={@suppliers}
-        card_fields={fn s -> [
-          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website"), value: s.website || "—"},
-          %{label: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status"), value: status_label(s.status)}
-        ] end}
-      >
-        <.table_default_header>
-          <.table_default_row>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Website")}</.table_default_header_cell>
-            <.table_default_header_cell>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</.table_default_header_cell>
-            <.table_default_header_cell class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</.table_default_header_cell>
-          </.table_default_row>
-        </.table_default_header>
-        <.table_default_body>
-          <.table_default_row :for={s <- @suppliers}>
-            <.table_default_cell class="font-medium">
-              <.link navigate={Paths.supplier_edit(s.uuid)} class="link link-hover">
-                {s.name}
-              </.link>
-            </.table_default_cell>
-            <.table_default_cell class="text-sm text-base-content/60">{s.website}</.table_default_cell>
-            <.table_default_cell><.status_badge status={s.status} size={:sm} /></.table_default_cell>
-            <.table_default_cell class="text-right whitespace-nowrap">
-              <.table_row_menu mode="auto" id={"supplier-menu-#{s.uuid}"}>
-                <.table_row_menu_link navigate={Paths.supplier_edit(s.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} variant="secondary" />
-                <.table_row_menu_divider />
-                <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
-              </.table_row_menu>
-            </.table_default_cell>
-          </.table_default_row>
-        </.table_default_body>
-        <:card_header :let={s}>
-          <.link navigate={Paths.supplier_edit(s.uuid)} class="font-medium text-sm link link-hover">{s.name}</.link>
-        </:card_header>
-        <:card_actions :let={s}>
-          <.link navigate={Paths.supplier_edit(s.uuid)} class="btn btn-ghost btn-xs">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}</.link>
-          <button phx-click="show_delete_confirm" phx-value-uuid={s.uuid} phx-value-type="supplier" class="btn btn-ghost btn-xs text-error">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}</button>
-        </:card_actions>
-      </.table_default>
-    </div>
+    <.table_default
+      :if={@rows != []}
+      id={"#{@scope}-table"}
+      variant="zebra"
+      size="sm"
+      toggleable
+      view_mode={@cfg.view}
+      view_event="set_view"
+      items={@rows}
+      card_fields={fn row ->
+        for c <- @cols, c.id != "name" do
+          %{label: c.label.(), value: render_card_value(@scope, c.id, row)}
+        end
+      end}
+    >
+      <.table_default_header>
+        <.table_default_row>
+          <.table_default_header_cell
+            :for={c <- @cols}
+            class={c.align == :right && "text-right"}
+          >
+            <.sort_header
+              :if={c.sortable?}
+              by={c.id}
+              label={c.label.()}
+              sort_by={@cfg.sort_by}
+              sort_dir={@cfg.sort_dir}
+              align={c.align}
+            />
+            <span :if={!c.sortable?}>{c.label.()}</span>
+          </.table_default_header_cell>
+          <.table_default_header_cell class="text-right">
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}
+          </.table_default_header_cell>
+        </.table_default_row>
+      </.table_default_header>
+      <.table_default_body>
+        <.table_default_row :for={row <- @rows}>
+          <.table_default_cell :for={c <- @cols} class={c.align == :right && "text-right"}>
+            {render_cell(@scope, c.id, row)}
+          </.table_default_cell>
+          <.table_default_cell class="text-right whitespace-nowrap">
+            {render_slot(@row_actions, row)}
+          </.table_default_cell>
+        </.table_default_row>
+      </.table_default_body>
+      <:card_header :let={row}>{render_cell(@scope, "name", row)}</:card_header>
+      <:card_actions :let={row}>{render_slot(@card_actions, row)}</:card_actions>
+    </.table_default>
     """
   end
+
+  # ── Sort header button ───────────────────────────────────────────
+
+  attr(:by, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:sort_by, :string, required: true)
+  attr(:sort_dir, :atom, required: true)
+  attr(:align, :atom, default: :left)
+
+  defp sort_header(assigns) do
+    assigns = assign(assigns, :active?, assigns.sort_by == assigns.by)
+
+    ~H"""
+    <button
+      type="button"
+      phx-click="toggle_sort"
+      phx-value-by={@by}
+      class={[
+        "inline-flex items-center gap-1 cursor-pointer select-none",
+        @align == :right && "justify-end w-full"
+      ]}
+    >
+      <span>{@label}</span>
+      <.icon
+        :if={@active?}
+        name={if @sort_dir == :asc, do: "hero-chevron-up-mini", else: "hero-chevron-down-mini"}
+        class="w-3.5 h-3.5"
+      />
+    </button>
+    """
+  end
+
+  # ── Cell renderers (suppliers / manufacturers) ───────────────────
+
+  defp render_cell(scope, "name", row) when scope in [:suppliers, :manufacturers] do
+    path =
+      if scope == :suppliers,
+        do: Paths.supplier_edit(row.uuid),
+        else: Paths.manufacturer_edit(row.uuid)
+
+    assigns = %{path: path, name: row.name}
+
+    ~H"""
+    <.link navigate={@path} class="link link-hover font-medium">{@name}</.link>
+    """
+  end
+
+  defp render_cell(_scope, "website", row), do: website_cell(row.website)
+  defp render_cell(_scope, "contact_info", row), do: text_or_dash(row.contact_info)
+  defp render_cell(_scope, "status", row), do: status_badge_cell(row.status)
+  defp render_cell(_scope, "updated", row), do: ts(row.updated_at)
+
+  defp render_card_value(_scope, "website", row), do: row.website || "—"
+  defp render_card_value(_scope, "status", row), do: status_label(row.status)
+  defp render_card_value(_scope, "contact_info", row), do: row.contact_info || "—"
+  defp render_card_value(_scope, "updated", row), do: ts_str(row.updated_at)
+  defp render_card_value(_scope, _id, _row), do: "—"
+
+  # ── Small render helpers ─────────────────────────────────────────
+
+  defp website_cell(nil), do: ""
+
+  defp website_cell(url) do
+    assigns = %{url: url}
+    ~H"<span class='text-sm text-base-content/60'>{@url}</span>"
+  end
+
+  defp text_or_dash(nil) do
+    assigns = %{}
+    ~H"<span class='text-base-content/40'>—</span>"
+  end
+
+  defp text_or_dash(v) do
+    assigns = %{v: v}
+    ~H"<span class='text-sm'>{@v}</span>"
+  end
+
+  defp status_badge_cell(status) do
+    assigns = %{status: status}
+    ~H"<.status_badge status={@status} size={:sm} />"
+  end
+
+  defp ts(nil) do
+    assigns = %{}
+    ~H"<span class='text-base-content/40'>—</span>"
+  end
+
+  defp ts(dt) do
+    assigns = %{dt: dt}
+
+    ~H"""
+    <span class="text-sm text-base-content/60">{Calendar.strftime(@dt, "%Y-%m-%d %H:%M")}</span>
+    """
+  end
+
+  defp ts_str(nil), do: "—"
+  defp ts_str(dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
 end

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -388,10 +388,19 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   def handle_event("restore_folder", %{"uuid" => uuid}, socket) do
     with %{} = folder <- Catalogue.get_folder(uuid),
          {:ok, _} <- Catalogue.restore_folder(folder, actor_opts(socket)) do
-      {:noreply,
-       socket
-       |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folder restored."))
-       |> load_data(:index)}
+      socket =
+        socket
+        |> put_flash(:info, Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folder restored."))
+        |> load_data(:index)
+
+      # If no deleted folders remain, return to the active view so the user
+      # isn't stranded on an empty "Deleted" list with no way to switch back.
+      socket =
+        if socket.assigns.deleted_folder_count == 0,
+          do: assign(socket, :folders_modal_view, "active"),
+          else: socket
+
+      {:noreply, socket}
     else
       _ ->
         {:noreply,
@@ -910,7 +919,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
               {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({@deleted_catalogue_count})
             </button>
           </div>
-          <.table_toolbar scope={:catalogues} cfg={cfg} rows={@catalogue_rows}>
+          <.table_toolbar scope={:catalogues} cfg={cfg}>
             <:filters>
               <.enum_filter
                 id="folder"
@@ -955,6 +964,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             scope={:catalogues}
             cfg={cfg}
             rows={derive_rows(@catalogue_rows, :catalogues, cfg)}
+            total={length(@catalogue_rows)}
             empty={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No catalogues yet.")}
           >
             <:row_actions :let={c}>
@@ -1046,7 +1056,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
         <div :if={@active_tab == :manufacturers} class="flex flex-col gap-4">
         <% cfg = @view_configs.manufacturers %>
-        <.table_toolbar scope={:manufacturers} cfg={cfg} rows={@manufacturers}>
+        <.table_toolbar scope={:manufacturers} cfg={cfg}>
           <:filters>
             <.enum_filter
               id="status"
@@ -1067,6 +1077,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           scope={:manufacturers}
           cfg={cfg}
           rows={derive_rows(@manufacturers, :manufacturers, cfg)}
+          total={length(@manufacturers)}
           empty={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No manufacturers yet.")}
         >
           <:row_actions :let={m}>
@@ -1105,7 +1116,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
       <div :if={@active_tab == :suppliers} class="flex flex-col gap-4">
         <% cfg = @view_configs.suppliers %>
-        <.table_toolbar scope={:suppliers} cfg={cfg} rows={@suppliers}>
+        <.table_toolbar scope={:suppliers} cfg={cfg}>
           <:filters>
             <.enum_filter
               id="status"
@@ -1126,6 +1137,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           scope={:suppliers}
           cfg={cfg}
           rows={derive_rows(@suppliers, :suppliers, cfg)}
+          total={length(@suppliers)}
           empty={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No suppliers yet.")}
         >
           <:row_actions :let={s}>
@@ -1434,7 +1446,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
   attr(:scope, :atom, required: true)
   attr(:cfg, :map, required: true)
-  attr(:rows, :list, required: true)
   slot(:filters)
   slot(:actions)
 
@@ -1478,6 +1489,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   attr(:scope, :atom, required: true)
   attr(:cfg, :map, required: true)
   attr(:rows, :list, required: true)
+  attr(:total, :integer, required: true)
   attr(:empty, :string, required: true)
   slot(:row_actions, required: true)
   slot(:card_actions, required: true)
@@ -1488,7 +1500,13 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     ~H"""
     <div :if={@rows == []} class="card bg-base-100 shadow">
       <div class="card-body items-center text-center py-12">
-        <p class="text-base-content/60">{@empty}</p>
+        <p class="text-base-content/60">
+          <%= if @total > 0 do %>
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No results found.")}
+          <% else %>
+            {@empty}
+          <% end %>
+        </p>
       </div>
     </div>
 

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -63,7 +63,10 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
        search_offset: 0,
        search_total: 0,
        search_has_more: false,
-       search_loading: false
+       search_loading: false,
+       view_configs: load_view_configs(socket),
+       show_column_modal: false,
+       temp_columns: nil
      )}
   end
 
@@ -105,6 +108,29 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       |> load_data(action)
 
     {:noreply, socket}
+  end
+
+  # Maps the active UI tab to a TableConfig/ViewConfig scope.
+  defp active_scope(%{assigns: a}), do: active_scope(a)
+  defp active_scope(%{active_tab: :index}), do: :catalogues
+  defp active_scope(%{active_tab: :manufacturers}), do: :manufacturers
+  defp active_scope(%{active_tab: :suppliers}), do: :suppliers
+
+  defp load_view_configs(socket) do
+    user = socket.assigns[:phoenix_kit_current_user]
+
+    Map.new([:catalogues, :suppliers, :manufacturers], fn scope ->
+      {scope, PhoenixKitCatalogue.Web.ViewConfig.load(user, scope)}
+    end)
+  end
+
+  defp current_cfg(assigns), do: Map.fetch!(assigns.view_configs, active_scope(assigns))
+
+  # Update one scope's cfg in assigns AND persist to the user row.
+  defp put_cfg(socket, scope, cfg) do
+    user = socket.assigns[:phoenix_kit_current_user]
+    _ = PhoenixKitCatalogue.Web.ViewConfig.save(user, scope, cfg)
+    assign(socket, :view_configs, Map.put(socket.assigns.view_configs, scope, cfg))
   end
 
   defp tab_title(:index), do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogues")
@@ -794,6 +820,118 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     end
   end
 
+  # ── Column / sort / filter / view handlers ──────────────────────
+
+  def handle_event("show_column_modal", _p, socket) do
+    {:noreply,
+     assign(socket,
+       show_column_modal: true,
+       temp_columns: current_cfg(socket.assigns).columns
+     )}
+  end
+
+  def handle_event("hide_column_modal", _p, socket),
+    do: {:noreply, assign(socket, show_column_modal: false, temp_columns: nil)}
+
+  def handle_event("add_column", %{"column_id" => id}, socket) do
+    {:noreply, update(socket, :temp_columns, &((&1 || []) ++ [id]))}
+  end
+
+  def handle_event("remove_column", %{"column_id" => id}, socket) do
+    {:noreply, update(socket, :temp_columns, &Enum.reject(&1 || [], fn c -> c == id end))}
+  end
+
+  def handle_event("reorder_columns", params, socket) do
+    {:noreply, assign(socket, :temp_columns, parse_order(params))}
+  end
+
+  def handle_event("reset_columns", _p, socket) do
+    scope = active_scope(socket.assigns)
+
+    {:noreply,
+     assign(socket, :temp_columns, PhoenixKitCatalogue.Web.TableConfig.default_columns(scope))}
+  end
+
+  def handle_event("apply_columns", params, socket) do
+    scope = active_scope(socket.assigns)
+
+    ids =
+      PhoenixKitCatalogue.Web.TableConfig.validate_columns(
+        scope,
+        parse_order(params) || socket.assigns.temp_columns || []
+      )
+
+    ids =
+      if ids == [], do: PhoenixKitCatalogue.Web.TableConfig.default_columns(scope), else: ids
+
+    cfg = %{current_cfg(socket.assigns) | columns: ids}
+    cfg = if cfg.sort_by in ids, do: cfg, else: %{cfg | sort_by: List.first(ids)}
+
+    {:noreply,
+     socket |> put_cfg(scope, cfg) |> assign(show_column_modal: false, temp_columns: nil)}
+  end
+
+  def handle_event("set_sort", %{"sort_by" => by}, socket) do
+    scope = active_scope(socket.assigns)
+
+    if MapSet.member?(known_sortable_ids(scope), by) do
+      {:noreply, put_cfg(socket, scope, %{current_cfg(socket.assigns) | sort_by: by})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("flip_sort_dir", _p, socket) do
+    scope = active_scope(socket.assigns)
+    cfg = current_cfg(socket.assigns)
+    {:noreply, put_cfg(socket, scope, %{cfg | sort_dir: flip(cfg.sort_dir)})}
+  end
+
+  def handle_event("toggle_sort", %{"by" => by}, socket) do
+    scope = active_scope(socket.assigns)
+
+    if MapSet.member?(known_sortable_ids(scope), by) do
+      cfg = current_cfg(socket.assigns)
+      dir = if cfg.sort_by == by, do: flip(cfg.sort_dir), else: :asc
+      {:noreply, put_cfg(socket, scope, %{cfg | sort_by: by, sort_dir: dir})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("set_filter", %{"column_id" => id, "value" => val}, socket) do
+    scope = active_scope(socket.assigns)
+
+    if MapSet.member?(filterable_ids(scope), id) do
+      cfg = current_cfg(socket.assigns)
+
+      filters =
+        if val in [nil, "", "all"],
+          do: Map.delete(cfg.filters, id),
+          else: Map.put(cfg.filters, id, val)
+
+      {:noreply, put_cfg(socket, scope, %{cfg | filters: filters})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("clear_filter", %{"column_id" => id}, socket) do
+    scope = active_scope(socket.assigns)
+
+    if MapSet.member?(filterable_ids(scope), id) do
+      cfg = current_cfg(socket.assigns)
+      {:noreply, put_cfg(socket, scope, %{cfg | filters: Map.delete(cfg.filters, id)})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("set_view", %{"view" => v}, socket) when v in ["table", "card"] do
+    scope = active_scope(socket.assigns)
+    {:noreply, put_cfg(socket, scope, %{current_cfg(socket.assigns) | view: v})}
+  end
+
   # ── Search helpers ──────────────────────────────────────────────
 
   # Runs a fresh search query asynchronously. If a prior search is still
@@ -923,6 +1061,36 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       search_has_more: false,
       search_loading: false
     )
+  end
+
+  # ── View-config helpers ──────────────────────────────────────────
+
+  defp flip(:asc), do: :desc
+  defp flip(_), do: :asc
+
+  # SortableGrid sends "ordered_ids"/"order" (list) or "column_order" (csv).
+  defp parse_order(%{"ordered_ids" => ids}) when is_list(ids), do: ids
+  defp parse_order(%{"order" => ids}) when is_list(ids), do: ids
+
+  defp parse_order(%{"column_order" => csv}) when is_binary(csv),
+    do: String.split(csv, ",", trim: true)
+
+  defp parse_order(_), do: nil
+
+  # Guard helpers: prevent client-supplied ids from flowing into
+  # String.to_existing_atom (filterable) or persisting junk sort keys.
+  defp filterable_ids(scope) do
+    scope
+    |> PhoenixKitCatalogue.Web.TableConfig.columns()
+    |> Enum.filter(& &1.filterable?)
+    |> MapSet.new(& &1.id)
+  end
+
+  defp known_sortable_ids(scope) do
+    scope
+    |> PhoenixKitCatalogue.Web.TableConfig.columns()
+    |> Enum.filter(& &1.sortable?)
+    |> MapSet.new(& &1.id)
   end
 
   # ── Render ──────────────────────────────────────────────────────

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -16,7 +16,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1, modal: 1]
   import PhoenixKitWeb.Components.Core.TableDefault
   import PhoenixKitWeb.Components.Core.TableRowMenu
-  import PhoenixKitWeb.Components.Core.EmptyState, only: [empty_state: 1]
   import PhoenixKitCatalogue.Web.Components
   import PhoenixKitCatalogue.Web.TableToolbar
 
@@ -26,8 +25,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Catalogue.PubSub
   alias PhoenixKitCatalogue.Paths
-
-  @per_page 100
 
   # PhoenixKit auto-applies its admin chrome layout to external module admin
   # views via socket.private[:live_layout]. Opt out here so this view can
@@ -46,25 +43,18 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     {:ok,
      assign(socket,
        page_title: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue"),
-       catalogues: [],
-       item_counts: %{},
+       catalogue_rows: [],
        manufacturers: [],
        suppliers: [],
        confirm_delete: nil,
        catalogue_view_mode: "active",
        deleted_catalogue_count: 0,
        deleted_folder_count: 0,
-       rows: [],
        expanded_folders: MapSet.new(),
        renaming_folder: nil,
        move_dialog: nil,
        folder_options: [],
-       search_query: "",
-       search_results: nil,
-       search_offset: 0,
-       search_total: 0,
-       search_has_more: false,
-       search_loading: false,
+       show_folders_modal: false,
        view_configs: load_view_configs(socket),
        show_column_modal: false,
        temp_columns: nil
@@ -105,7 +95,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       socket
       |> assign(:active_tab, action)
       |> assign(:page_title, tab_title(action))
-      |> clear_search()
       |> load_data(action)
 
     {:noreply, socket}
@@ -170,8 +159,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     if connected?(socket) do
       requested = socket.assigns.catalogue_view_mode
       deleted_cat_count = Catalogue.deleted_catalogue_count()
-      deleted_folders = Catalogue.list_folder_tree(mode: :deleted)
-      deleted_folder_count = length(deleted_folders)
+      deleted_folder_tree = Catalogue.list_folder_tree(mode: :deleted)
+      deleted_folder_count = length(deleted_folder_tree)
 
       # Auto-switch to active when nothing is deleted in either dimension.
       mode =
@@ -179,21 +168,21 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
           do: "active",
           else: requested
 
-      # Loaded once and shared by both the active row builder and the
-      # "Move to folder" picker — they previously each ran their own
-      # identical `list_folder_tree(:active)` query.
       active_tree = Catalogue.list_folder_tree(mode: :active)
+      folder_lookup = Map.new(active_tree, fn {f, _depth} -> {f.uuid, f} end)
+      item_counts = Catalogue.item_counts_by_catalogue()
 
-      rows =
+      catalogues =
         if mode == "deleted" do
-          build_deleted_rows(deleted_folders, Catalogue.list_catalogues(status: "deleted"))
+          Catalogue.list_catalogues(status: "deleted")
         else
-          build_active_rows(active_tree, socket.assigns.expanded_folders)
+          Catalogue.catalogues_by_folder() |> Map.values() |> List.flatten()
         end
 
+      catalogue_rows = build_catalogue_rows(catalogues, folder_lookup, item_counts)
+
       assign(socket,
-        rows: rows,
-        item_counts: Catalogue.item_counts_by_catalogue(),
+        catalogue_rows: catalogue_rows,
         deleted_catalogue_count: deleted_cat_count,
         deleted_folder_count: deleted_folder_count,
         catalogue_view_mode: mode,
@@ -216,80 +205,19 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       else: socket
   end
 
-  # ── Tree-row assembly ────────────────────────────────────────────
-  #
-  # The active view is a single flattened list of `{:folder, …}` /
-  # `{:catalogue, …}` rows in depth-first display order: at each level
-  # child folders come first (each recursing only when expanded), then
-  # the catalogues filed at that level; the root level ends with the
-  # unfiled catalogues. Orphan promotion (a child of a trashed folder, or
-  # a catalogue whose folder is trashed) is already handled by the
-  # context — promoted rows arrive with `parent_uuid`/folder = nil.
-  defp build_active_rows(active_tree, expanded) do
-    folders = Enum.map(active_tree, fn {f, _depth} -> f end)
-    folders_by_parent = Enum.group_by(folders, & &1.parent_uuid)
-    cats_by_folder = Catalogue.catalogues_by_folder()
-    # Folder rows only ever look up their own (active) folder's count, and
-    # those catalogues are already loaded in `cats_by_folder` — derive the
-    # counts from it instead of a second `folder_catalogue_counts/0` query
-    # (which also keeps the badge and the rendered children consistent by
-    # construction).
-    counts = Map.new(cats_by_folder, fn {folder_uuid, cats} -> {folder_uuid, length(cats)} end)
-    with_child_folders = Catalogue.folder_uuids_with_children(mode: :active)
-
-    walk_level(nil, 0, folders_by_parent, cats_by_folder, counts, with_child_folders, expanded)
-  end
-
-  defp walk_level(parent_uuid, depth, folders_by_parent, cats, counts, with_children, expanded) do
-    # `parent_key` identifies the sibling group for drag-reorder ("root"
-    # at the top level). Both folders and the catalogues filed here share
-    # this level's parent.
-    parent_key = parent_uuid || "root"
-
-    folder_rows =
-      folders_by_parent
-      |> Map.get(parent_uuid, [])
-      |> Enum.flat_map(fn folder ->
-        cat_count = Map.get(counts, folder.uuid, 0)
-        has_children = MapSet.member?(with_children, folder.uuid) or cat_count > 0
-        is_expanded = MapSet.member?(expanded, folder.uuid)
-
-        meta = %{expanded: is_expanded, has_children: has_children, count: cat_count}
-        row = {:folder, folder, depth, meta, parent_key}
-
-        if is_expanded do
-          [
-            row
-            | walk_level(
-                folder.uuid,
-                depth + 1,
-                folders_by_parent,
-                cats,
-                counts,
-                with_children,
-                expanded
-              )
-          ]
-        else
-          [row]
-        end
-      end)
-
-    catalogue_rows =
-      cats |> Map.get(parent_uuid, []) |> Enum.map(&{:catalogue, &1, depth, parent_key})
-
-    folder_rows ++ catalogue_rows
-  end
-
-  # Deleted view is a flat recovery list: deleted folders first, then
-  # deleted catalogues. No nesting, no expand/collapse, no DnD.
-  defp build_deleted_rows(deleted_folder_tree, deleted_catalogues) do
-    folder_rows =
-      Enum.map(deleted_folder_tree, fn {folder, _depth} ->
-        {:folder, folder, 0, %{expanded: false, has_children: false, count: 0}, "root"}
-      end)
-
-    folder_rows ++ Enum.map(deleted_catalogues, &{:catalogue, &1, 0, "root"})
+  # Each catalogue enriched into a plain atom-key map for the flat table:
+  # `:folder_name` from the lookup, `:item_count` from item_counts.
+  defp build_catalogue_rows(catalogues, folder_lookup, item_counts) do
+    Enum.map(catalogues, fn c ->
+      c
+      |> Map.from_struct()
+      |> Map.put(:folder_uuid, c.folder_uuid)
+      |> Map.put(
+        :folder_name,
+        c.folder_uuid && folder_lookup[c.folder_uuid] && folder_lookup[c.folder_uuid].name
+      )
+      |> Map.put(:item_count, Map.get(item_counts, c.uuid, 0))
+    end)
   end
 
   # Depth-indented `{value, label}` options for the "Move to folder"
@@ -369,15 +297,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
   # ── Folder handlers ─────────────────────────────────────────────
 
-  def handle_event("toggle_folder", %{"uuid" => uuid}, socket) do
-    expanded =
-      if MapSet.member?(socket.assigns.expanded_folders, uuid),
-        do: MapSet.delete(socket.assigns.expanded_folders, uuid),
-        else: MapSet.put(socket.assigns.expanded_folders, uuid)
-
-    {:noreply, socket |> assign(:expanded_folders, expanded) |> load_data(:index)}
-  end
-
   def handle_event("new_folder", _params, socket) do
     case Catalogue.create_folder(%{name: default_folder_name()}, actor_opts(socket)) do
       {:ok, folder} ->
@@ -399,11 +318,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
            actor_opts(socket)
          ) do
       {:ok, folder} ->
-        expanded = MapSet.put(socket.assigns.expanded_folders, parent_uuid)
-
         {:noreply,
          socket
-         |> assign(expanded_folders: expanded, renaming_folder: folder.uuid)
+         |> assign(:renaming_folder, folder.uuid)
          |> load_data(:index)}
 
       {:error, _} ->
@@ -506,8 +423,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     {:noreply, socket |> assign(:move_dialog, nil) |> load_data(:index)}
   end
 
-  # Native drag-to-file (CatalogueTreeDnD hook): a row dropped onto a
-  # folder row. `target` is the destination folder uuid (or "root").
+  # Used by "Move to folder" row menu and the move dialog.
+  # `target` is the destination folder uuid (or "root" → nil → unfiled).
   def handle_event(
         "move_to_folder",
         %{"type" => type, "uuid" => uuid, "target" => target},
@@ -523,42 +440,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       end
 
     {:noreply, load_data(socket, :index)}
-  end
-
-  def handle_event("reorder_catalogues", %{"ordered_ids" => ordered_ids}, socket)
-      when is_list(ordered_ids) do
-    case Catalogue.reorder_catalogues(ordered_ids, actor_opts(socket)) do
-      :ok ->
-        {:noreply, load_data(socket, :index)}
-
-      {:error, reason} ->
-        log_operation_error(socket, "reorder_catalogues", %{reason: reason})
-
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to save the new order.")
-         )}
-    end
-  end
-
-  def handle_event("reorder_folders", %{"ordered_ids" => ordered_ids}, socket)
-      when is_list(ordered_ids) do
-    case Catalogue.reorder_folders(ordered_ids, actor_opts(socket)) do
-      :ok ->
-        {:noreply, load_data(socket, :index)}
-
-      {:error, reason} ->
-        log_operation_error(socket, "reorder_folders", %{reason: reason})
-
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Failed to save the new order.")
-         )}
-    end
   end
 
   def handle_event("trash_catalogue", %{"uuid" => uuid}, socket) do
@@ -798,28 +679,11 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     {:noreply, assign(socket, :confirm_delete, nil)}
   end
 
-  def handle_event("search", %{"query" => query}, socket) do
-    query = String.trim(query)
+  def handle_event("show_folders_modal", _p, socket),
+    do: {:noreply, assign(socket, :show_folders_modal, true)}
 
-    if query == "" do
-      {:noreply, clear_search(socket)}
-    else
-      {:noreply, run_search(socket, query)}
-    end
-  end
-
-  def handle_event("clear_search", _params, socket) do
-    {:noreply, clear_search(socket)}
-  end
-
-  def handle_event("load_more", _params, socket) do
-    if socket.assigns.search_results != nil and socket.assigns.search_has_more and
-         not socket.assigns.search_loading do
-      {:noreply, start_search_page(socket)}
-    else
-      {:noreply, socket}
-    end
-  end
+  def handle_event("hide_folders_modal", _p, socket),
+    do: {:noreply, assign(socket, :show_folders_modal, false)}
 
   # ── Column / sort / filter / view handlers ──────────────────────
 
@@ -940,137 +804,6 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     {:noreply, assign(socket, :view_configs, Map.put(socket.assigns.view_configs, scope, cfg))}
   end
 
-  # ── Search helpers ──────────────────────────────────────────────
-
-  # Runs a fresh search query asynchronously. If a prior search is still
-  # in flight, `start_async/3` cancels it — so fast typing (type-pause-
-  # type-pause) doesn't flash stale intermediate results as each old
-  # request lands out of order. The actual assign happens in
-  # `handle_async(:search, ...)`, guarded by a query equality check.
-  defp run_search(socket, query) do
-    socket
-    |> assign(search_query: query, search_loading: true)
-    |> start_async(:search, fn ->
-      results = Catalogue.search_items(query, limit: @per_page, offset: 0)
-      total = Catalogue.count_search_items(query)
-      {query, results, total}
-    end)
-  end
-
-  @impl true
-  def handle_async(:search, {:ok, {query, results, total}}, socket) do
-    # Only apply if the user is still asking for this query. A late
-    # response for a query the user has already superseded gets dropped.
-    if socket.assigns.search_query == query do
-      {:noreply,
-       assign(socket,
-         search_results: results,
-         search_offset: length(results),
-         search_total: total,
-         search_has_more: length(results) < total,
-         search_loading: false
-       )}
-    else
-      {:noreply, socket}
-    end
-  end
-
-  def handle_async(:search, {:exit, reason}, socket) do
-    # Cancellations (reason `:shutdown` / `:killed` / `{:shutdown, _}`) are
-    # expected when a newer query supersedes a pending one — the newer
-    # handler owns `search_loading`, so leave the socket alone. For any
-    # other exit (crashed DB query, timeout, raise in the task fn) clear
-    # loading and flash the user so they don't stare at a perpetual
-    # spinner, and log so we can debug without reproducing.
-    case reason do
-      r when r in [:shutdown, :killed] ->
-        {:noreply, socket}
-
-      {:shutdown, _} ->
-        {:noreply, socket}
-
-      other ->
-        Logger.warning(
-          "CataloguesLive search task exited unexpectedly: reason=#{inspect(other)} query=#{inspect(socket.assigns.search_query)} actor_uuid=#{inspect(actor_uuid(socket))}"
-        )
-
-        {:noreply,
-         socket
-         |> assign(:search_loading, false)
-         |> put_flash(
-           :error,
-           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search failed. Please try again.")
-         )}
-    end
-  end
-
-  def handle_async(:search_page, {:ok, {query, offset, page}}, socket) do
-    if socket.assigns.search_query == query and socket.assigns.search_offset == offset do
-      new_offset = offset + length(page)
-      has_more = page != [] and new_offset < socket.assigns.search_total
-
-      {:noreply,
-       assign(socket,
-         search_results: (socket.assigns.search_results || []) ++ page,
-         search_offset: new_offset,
-         search_has_more: has_more,
-         search_loading: false
-       )}
-    else
-      {:noreply, socket}
-    end
-  end
-
-  def handle_async(:search_page, {:exit, reason}, socket) do
-    case reason do
-      r when r in [:shutdown, :killed] ->
-        {:noreply, socket}
-
-      {:shutdown, _} ->
-        {:noreply, socket}
-
-      other ->
-        Logger.warning(
-          "CataloguesLive search_page task exited unexpectedly: reason=#{inspect(other)} query=#{inspect(socket.assigns.search_query)} offset=#{socket.assigns.search_offset} actor_uuid=#{inspect(actor_uuid(socket))}"
-        )
-
-        {:noreply,
-         socket
-         |> assign(:search_loading, false)
-         |> put_flash(
-           :error,
-           Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search failed. Please try again.")
-         )}
-    end
-  end
-
-  # Global-search paging runs off-process for the same reason the
-  # per-catalogue detail view does: the ILIKE-against-jsonb-as-text
-  # query doesn't hit an index and can take hundreds of ms on large
-  # datasets. `handle_async(:search_page, …)` guards on `{query, offset}`
-  # so a superseding new search or a stale page can't double-append.
-  defp start_search_page(socket) do
-    %{search_query: query, search_offset: offset} = socket.assigns
-
-    socket
-    |> assign(:search_loading, true)
-    |> start_async(:search_page, fn ->
-      page = Catalogue.search_items(query, limit: @per_page, offset: offset)
-      {query, offset, page}
-    end)
-  end
-
-  defp clear_search(socket) do
-    assign(socket,
-      search_query: "",
-      search_results: nil,
-      search_offset: 0,
-      search_total: 0,
-      search_has_more: false,
-      search_loading: false
-    )
-  end
-
   # ── View-config helpers ──────────────────────────────────────────
 
   # Visible columns (col maps) for a scope per the user's cfg, in order.
@@ -1132,126 +865,175 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       current_locale={assigns[:current_locale]}
     >
       <div class="flex flex-col w-full px-4 py-6 gap-6">
-        <div class="flex flex-wrap items-center justify-end gap-2 mb-2">
-          <button
-            :if={@active_tab == :index && @catalogue_view_mode == "active"}
-            type="button"
-            phx-click="new_folder"
-            phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Creating...")}
-            class="btn btn-ghost btn-sm gap-1"
-          >
-            <.icon name="hero-folder-plus" class="w-4 h-4" />
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Folder")}
-          </button>
-          <.link :if={@active_tab == :index && @catalogue_view_mode == "active"} navigate={Paths.catalogue_new()} class="btn btn-primary btn-sm">
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Catalogue")}
-          </.link>
-        </div>
-
-        <%!-- Global search (only on catalogues tab). While a tree row is being
-           dragged, the CatalogueTreeDnD hook swaps the search bar for the
-           "move to root" drop target in-place, so the layout doesn't jump. --%>
-      <div :if={@active_tab == :index} class="relative">
-        <.search_input query={@search_query} placeholder={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Search items across all catalogues...")} />
-        <%!-- Overlaid on the search bar's exact box while dragging (absolute, so
-             it adds no height) → the "move to root" target appears with no jump. --%>
-        <div
-          data-tree-rootzone="1"
-          data-tree-drop="root"
-          class="hidden absolute inset-0 z-10 flex items-center justify-center gap-1 rounded-lg border-2 border-dashed border-primary/50 bg-base-100 text-sm text-base-content/60"
-        >
-          <.icon name="hero-arrow-up-tray" class="w-4 h-4" />
-          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drop here to move to root (unfiled)")}
-        </div>
-      </div>
-
-      <%!-- Search results (visible when the user has typed a query) --%>
-      <div :if={@search_results != nil or @search_loading} class="flex flex-col gap-4">
-        <%!-- Status line: spinner while loading, "X of Y results" when settled --%>
-        <div class="flex items-center gap-2">
-          <%= if @search_loading and is_nil(@search_results) do %>
-            <span class="text-sm text-base-content/60">
-              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Searching for \"%{query}\"...", query: @search_query)}
-            </span>
-          <% else %>
-            <.search_results_summary :if={@search_results != nil} count={@search_total} query={@search_query} loaded={length(@search_results)} />
-          <% end %>
-          <span :if={@search_loading} class="loading loading-spinner loading-xs text-base-content/40"></span>
-        </div>
-
-        <.empty_state :if={@search_results == [] and not @search_loading} variant="card" title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No items match your search.")} />
-
-        <%!-- Stale results are dimmed while a newer query is in flight to
-             signal that the list is about to update. --%>
-        <div :if={@search_results not in [nil, []]} class={["transition-opacity", @search_loading && "opacity-50"]}>
-          <.item_table
-            items={@search_results}
-            columns={[:name, :sku, :base_price, :catalogue, :category, :manufacturer, :status]}
-            variant="zebra"
-            edit_path={&Paths.item_edit/1}
-            catalogue_path={&Paths.catalogue_detail/1}
-            cards={true}
-            id="global-search-items"
-          />
-        </div>
-
-        <%!-- Infinite-scroll sentinel for global search --%>
-        <div
-          :if={@search_has_more and not @search_loading}
-          id="catalogues-search-load-more-sentinel"
-          phx-hook="InfiniteScroll"
-          data-cursor={"global-search-#{@search_offset}"}
-          class="py-4"
-        >
-          <div class="flex justify-center">
-            <span class="loading loading-spinner loading-sm text-base-content/30"></span>
+        <%!-- Catalogue tab content --%>
+        <div :if={@active_tab == :index} class="flex flex-col gap-4">
+          <% cfg = @view_configs.catalogues %>
+          <%!-- Active/Deleted sub-tabs — shown only when there are deleted items. --%>
+          <div :if={@deleted_catalogue_count > 0} class="flex items-center gap-0.5 border-b border-base-200">
+            <button
+              type="button"
+              phx-click="switch_catalogue_view"
+              phx-value-mode="active"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@catalogue_view_mode == "active",
+                  do: "border-primary text-primary",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")}
+            </button>
+            <button
+              type="button"
+              phx-click="switch_catalogue_view"
+              phx-value-mode="deleted"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@catalogue_view_mode == "deleted",
+                  do: "border-error text-error",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({@deleted_catalogue_count})
+            </button>
           </div>
-        </div>
-      </div>
-
-      <%!-- Catalogue tab content --%>
-      <div :if={@active_tab == :index and is_nil(@search_results) and not @search_loading} class="flex flex-col gap-4">
-        <%!-- Status sub-tabs for catalogues --%>
-        <div :if={@deleted_catalogue_count > 0} class="flex items-center gap-0.5 border-b border-base-200">
-          <button
-            type="button"
-            phx-click="switch_catalogue_view"
-            phx-value-mode="active"
-            class={[
-              "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-              if(@catalogue_view_mode == "active",
-                do: "border-primary text-primary",
-                else: "border-transparent text-base-content/50 hover:text-base-content"
-              )
-            ]}
+          <.table_toolbar scope={:catalogues} cfg={cfg} rows={@catalogue_rows}>
+            <:filters>
+              <.enum_filter
+                id="folder"
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folder")}
+                value={cfg.filters["folder"]}
+                prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All folders")}
+                options={PhoenixKitCatalogue.Web.TableQuery.enum_options(@catalogue_rows, :catalogues, "folder")}
+              />
+              <.enum_filter
+                id="status"
+                label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}
+                value={cfg.filters["status"]}
+                prompt={Gettext.gettext(PhoenixKitCatalogue.Gettext, "All statuses")}
+                options={PhoenixKitCatalogue.Web.TableQuery.enum_options(@catalogue_rows, :catalogues, "status")}
+              />
+            </:filters>
+            <:actions>
+              <button
+                :if={@catalogue_view_mode == "active"}
+                type="button"
+                phx-click="new_folder"
+                phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Creating...")}
+                class="btn btn-ghost btn-sm gap-1"
+              >
+                <.icon name="hero-folder-plus" class="w-4 h-4" />
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Folder")}
+              </button>
+              <button
+                type="button"
+                phx-click="show_folders_modal"
+                class="btn btn-ghost btn-sm gap-1"
+              >
+                <.icon name="hero-folder-open" class="w-4 h-4" />
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folders…")}
+              </button>
+              <.link :if={@catalogue_view_mode == "active"} navigate={Paths.catalogue_new()} class="btn btn-primary btn-sm">
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Catalogue")}
+              </.link>
+            </:actions>
+          </.table_toolbar>
+          <.simple_table
+            scope={:catalogues}
+            cfg={cfg}
+            rows={derive_rows(@catalogue_rows, :catalogues, cfg)}
+            empty={Gettext.gettext(PhoenixKitCatalogue.Gettext, "No catalogues yet.")}
           >
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")}
-          </button>
-          <button
-            type="button"
-            phx-click="switch_catalogue_view"
-            phx-value-mode="deleted"
-            class={[
-              "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
-              if(@catalogue_view_mode == "deleted",
-                do: "border-error text-error",
-                else: "border-transparent text-base-content/50 hover:text-base-content"
-              )
-            ]}
-          >
-            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({@deleted_catalogue_count})
-          </button>
+            <:row_actions :let={c}>
+              <.table_row_menu :if={@catalogue_view_mode == "active"} mode="auto" id={"cat-menu-#{c.uuid}"}>
+                <.table_row_menu_link
+                  navigate={Paths.catalogue_detail(c.uuid)}
+                  icon="hero-eye"
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")}
+                />
+                <.table_row_menu_link
+                  navigate={Paths.catalogue_edit(c.uuid)}
+                  icon="hero-pencil"
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+                  variant="secondary"
+                />
+                <.table_row_menu_button
+                  phx-click="open_move"
+                  phx-value-type="catalogue"
+                  phx-value-uuid={c.uuid}
+                  icon="hero-folder-arrow-down"
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")}
+                  variant="secondary"
+                />
+                <.table_row_menu_divider />
+                <.table_row_menu_button
+                  phx-click="trash_catalogue"
+                  phx-value-uuid={c.uuid}
+                  phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")}
+                  icon="hero-trash"
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+                  variant="error"
+                />
+              </.table_row_menu>
+              <.table_row_menu :if={@catalogue_view_mode == "deleted"} mode="auto" id={"cat-del-menu-#{c.uuid}"}>
+                <.table_row_menu_button
+                  phx-click="restore_catalogue"
+                  phx-value-uuid={c.uuid}
+                  phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")}
+                  icon="hero-arrow-path"
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
+                  variant="success"
+                />
+                <.table_row_menu_divider />
+                <.table_row_menu_button
+                  phx-click="show_delete_confirm"
+                  phx-value-uuid={c.uuid}
+                  phx-value-type="catalogue"
+                  icon="hero-trash"
+                  label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
+                  variant="error"
+                />
+              </.table_row_menu>
+            </:row_actions>
+            <:card_actions :let={c}>
+              <.link
+                :if={@catalogue_view_mode == "active"}
+                navigate={Paths.catalogue_detail(c.uuid)}
+                class="btn btn-ghost btn-xs"
+              >
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")}
+              </.link>
+              <.link
+                :if={@catalogue_view_mode == "active"}
+                navigate={Paths.catalogue_edit(c.uuid)}
+                class="btn btn-ghost btn-xs"
+              >
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")}
+              </.link>
+              <button
+                :if={@catalogue_view_mode == "deleted"}
+                phx-click="restore_catalogue"
+                phx-value-uuid={c.uuid}
+                class="btn btn-ghost btn-xs text-success"
+              >
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
+              </button>
+              <button
+                :if={@catalogue_view_mode == "deleted"}
+                phx-click="show_delete_confirm"
+                phx-value-uuid={c.uuid}
+                phx-value-type="catalogue"
+                class="btn btn-ghost btn-xs text-error"
+              >
+                {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
+              </button>
+            </:card_actions>
+          </.simple_table>
         </div>
 
-        <.folder_tree_table
-          rows={@rows}
-          item_counts={@item_counts}
-          view_mode={@catalogue_view_mode}
-          renaming_folder={@renaming_folder}
-        />
-      </div>
-
-      <div :if={@active_tab == :manufacturers and is_nil(@search_results)} class="flex flex-col gap-4">
+        <div :if={@active_tab == :manufacturers} class="flex flex-col gap-4">
         <% cfg = @view_configs.manufacturers %>
         <.table_toolbar scope={:manufacturers} cfg={cfg} rows={@manufacturers}>
           <:filters>
@@ -1310,7 +1092,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         </.simple_table>
       </div>
 
-      <div :if={@active_tab == :suppliers and is_nil(@search_results)} class="flex flex-col gap-4">
+      <div :if={@active_tab == :suppliers} class="flex flex-col gap-4">
         <% cfg = @view_configs.suppliers %>
         <.table_toolbar scope={:suppliers} cfg={cfg} rows={@suppliers}>
           <:filters>
@@ -1442,345 +1224,7 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
       />
       </div>
 
-      <script>
-        window.PhoenixKitHooks = window.PhoenixKitHooks || {};
-      window.PhoenixKitHooks.InfiniteScroll = window.PhoenixKitHooks.InfiniteScroll || {
-        mounted() {
-          this.intersecting = false;
-          this.observer = new IntersectionObserver((entries) => {
-            this.intersecting = entries[0].isIntersecting;
-            if (this.intersecting) {
-              this.pushEvent("load_more", {});
-            }
-          }, { rootMargin: "200px" });
-          this.observer.observe(this.el);
-        },
-        updated() {
-          // IntersectionObserver only fires on state transitions. When the
-          // viewport is tall or the user jumped via Page Down / resize, the
-          // sentinel stays continuously in view across batches — so the
-          // observer goes silent after the first fire. Re-trigger explicitly
-          // whenever the server patches us while we're still on-screen.
-          // The server's `loading` guard dedupes duplicate events.
-          if (this.intersecting) {
-            this.pushEvent("load_more", {});
-          }
-        },
-        destroyed() {
-          this.observer.disconnect();
-        }
-      };
-
-      // Native HTML5 DnD for the catalogue folder tree-table — one system,
-      // no SortableJS, so nothing collides. Grab a row's handle, then drop:
-      //   • on a folder's MIDDLE → file into that folder
-      //   • on a row's TOP/BOTTOM edge → reorder among same-parent siblings
-      //   • on a "move to root" zone → unfile to root
-      // The context enforces the cycle / trashed-target guards server-side.
-      window.PhoenixKitHooks.CatalogueTreeDnD = window.PhoenixKitHooks.CatalogueTreeDnD || {
-        mounted() { this.setupTreeDnD(); },
-        updated() { this.setupTreeDnD(); },
-        setupTreeDnD() {
-          var hook = this;
-
-          // Drag sources: the grip handles.
-          this.el.querySelectorAll("[data-tree-item]").forEach(function(handle) {
-            handle.setAttribute("draggable", "true");
-            handle.ondragstart = function(e) {
-              var row = handle.closest("tr");
-              hook._drag = row && {
-                uuid: row.dataset.treeUuid,
-                type: row.dataset.treeType,
-                parent: row.dataset.treeParent
-              };
-              e.dataTransfer.setData("text/plain", handle.dataset.treeItem);
-              e.dataTransfer.effectAllowed = "move";
-              if (row) {
-                try { e.dataTransfer.setDragImage(row, 12, 12); } catch (err) {}
-                row.classList.add("opacity-50");
-                hook._dragRowEl = row;
-              }
-              // Reveal the "move to root" target, overlaid on the search bar's
-              // box (absolute → no layout shift).
-              document.querySelectorAll("[data-tree-rootzone]").forEach(function(z) {
-                z.classList.remove("hidden");
-              });
-            };
-            handle.ondragend = function() { hook.endDrag(); };
-          });
-
-          // Row targets: file-into (folder middle) or reorder (top/bottom edge).
-          this.el.querySelectorAll("[data-tree-uuid]").forEach(function(row) {
-            row.ondragover = function(e) {
-              var intent = hook.dropIntent(row, e);
-              if (!intent) return;
-              e.preventDefault();
-              e.dataTransfer.dropEffect = "move";
-              hook.showIndicator(row, intent);
-            };
-            row.ondragleave = function() { hook.clearRow(row); };
-            row.ondrop = function(e) {
-              var intent = hook.dropIntent(row, e);
-              hook.clearRow(row);
-              if (!intent || !hook._drag) return;
-              e.preventDefault();
-              var drag = hook._drag;
-              if (intent === "into") {
-                hook.pushEvent("move_to_folder", { type: drag.type, uuid: drag.uuid, target: row.dataset.treeDrop });
-              } else {
-                hook.reorder(drag, row, intent);
-              }
-            };
-          });
-
-          // Root drop zone lives in the search-bar slot (outside this.el),
-          // so query the whole document to bind + toggle it.
-          document.querySelectorAll("[data-tree-rootzone]").forEach(function(zone) {
-            zone.ondragover = function(e) {
-              if (!hook._drag) return;
-              e.preventDefault();
-              e.dataTransfer.dropEffect = "move";
-              zone.classList.add("bg-primary/10");
-            };
-            zone.ondragleave = function() { zone.classList.remove("bg-primary/10"); };
-            zone.ondrop = function(e) {
-              e.preventDefault();
-              zone.classList.remove("bg-primary/10");
-              if (hook._drag) {
-                hook.pushEvent("move_to_folder", { type: hook._drag.type, uuid: hook._drag.uuid, target: "root" });
-              }
-            };
-          });
-        },
-
-        // "into" | "before" | "after" | null for the pointer over `row`.
-        dropIntent(row, e) {
-          var drag = this._drag;
-          if (!drag || drag.uuid === row.dataset.treeUuid) return null;
-          var rect = row.getBoundingClientRect();
-          var ratio = (e.clientY - rect.top) / rect.height;
-          var isFolder = row.hasAttribute("data-tree-drop");
-          if (isFolder && ratio > 0.25 && ratio < 0.75) return "into";
-          if (drag.parent === row.dataset.treeParent && drag.type === row.dataset.treeType) {
-            return ratio < 0.5 ? "before" : "after";
-          }
-          // Over a folder but not a sibling → fall back to filing into it.
-          return isFolder ? "into" : null;
-        },
-
-        reorder(drag, row, intent) {
-          // Same-parent, same-type siblings in current DOM order.
-          var order = [];
-          this.el.querySelectorAll("[data-tree-uuid]").forEach(function(r) {
-            if (r.dataset.treeParent === drag.parent &&
-                r.dataset.treeType === drag.type &&
-                r.dataset.treeUuid !== drag.uuid) {
-              order.push(r.dataset.treeUuid);
-            }
-          });
-          var idx = order.indexOf(row.dataset.treeUuid);
-          if (idx < 0) return;
-          order.splice(intent === "before" ? idx : idx + 1, 0, drag.uuid);
-          this.pushEvent(drag.type === "folder" ? "reorder_folders" : "reorder_catalogues", { ordered_ids: order });
-        },
-
-        showIndicator(row, intent) {
-          this.clearAll();
-          if (intent === "into") {
-            // Inline style (not a class) so the highlight wins over the
-            // table-zebra row background, which otherwise hides it.
-            row.style.backgroundColor = "rgba(59, 130, 246, 0.18)";
-          } else {
-            row.style.boxShadow = intent === "before"
-              ? "inset 0 3px 0 0 rgb(59 130 246)"
-              : "inset 0 -3px 0 0 rgb(59 130 246)";
-          }
-        },
-
-        clearRow(row) {
-          row.style.backgroundColor = "";
-          row.style.boxShadow = "";
-        },
-
-        clearAll() {
-          var self = this;
-          this.el.querySelectorAll("[data-tree-uuid]").forEach(function(r) { self.clearRow(r); });
-        },
-
-        endDrag() {
-          if (this._dragRowEl) { this._dragRowEl.classList.remove("opacity-50"); this._dragRowEl = null; }
-          this._drag = null;
-          document.querySelectorAll("[data-tree-rootzone]").forEach(function(z) {
-            z.classList.add("hidden");
-            z.classList.remove("bg-primary/10");
-          });
-          this.clearAll();
-        }
-      };
-      </script>
     </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
-    """
-  end
-
-  defp folder_tree_table(assigns) do
-    ~H"""
-    <div :if={@rows == []} class="card bg-base-100 shadow">
-      <div class="card-body items-center text-center py-12">
-        <p class="text-base-content/60">
-          {if @view_mode == "deleted", do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Nothing in the trash."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "No catalogues yet.")}
-        </p>
-      </div>
-    </div>
-
-    <div :if={@rows != []} id={"cat-tree-#{@view_mode}"} phx-hook="CatalogueTreeDnD" class="overflow-x-auto">
-      <table class="table table-zebra table-sm">
-        <thead>
-          <tr>
-            <th :if={@view_mode == "active"} class="w-8"></th>
-            <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Name")}</th>
-            <th class="text-right">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Items")}</th>
-            <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Status")}</th>
-            <th>{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Updated")}</th>
-            <th class="text-right whitespace-nowrap">{Gettext.gettext(PhoenixKitCatalogue.Gettext, "Actions")}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <%= for row <- @rows do %>
-            <%= case row do %>
-              <% {:folder, folder, depth, meta, parent_key} -> %>
-                <tr
-                  class={["group/row hover"]}
-                  data-tree-uuid={@view_mode == "active" && folder.uuid}
-                  data-tree-type={@view_mode == "active" && "folder"}
-                  data-tree-parent={@view_mode == "active" && parent_key}
-                  data-tree-drop={@view_mode == "active" && folder.uuid}
-                >
-                  <td
-                    :if={@view_mode == "active"}
-                    data-tree-item={"folder:" <> folder.uuid}
-                    class="w-8 pk-tree-handle cursor-grab active:cursor-grabbing text-base-content/40 opacity-0 group-hover/row:opacity-100 transition-opacity"
-                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to move into a folder")}
-                  >
-                    <.icon name="hero-bars-3" class="w-4 h-4" />
-                  </td>
-                  <td>
-                    <div class="flex items-center gap-1.5" style={"padding-left: #{depth * 1.5}rem"}>
-                      <button
-                        :if={meta.has_children}
-                        type="button"
-                        phx-click="toggle_folder"
-                        phx-value-uuid={folder.uuid}
-                        class="btn btn-ghost btn-xs p-0 min-h-0 h-5 w-5"
-                        aria-label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Toggle folder")}
-                      >
-                        <.icon name={if meta.expanded, do: "hero-chevron-down-mini", else: "hero-chevron-right-mini"} class="w-4 h-4 text-base-content/50" />
-                      </button>
-                      <span :if={not meta.has_children} class="w-5"></span>
-                      <.icon name="hero-folder" class="w-4 h-4 text-warning shrink-0" />
-                      <%= cond do %>
-                        <% @renaming_folder == folder.uuid -> %>
-                          <form phx-submit="rename_folder" phx-value-uuid={folder.uuid}>
-                            <input
-                              type="text"
-                              name="name"
-                              value={folder.name}
-                              phx-mounted={Phoenix.LiveView.JS.focus()}
-                              phx-blur="rename_folder"
-                              phx-value-uuid={folder.uuid}
-                              class="input input-bordered input-xs"
-                            />
-                          </form>
-                        <% @view_mode == "active" -> %>
-                          <button
-                            type="button"
-                            phx-click="start_rename_folder"
-                            phx-value-uuid={folder.uuid}
-                            class="font-medium text-left cursor-pointer hover:underline decoration-dotted underline-offset-2"
-                            title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Click to rename")}
-                          >
-                            {folder.name}
-                          </button>
-                        <% true -> %>
-                          <span class="font-medium text-base-content/50">{folder.name}</span>
-                      <% end %>
-                    </div>
-                  </td>
-                  <td class="text-right tabular-nums text-base-content/60">{meta.count}</td>
-                  <td><.status_badge status={folder.status} size={:sm} /></td>
-                  <td class="text-sm text-base-content/60">{Calendar.strftime(folder.updated_at, "%Y-%m-%d %H:%M")}</td>
-                  <td class="text-right whitespace-nowrap">
-                    <.table_row_menu :if={@view_mode == "active"} mode="auto" id={"folder-menu-#{folder.uuid}"}>
-                      <.table_row_menu_button phx-click="new_subfolder" phx-value-uuid={folder.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Creating...")} icon="hero-folder-plus" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "New subfolder")} />
-                      <.table_row_menu_button phx-click="start_rename_folder" phx-value-uuid={folder.uuid} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Rename")} variant="secondary" />
-                      <.table_row_menu_button phx-click="open_move" phx-value-type="folder" phx-value-uuid={folder.uuid} icon="hero-folder-arrow-down" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")} variant="secondary" />
-                      <.table_row_menu_divider />
-                      <.table_row_menu_button phx-click="trash_folder" phx-value-uuid={folder.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
-                    </.table_row_menu>
-                    <.table_row_menu :if={@view_mode == "deleted"} mode="auto" id={"folder-del-menu-#{folder.uuid}"}>
-                      <.table_row_menu_button phx-click="restore_folder" phx-value-uuid={folder.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
-                      <.table_row_menu_divider />
-                      <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={folder.uuid} phx-value-type="folder" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")} variant="error" />
-                    </.table_row_menu>
-                  </td>
-                </tr>
-              <% {:catalogue, catalogue, depth, parent_key} -> %>
-                <tr
-                  class={["group/row hover"]}
-                  data-tree-uuid={@view_mode == "active" && catalogue.uuid}
-                  data-tree-type={@view_mode == "active" && "catalogue"}
-                  data-tree-parent={@view_mode == "active" && parent_key}
-                >
-                  <td
-                    :if={@view_mode == "active"}
-                    data-tree-item={"catalogue:" <> catalogue.uuid}
-                    class="w-8 pk-tree-handle cursor-grab active:cursor-grabbing text-base-content/40 opacity-0 group-hover/row:opacity-100 transition-opacity"
-                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drag to move into a folder")}
-                  >
-                    <.icon name="hero-bars-3" class="w-4 h-4" />
-                  </td>
-                  <td>
-                    <div class="flex items-center gap-1.5" style={"padding-left: #{depth * 1.5 + 1.5}rem"}>
-                      <.icon name="hero-document-text" class="w-4 h-4 text-base-content/40 shrink-0" />
-                      <.link :if={@view_mode == "active"} navigate={Paths.catalogue_detail(catalogue.uuid)} class="link link-hover font-medium">
-                        {catalogue.name}
-                      </.link>
-                      <span :if={@view_mode == "deleted"} class="font-medium text-base-content/50">{catalogue.name}</span>
-                    </div>
-                  </td>
-                  <td class="text-right tabular-nums">{Map.get(@item_counts, catalogue.uuid, 0)}</td>
-                  <td><.status_badge status={catalogue.status} size={:sm} /></td>
-                  <td class="text-sm text-base-content/60">{Calendar.strftime(catalogue.updated_at, "%Y-%m-%d %H:%M")}</td>
-                  <td class="text-right whitespace-nowrap">
-                    <.table_row_menu :if={@view_mode == "active"} mode="auto" id={"cat-menu-#{catalogue.uuid}"}>
-                      <.table_row_menu_link navigate={Paths.catalogue_detail(catalogue.uuid)} icon="hero-eye" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "View")} />
-                      <.table_row_menu_link navigate={Paths.catalogue_edit(catalogue.uuid)} icon="hero-pencil" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Edit")} variant="secondary" />
-                      <.table_row_menu_button phx-click="open_move" phx-value-type="catalogue" phx-value-uuid={catalogue.uuid} icon="hero-folder-arrow-down" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")} variant="secondary" />
-                      <.table_row_menu_divider />
-                      <.table_row_menu_button phx-click="trash_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleting...")} icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")} variant="error" />
-                    </.table_row_menu>
-                    <.table_row_menu :if={@view_mode == "deleted"} mode="auto" id={"cat-del-menu-#{catalogue.uuid}"}>
-                      <.table_row_menu_button phx-click="restore_catalogue" phx-value-uuid={catalogue.uuid} phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restoring...")} icon="hero-arrow-path" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")} variant="success" />
-                      <.table_row_menu_divider />
-                      <.table_row_menu_button phx-click="show_delete_confirm" phx-value-uuid={catalogue.uuid} phx-value-type="catalogue" icon="hero-trash" label={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")} variant="error" />
-                    </.table_row_menu>
-                  </td>
-                </tr>
-            <% end %>
-          <% end %>
-        </tbody>
-      </table>
-      <%!-- "Move to root" target below the list (revealed only while dragging).
-           Below the table, so appearing here doesn't shift the rows above. --%>
-      <div
-        :if={@view_mode == "active"}
-        data-tree-rootzone="1"
-        data-tree-drop="root"
-        class="hidden mt-2 rounded-lg border-2 border-dashed border-primary/50 py-3 text-center text-sm text-base-content/60"
-      >
-        <.icon name="hero-arrow-up-tray" class="w-4 h-4 inline-block mr-1 align-text-bottom" />
-        {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Drop here to move to root (unfiled)")}
-      </div>
-    </div>
     """
   end
 
@@ -1942,7 +1386,28 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
     """
   end
 
-  # ── Cell renderers (suppliers / manufacturers) ───────────────────
+  # ── Cell renderers ───────────────────────────────────────────────
+
+  defp render_cell(:catalogues, "name", row) do
+    assigns = %{row: row}
+
+    ~H"""
+    <.link :if={@row.status != "deleted"} navigate={Paths.catalogue_detail(@row.uuid)} class="link link-hover font-medium">{@row.name}</.link>
+    <span :if={@row.status == "deleted"} class="font-medium text-base-content/50">{@row.name}</span>
+    """
+  end
+
+  defp render_cell(:catalogues, "folder", row), do: text_or_dash(row[:folder_name])
+
+  defp render_cell(:catalogues, "items", row) do
+    assigns = %{n: row[:item_count] || 0}
+    ~H"<span class='tabular-nums'>{@n}</span>"
+  end
+
+  defp render_cell(:catalogues, "kind", row), do: text_or_dash(row[:kind])
+  defp render_cell(:catalogues, "markup", row), do: pct(row[:markup_percentage])
+  defp render_cell(:catalogues, "discount", row), do: pct(row[:discount_percentage])
+  defp render_cell(:catalogues, "created", row), do: ts(row[:inserted_at])
 
   defp render_cell(scope, "name", row) when scope in [:suppliers, :manufacturers] do
     path =
@@ -1962,6 +1427,12 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   defp render_cell(_scope, "status", row), do: status_badge_cell(row.status)
   defp render_cell(_scope, "updated", row), do: ts(row.updated_at)
 
+  defp render_card_value(:catalogues, "folder", row), do: row[:folder_name] || "—"
+  defp render_card_value(:catalogues, "items", row), do: to_string(row[:item_count] || 0)
+  defp render_card_value(:catalogues, "kind", row), do: row[:kind] || "—"
+  defp render_card_value(:catalogues, "markup", row), do: pct_str(row[:markup_percentage])
+  defp render_card_value(:catalogues, "discount", row), do: pct_str(row[:discount_percentage])
+  defp render_card_value(:catalogues, "created", row), do: ts_str(row[:inserted_at])
   defp render_card_value(_scope, "website", row), do: row.website || "—"
   defp render_card_value(_scope, "status", row), do: status_label(row.status)
   defp render_card_value(_scope, "contact_info", row), do: row.contact_info || "—"
@@ -2007,4 +1478,17 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
 
   defp ts_str(nil), do: "—"
   defp ts_str(dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+
+  defp pct(nil) do
+    assigns = %{}
+    ~H"<span class='text-base-content/40'>—</span>"
+  end
+
+  defp pct(d) do
+    assigns = %{v: Decimal.to_string(d)}
+    ~H"<span class='tabular-nums'>{@v}%</span>"
+  end
+
+  defp pct_str(nil), do: "—"
+  defp pct_str(d), do: Decimal.to_string(d) <> "%"
 end

--- a/lib/phoenix_kit_catalogue/web/catalogues_live.ex
+++ b/lib/phoenix_kit_catalogue/web/catalogues_live.ex
@@ -50,11 +50,13 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
        catalogue_view_mode: "active",
        deleted_catalogue_count: 0,
        deleted_folder_count: 0,
-       expanded_folders: MapSet.new(),
+       folder_tree: [],
+       folder_tree_deleted: [],
        renaming_folder: nil,
        move_dialog: nil,
        folder_options: [],
        show_folders_modal: false,
+       folders_modal_view: "active",
        view_configs: load_view_configs(socket),
        show_column_modal: false,
        temp_columns: nil
@@ -186,6 +188,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
         deleted_catalogue_count: deleted_cat_count,
         deleted_folder_count: deleted_folder_count,
         catalogue_view_mode: mode,
+        folder_tree: active_tree,
+        folder_tree_deleted: deleted_folder_tree,
         folder_options: folder_options(active_tree)
       )
     else
@@ -403,7 +407,8 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   def handle_event("open_move", %{"type" => type, "uuid" => uuid}, socket)
       when type in ~w(folder catalogue) do
     target_type = if type == "folder", do: :folder, else: :catalogue
-    {:noreply, assign(socket, :move_dialog, {target_type, uuid})}
+    # Close the folders modal when opening the move dialog so dialogs don't stack.
+    {:noreply, assign(socket, move_dialog: {target_type, uuid}, show_folders_modal: false)}
   end
 
   def handle_event("cancel_move", _params, socket) do
@@ -516,7 +521,9 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   end
 
   def handle_event("show_delete_confirm", %{"uuid" => uuid, "type" => type}, socket) do
-    {:noreply, assign(socket, :confirm_delete, {type, uuid})}
+    # Close the folders modal when confirming folder deletion so dialogs don't stack.
+    show_folders = if type == "folder", do: false, else: socket.assigns.show_folders_modal
+    {:noreply, assign(socket, confirm_delete: {type, uuid}, show_folders_modal: show_folders)}
   end
 
   def handle_event("permanently_delete_catalogue", _params, socket) do
@@ -680,10 +687,14 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
   end
 
   def handle_event("show_folders_modal", _p, socket),
-    do: {:noreply, assign(socket, :show_folders_modal, true)}
+    do: {:noreply, assign(socket, show_folders_modal: true, folders_modal_view: "active")}
 
   def handle_event("hide_folders_modal", _p, socket),
     do: {:noreply, assign(socket, :show_folders_modal, false)}
+
+  def handle_event("set_folders_modal_view", %{"mode" => mode}, socket)
+      when mode in ~w(active deleted),
+      do: {:noreply, assign(socket, :folders_modal_view, mode)}
 
   # ── Column / sort / filter / view handlers ──────────────────────
 
@@ -1214,6 +1225,184 @@ defmodule PhoenixKitCatalogue.Web.CataloguesLive do
             </button>
           </div>
         </form>
+      </.modal>
+
+      <%!-- Folders management modal — create, rename, move, trash, restore, delete-forever. --%>
+      <.modal
+        :if={@show_folders_modal}
+        id="catalogue-folders-modal"
+        show
+        on_close="hide_folders_modal"
+      >
+        <div class="flex flex-col gap-4 min-w-72">
+          <h3 class="text-lg font-semibold">
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Folders")}
+          </h3>
+
+          <%!-- Active / Deleted toggle — only when there are deleted folders. --%>
+          <div
+            :if={@deleted_folder_count > 0}
+            class="flex items-center gap-0.5 border-b border-base-200"
+          >
+            <button
+              type="button"
+              phx-click="set_folders_modal_view"
+              phx-value-mode="active"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@folders_modal_view == "active",
+                  do: "border-primary text-primary",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Active")}
+            </button>
+            <button
+              type="button"
+              phx-click="set_folders_modal_view"
+              phx-value-mode="deleted"
+              class={[
+                "px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer",
+                if(@folders_modal_view == "deleted",
+                  do: "border-error text-error",
+                  else: "border-transparent text-base-content/50 hover:text-base-content"
+                )
+              ]}
+            >
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Deleted")} ({@deleted_folder_count})
+            </button>
+          </div>
+
+          <%!-- Empty states --%>
+          <p
+            :if={@folders_modal_view == "active" and @folder_tree == []}
+            class="text-sm text-base-content/60 py-2"
+          >
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "No folders yet.")}
+          </p>
+          <p
+            :if={@folders_modal_view == "deleted" and @folder_tree_deleted == []}
+            class="text-sm text-base-content/60 py-2"
+          >
+            {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Nothing in the trash.")}
+          </p>
+
+          <%!-- Folder list --%>
+          <% tree = if @folders_modal_view == "deleted", do: @folder_tree_deleted, else: @folder_tree %>
+          <div :if={tree != []} class="flex flex-col divide-y divide-base-200 max-h-96 overflow-y-auto">
+            <%= for {folder, depth} <- tree do %>
+              <div
+                class="flex items-center gap-2 py-1.5 group/row"
+                style={"padding-left: #{depth * 1.25 + 0.5}rem"}
+              >
+                <.icon name="hero-folder" class="w-4 h-4 text-warning shrink-0" />
+
+                <%!-- Inline rename input or display name --%>
+                <%= if @renaming_folder == folder.uuid do %>
+                  <form phx-submit="rename_folder" phx-value-uuid={folder.uuid} class="flex-1 min-w-0">
+                    <input
+                      type="text"
+                      name="name"
+                      value={folder.name}
+                      phx-mounted={Phoenix.LiveView.JS.focus()}
+                      phx-blur="rename_folder"
+                      phx-value-uuid={folder.uuid}
+                      class="input input-bordered input-xs w-full"
+                    />
+                  </form>
+                <% else %>
+                  <span class={[
+                    "flex-1 min-w-0 truncate text-sm",
+                    @folders_modal_view == "deleted" && "text-base-content/50"
+                  ]}>
+                    {folder.name}
+                  </span>
+                <% end %>
+
+                <%!-- Active row actions (hidden until hover) --%>
+                <div
+                  :if={@folders_modal_view == "active" and @renaming_folder != folder.uuid}
+                  class="flex items-center gap-0.5 opacity-0 group-hover/row:opacity-100 transition-opacity shrink-0"
+                >
+                  <button
+                    type="button"
+                    phx-click="start_rename_folder"
+                    phx-value-uuid={folder.uuid}
+                    class="btn btn-ghost btn-xs"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Rename")}
+                  >
+                    <.icon name="hero-pencil" class="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="new_subfolder"
+                    phx-value-uuid={folder.uuid}
+                    class="btn btn-ghost btn-xs"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "New subfolder")}
+                  >
+                    <.icon name="hero-folder-plus" class="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="open_move"
+                    phx-value-type="folder"
+                    phx-value-uuid={folder.uuid}
+                    class="btn btn-ghost btn-xs"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Move to folder")}
+                  >
+                    <.icon name="hero-folder-arrow-down" class="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="trash_folder"
+                    phx-value-uuid={folder.uuid}
+                    class="btn btn-ghost btn-xs text-error"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete")}
+                  >
+                    <.icon name="hero-trash" class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+
+                <%!-- Deleted row actions --%>
+                <div :if={@folders_modal_view == "deleted"} class="flex items-center gap-0.5 shrink-0">
+                  <button
+                    type="button"
+                    phx-click="restore_folder"
+                    phx-value-uuid={folder.uuid}
+                    class="btn btn-ghost btn-xs text-success"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Restore")}
+                  >
+                    <.icon name="hero-arrow-path" class="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="show_delete_confirm"
+                    phx-value-uuid={folder.uuid}
+                    phx-value-type="folder"
+                    class="btn btn-ghost btn-xs text-error"
+                    title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
+                  >
+                    <.icon name="hero-trash" class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+            <% end %>
+          </div>
+
+          <%!-- Footer: New Folder button (active view only) --%>
+          <div :if={@folders_modal_view == "active"} class="flex justify-start pt-1 border-t border-base-200">
+            <button
+              type="button"
+              phx-click="new_folder"
+              phx-disable-with={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Creating...")}
+              class="btn btn-ghost btn-sm gap-1"
+            >
+              <.icon name="hero-folder-plus" class="w-4 h-4" />
+              {Gettext.gettext(PhoenixKitCatalogue.Gettext, "New Folder")}
+            </button>
+          </div>
+        </div>
       </.modal>
 
       <.column_settings_modal

--- a/lib/phoenix_kit_catalogue/web/category_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/category_form_live.ex
@@ -7,7 +7,6 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.MultilangForm
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Modal, only: [confirm_modal: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
@@ -36,6 +35,16 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
   alias PhoenixKitCatalogue.Schemas.Category
 
   @translatable_fields ["name", "description"]
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -371,7 +380,16 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
       )
 
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new category to organize items within this catalogue."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update category details and ordering.")}
+      current_path={assigns[:url_path] || Paths.catalogue_detail(@catalogue_uuid)}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
       <%!-- Media selector — folder-scoped featured-image picker.
            No inline files grid on Category forms; featured image only. --%>
       <.live_component
@@ -384,9 +402,6 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         scope_folder_id={@files_folder_uuid}
         phoenix_kit_current_user={assigns[:phoenix_kit_current_user]}
       />
-
-      <%!-- Header --%>
-      <.admin_page_header back={Paths.catalogue_detail(@catalogue_uuid)} title={@page_title} subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new category to organize items within this catalogue."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update category details and ordering.")} />
 
       <%!-- Featured image — opens the scoped picker. Uuid stored on
            `category.data["featured_image_uuid"]`. The folder is lazily
@@ -597,7 +612,8 @@ defmodule PhoenixKitCatalogue.Web.CategoryFormLive do
         confirm_text={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Delete Forever")}
         danger={true}
       />
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/events_live.ex
+++ b/lib/phoenix_kit_catalogue/web/events_live.ex
@@ -19,6 +19,16 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
 
   @per_page 20
 
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -253,13 +263,20 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
   @impl true
   def render(assigns) do
     ~H"""
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={Gettext.gettext(PhoenixKitCatalogue.Gettext, "Events")}
+      page_subtitle={
+        Gettext.gettext(PhoenixKitCatalogue.Gettext, "Catalogue") <>
+          " · " <>
+          Gettext.gettext(PhoenixKitCatalogue.Gettext, "Events: %{count}", count: @total)
+      }
+      current_path={assigns[:url_path] || Paths.events()}
+      current_locale={assigns[:current_locale]}
+    >
     <div class="flex flex-col w-full px-4 py-6 gap-4">
-      <div class="flex items-center justify-between">
-        <div class="text-sm text-base-content/60">
-          {Gettext.gettext(PhoenixKitCatalogue.Gettext, "%{count} events", count: @total)}
-        </div>
-      </div>
-
       <%!-- Filters --%>
       <div class="bg-base-200 rounded-lg p-3">
         <.form for={%{}} phx-change="filter" class="flex flex-wrap gap-3 items-end">
@@ -413,6 +430,7 @@ defmodule PhoenixKitCatalogue.Web.EventsLive do
         }
       };
     </script>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/export_controller.ex
+++ b/lib/phoenix_kit_catalogue/web/export_controller.ex
@@ -18,7 +18,7 @@ defmodule PhoenixKitCatalogue.Web.ExportController do
     catalogue_uuids = Map.get(params, "catalogue_uuids", [])
     prefix_catalogue = Map.get(params, "prefix_catalogue", false)
 
-    {filename, content, _mime} =
+    {filename, content, mime} =
       PhoenixKitCatalogue.Export.build(%{
         destination: destination,
         format: format,
@@ -26,6 +26,9 @@ defmodule PhoenixKitCatalogue.Web.ExportController do
         prefix_catalogue: prefix_catalogue
       })
 
-    send_download(conn, {:binary, IO.iodata_to_binary(content)}, filename: filename)
+    send_download(conn, {:binary, IO.iodata_to_binary(content)},
+      filename: filename,
+      content_type: mime
+    )
   end
 end

--- a/lib/phoenix_kit_catalogue/web/export_live.ex
+++ b/lib/phoenix_kit_catalogue/web/export_live.ex
@@ -139,8 +139,9 @@ defmodule PhoenixKitCatalogue.Web.ExportLive do
           </form>
 
           <%!-- Export button — plain <a> so the browser triggers a file download --%>
-          <%= if download_url(assigns) do %>
-            <a href={download_url(assigns)} class="btn btn-primary w-fit">
+          <% url = download_url(assigns) %>
+          <%= if url do %>
+            <a href={url} class="btn btn-primary w-fit">
               <.icon name="hero-arrow-down-tray" class="w-4 h-4" />
               {Gettext.gettext(PhoenixKitCatalogue.Gettext, "Export")}
             </a>

--- a/lib/phoenix_kit_catalogue/web/item_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/item_form_live.ex
@@ -7,7 +7,6 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
   require Logger
 
   import PhoenixKitWeb.Components.MultilangForm
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
@@ -52,6 +51,16 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
     "category_uuid" => :category_uuid,
     "manufacturer_uuid" => :manufacturer_uuid
   }
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -683,25 +692,28 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
       )
 
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
-      <%!-- Header --%>
-      <.admin_page_header
-        back={if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index()}
-        title={@page_title}
-        subtitle={
-          if @action == :new,
-            do:
-              Gettext.gettext(
-                PhoenixKitCatalogue.Gettext,
-                "Add a new product or material to the catalogue."
-              ),
-            else:
-              Gettext.gettext(
-                PhoenixKitCatalogue.Gettext,
-                "Update item details, pricing, and classification."
-              )
-        }
-      />
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={
+        if @action == :new,
+          do:
+            Gettext.gettext(
+              PhoenixKitCatalogue.Gettext,
+              "Add a new product or material to the catalogue."
+            ),
+          else:
+            Gettext.gettext(
+              PhoenixKitCatalogue.Gettext,
+              "Update item details, pricing, and classification."
+            )
+      }
+      current_path={assigns[:url_path] || (if @catalogue_uuid, do: Paths.catalogue_detail(@catalogue_uuid), else: Paths.index())}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
 
       <%!-- PDF search button — visible on edit only. Opens a modal that
            searches the PDF library for any page mentioning the item's
@@ -1408,7 +1420,8 @@ defmodule PhoenixKitCatalogue.Web.ItemFormLive do
           </div>
         </div>
       </details>
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 

--- a/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/manufacturer_form_live.ex
@@ -5,7 +5,6 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
 
   require Logger
 
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
@@ -16,6 +15,16 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Manufacturer
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -180,13 +189,16 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
-      <%!-- Header --%>
-      <.admin_page_header
-        back={Paths.manufacturers()}
-        title={@page_title}
-        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new manufacturer to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update manufacturer details and supplier links.")}
-      />
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new manufacturer to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update manufacturer details and supplier links.")}
+      current_path={assigns[:url_path] || Paths.manufacturers()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
@@ -312,7 +324,8 @@ defmodule PhoenixKitCatalogue.Web.ManufacturerFormLive do
           </div>
         </div>
       </.form>
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
+++ b/lib/phoenix_kit_catalogue/web/supplier_form_live.ex
@@ -5,7 +5,6 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
 
   require Logger
 
-  import PhoenixKitWeb.Components.Core.AdminPageHeader, only: [admin_page_header: 1]
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
   import PhoenixKitWeb.Components.Core.Input, only: [input: 1]
   import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
@@ -16,6 +15,16 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
   alias PhoenixKitCatalogue.Catalogue
   alias PhoenixKitCatalogue.Paths
   alias PhoenixKitCatalogue.Schemas.Supplier
+
+  # PhoenixKit auto-applies its admin chrome layout to external module admin
+  # views via socket.private[:live_layout]. Opt out here so this view can
+  # self-wrap with LayoutWrapper.app_layout and push its title/subtitle into
+  # the global admin header (same pattern as /admin/media and orders/index).
+  on_mount({__MODULE__, :self_wrapped_layout})
+
+  def on_mount(:self_wrapped_layout, _params, _session, socket) do
+    {:cont, put_in(socket.private[:live_layout], {PhoenixKitWeb.Layouts, :app})}
+  end
 
   @impl true
   def mount(params, _session, socket) do
@@ -175,13 +184,16 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
-      <%!-- Header --%>
-      <.admin_page_header
-        back={Paths.suppliers()}
-        title={@page_title}
-        subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new supplier to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update supplier details and manufacturer links.")}
-      />
+    <PhoenixKitWeb.Components.LayoutWrapper.app_layout
+      socket={@socket}
+      flash={@flash}
+      phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+      page_title={@page_title}
+      page_subtitle={if @action == :new, do: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Add a new supplier to your catalogue system."), else: Gettext.gettext(PhoenixKitCatalogue.Gettext, "Update supplier details and manufacturer links.")}
+      current_path={assigns[:url_path] || Paths.suppliers()}
+      current_locale={assigns[:current_locale]}
+    >
+      <div class="flex flex-col mx-auto max-w-2xl px-4 py-8 gap-6">
 
       <.form for={@form} action="#" phx-change="validate" phx-submit="save">
         <div class="card bg-base-100 shadow-lg">
@@ -300,7 +312,8 @@ defmodule PhoenixKitCatalogue.Web.SupplierFormLive do
           </div>
         </div>
       </.form>
-    </div>
+      </div>
+    </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
     """
   end
 end

--- a/lib/phoenix_kit_catalogue/web/table_config.ex
+++ b/lib/phoenix_kit_catalogue/web/table_config.ex
@@ -1,0 +1,159 @@
+defmodule PhoenixKitCatalogue.Web.TableConfig do
+  @moduledoc """
+  Column metadata for the catalogue admin tables, keyed by scope
+  (`:catalogues`, `:suppliers`, `:manufacturers`). Pure data — cell and
+  card rendering live in the LiveView. Labels are zero-arity fns so they
+  resolve in the request's current locale.
+  """
+  alias PhoenixKitCatalogue.Gettext, as: G
+
+  @type scope :: :catalogues | :suppliers | :manufacturers
+  @type column :: %{
+          id: String.t(),
+          label: (-> String.t()),
+          default?: boolean(),
+          managed?: boolean(),
+          sortable?: boolean(),
+          sort_key: (map() -> term()) | nil,
+          align: :left | :right,
+          filterable?: boolean(),
+          filter_type: :enum | nil
+        }
+
+  defp g(s), do: Gettext.gettext(G, s)
+
+  # Build a column with sensible defaults.
+  defp col(id, label_fn, opts) do
+    %{
+      id: id,
+      label: label_fn,
+      default?: Keyword.get(opts, :default?, false),
+      managed?: Keyword.get(opts, :managed?, true),
+      sortable?: Keyword.get(opts, :sortable?, false),
+      sort_key: Keyword.get(opts, :sort_key),
+      align: Keyword.get(opts, :align, :left),
+      filterable?: Keyword.get(opts, :filterable?, false),
+      filter_type: Keyword.get(opts, :filter_type)
+    }
+  end
+
+  @spec columns(scope()) :: [column()]
+  def columns(:catalogues) do
+    [
+      col("name", fn -> g("Name") end,
+        default?: true,
+        managed?: false,
+        sortable?: true,
+        sort_key: &down(&1.name)
+      ),
+      col("folder", fn -> g("Folder") end,
+        default?: true,
+        sortable?: true,
+        sort_key: &down(&1[:folder_name]),
+        filterable?: true,
+        filter_type: :enum
+      ),
+      col("items", fn -> g("Items") end,
+        default?: true,
+        sortable?: true,
+        align: :right,
+        sort_key: &(&1[:item_count] || 0)
+      ),
+      col("status", fn -> g("Status") end,
+        default?: true,
+        sortable?: true,
+        sort_key: &down(&1.status),
+        filterable?: true,
+        filter_type: :enum
+      ),
+      col("kind", fn -> g("Kind") end,
+        sortable?: true,
+        sort_key: &down(&1.kind),
+        filterable?: true,
+        filter_type: :enum
+      ),
+      col("markup", fn -> g("Markup %") end,
+        sortable?: true,
+        align: :right,
+        sort_key: &dec(&1.markup_percentage)
+      ),
+      col("discount", fn -> g("Discount %") end,
+        sortable?: true,
+        align: :right,
+        sort_key: &dec(&1.discount_percentage)
+      ),
+      col("updated", fn -> g("Updated") end,
+        default?: true,
+        sortable?: true,
+        sort_key: & &1.updated_at
+      ),
+      col("created", fn -> g("Created") end, sortable?: true, sort_key: & &1.inserted_at)
+    ]
+  end
+
+  def columns(scope) when scope in [:suppliers, :manufacturers] do
+    [
+      col("name", fn -> g("Name") end,
+        default?: true,
+        managed?: false,
+        sortable?: true,
+        sort_key: &down(&1.name)
+      ),
+      col("website", fn -> g("Website") end,
+        default?: true,
+        sortable?: true,
+        sort_key: &down(&1.website)
+      ),
+      col("status", fn -> g("Status") end,
+        default?: true,
+        sortable?: true,
+        sort_key: &down(&1.status),
+        filterable?: true,
+        filter_type: :enum
+      ),
+      col("contact_info", fn -> g("Contact Info") end,
+        sortable?: true,
+        sort_key: &down(&1.contact_info)
+      ),
+      col("updated", fn -> g("Updated") end, sortable?: true, sort_key: & &1.updated_at)
+    ]
+  end
+
+  @spec default_columns(scope()) :: [String.t()]
+  def default_columns(scope) do
+    scope |> columns() |> Enum.filter(& &1.default?) |> Enum.map(& &1.id)
+  end
+
+  @spec managed_columns(scope()) :: [column()]
+  def managed_columns(scope), do: scope |> columns() |> Enum.filter(& &1.managed?)
+
+  @spec column_map(scope()) :: %{String.t() => column()}
+  def column_map(scope), do: scope |> columns() |> Map.new(&{&1.id, &1})
+
+  @spec validate_columns(scope(), [String.t()]) :: [String.t()]
+  def validate_columns(scope, ids) when is_list(ids) do
+    known = scope |> managed_columns() |> MapSet.new(& &1.id)
+    ids |> Enum.filter(&MapSet.member?(known, &1)) |> Enum.uniq()
+  end
+
+  def validate_columns(_scope, _), do: []
+
+  @spec sortable_visible(scope(), [String.t()]) :: [column()]
+  def sortable_visible(scope, ids) do
+    map = column_map(scope)
+    ids |> Enum.map(&Map.get(map, &1)) |> Enum.filter(&(&1 && &1.sortable?))
+  end
+
+  @spec default_sort(scope()) :: {String.t(), :asc | :desc}
+  def default_sort(:catalogues), do: {"name", :asc}
+  def default_sort(_), do: {"name", :asc}
+
+  # sort helpers: case-insensitive for strings, Decimal→float, nil-safe.
+  defp down(nil), do: ""
+  defp down(s) when is_binary(s), do: String.downcase(s)
+  defp down(other), do: other
+
+  defp dec(%Decimal{} = d), do: Decimal.to_float(d)
+  defp dec(n) when is_number(n), do: n
+  defp dec(_), do: 0.0
+end

--- a/lib/phoenix_kit_catalogue/web/table_query.ex
+++ b/lib/phoenix_kit_catalogue/web/table_query.ex
@@ -1,0 +1,68 @@
+defmodule PhoenixKitCatalogue.Web.TableQuery do
+  @moduledoc """
+  Pure, in-memory search → filter → sort pipeline over a list of row maps
+  (catalogues/suppliers/manufacturers already loaded by the LiveView).
+  """
+  alias PhoenixKitCatalogue.Web.TableConfig
+
+  @spec apply([map()], TableConfig.scope(), map()) :: [map()]
+  def apply(rows, scope, opts) do
+    rows
+    |> search(Map.get(opts, :search, ""))
+    |> filter(scope, Map.get(opts, :filters, %{}))
+    |> sort(scope, Map.get(opts, :sort_by), Map.get(opts, :sort_dir, :asc))
+  end
+
+  @spec search([map()], String.t() | nil) :: [map()]
+  def search(rows, q) when is_binary(q) and q != "" do
+    needle = String.downcase(q)
+    Enum.filter(rows, fn r -> String.contains?(String.downcase(r.name || ""), needle) end)
+  end
+
+  def search(rows, _), do: rows
+
+  @spec filter([map()], TableConfig.scope(), map()) :: [map()]
+  def filter(rows, scope, filters) when is_map(filters) do
+    Enum.reduce(filters, rows, fn
+      {_id, val}, acc when val in [nil, "", "all"] -> acc
+      {id, val}, acc -> Enum.filter(acc, &filter_match?(scope, id, &1, val))
+    end)
+  end
+
+  def filter(rows, _scope, _), do: rows
+
+  defp filter_match?(_scope, "folder", row, val), do: to_string(row[:folder_uuid]) == val
+
+  defp filter_match?(_scope, id, row, val),
+    do: to_string(Map.get(row, String.to_existing_atom(id))) == val
+
+  @spec sort([map()], TableConfig.scope(), String.t() | nil, :asc | :desc) :: [map()]
+  def sort(rows, scope, sort_by, dir) when is_binary(sort_by) do
+    case TableConfig.column_map(scope)[sort_by] do
+      %{sort_key: key} when is_function(key, 1) -> Enum.sort_by(rows, key, dir)
+      _ -> rows
+    end
+  end
+
+  def sort(rows, _scope, _sort_by, _dir), do: rows
+
+  @spec enum_options([map()], TableConfig.scope(), String.t()) :: [{String.t(), String.t()}]
+  def enum_options(rows, _scope, "folder") do
+    rows
+    |> Enum.map(&{to_string(&1[:folder_uuid]), &1[:folder_name]})
+    |> Enum.reject(fn {uuid, _} -> uuid in ["", "nil"] end)
+    |> Enum.uniq()
+    |> Enum.sort_by(fn {_u, name} -> String.downcase(name || "") end)
+  end
+
+  def enum_options(rows, _scope, id) do
+    key = String.to_existing_atom(id)
+
+    rows
+    |> Enum.map(&to_string(Map.get(&1, key)))
+    |> Enum.reject(&(&1 in ["", "nil"]))
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.map(&{&1, &1})
+  end
+end

--- a/lib/phoenix_kit_catalogue/web/table_toolbar.ex
+++ b/lib/phoenix_kit_catalogue/web/table_toolbar.ex
@@ -1,0 +1,155 @@
+defmodule PhoenixKitCatalogue.Web.TableToolbar do
+  @moduledoc """
+  Toolbar pieces for the catalogue admin tables: the column-settings modal,
+  the sort select+direction control, and an enum filter select. All emit
+  plain events handled by `CataloguesLive` against the active scope.
+  """
+  use Phoenix.Component
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Modal, only: [modal: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
+
+  alias PhoenixKitCatalogue.Gettext, as: G
+  alias PhoenixKitCatalogue.Web.TableConfig
+
+  defp g(s), do: Gettext.gettext(G, s)
+
+  attr(:show, :boolean, required: true)
+  attr(:scope, :atom, required: true)
+  attr(:selected, :list, required: true)
+  attr(:temp_selected, :list, default: nil)
+
+  def column_settings_modal(assigns) do
+    assigns =
+      assigns
+      |> assign(:current, assigns.temp_selected || assigns.selected)
+      |> assign(:map, TableConfig.column_map(assigns.scope))
+      |> assign(:available, TableConfig.managed_columns(assigns.scope))
+
+    assigns =
+      assign(assigns, :hidden, Enum.reject(assigns.available, &(&1.id in assigns.current)))
+
+    ~H"""
+    <.modal :if={@show} id="catalogue-columns-modal" show on_close="hide_column_modal">
+      <form phx-submit="apply_columns">
+        <input type="hidden" name="column_order" value={Enum.join(@current, ",")} id="catalogue-columns-order" />
+        <h3 class="text-lg font-semibold mb-3">{g("Columns")}</h3>
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <p class="text-xs uppercase text-base-content/50 mb-2">{g("Shown")}</p>
+            <ul
+              id="catalogue-columns-selected"
+              phx-hook="SortableGrid"
+              data-sortable="true"
+              data-sortable-event="reorder_columns"
+              data-sortable-items=".col-item"
+              class="space-y-1"
+            >
+              <li
+                :for={id <- @current}
+                :if={@map[id] && @map[id].managed?}
+                data-id={id}
+                class="col-item flex items-center gap-2 px-2 py-1 rounded bg-base-200"
+              >
+                <.icon name="hero-bars-3" class="w-4 h-4 pk-drag-handle cursor-grab text-base-content/40" />
+                <span class="flex-1 text-sm">{@map[id].label.()}</span>
+                <button
+                  type="button"
+                  phx-click="remove_column"
+                  phx-value-column_id={id}
+                  class="btn btn-ghost btn-xs btn-square text-error"
+                >
+                  <.icon name="hero-x-mark" class="w-4 h-4" />
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <p class="text-xs uppercase text-base-content/50 mb-2">{g("Available")}</p>
+            <ul class="space-y-1">
+              <li
+                :for={c <- @hidden}
+                class="flex items-center gap-2 px-2 py-1 rounded hover:bg-base-200"
+              >
+                <button
+                  type="button"
+                  phx-click="add_column"
+                  phx-value-column_id={c.id}
+                  class="flex items-center gap-2 w-full text-left text-sm"
+                >
+                  <.icon name="hero-plus" class="w-4 h-4 text-base-content/40" />
+                  <span>{c.label.()}</span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="flex justify-between mt-4">
+          <button type="button" phx-click="reset_columns" class="btn btn-ghost btn-sm">
+            {g("Reset")}
+          </button>
+          <div class="flex gap-2">
+            <button type="button" phx-click="hide_column_modal" class="btn btn-ghost btn-sm">
+              {g("Cancel")}
+            </button>
+            <button type="submit" class="btn btn-primary btn-sm">{g("Apply")}</button>
+          </div>
+        </div>
+      </form>
+    </.modal>
+    """
+  end
+
+  attr(:scope, :atom, required: true)
+  attr(:selected, :list, required: true)
+  attr(:sort_by, :string, required: true)
+  attr(:sort_dir, :atom, required: true)
+
+  def sort_controls(assigns) do
+    assigns =
+      assign(assigns, :options, TableConfig.sortable_visible(assigns.scope, assigns.selected))
+
+    ~H"""
+    <form phx-change="set_sort" class="join">
+      <select name="sort_by" class="select select-sm join-item">
+        <option :for={c <- @options} value={c.id} selected={@sort_by == c.id}>{c.label.()}</option>
+      </select>
+      <button
+        type="button"
+        phx-click="flip_sort_dir"
+        class="btn btn-sm btn-ghost join-item"
+        title={g("Toggle sort direction")}
+      >
+        <.icon
+          name={if @sort_dir == :asc, do: "hero-chevron-up", else: "hero-chevron-down"}
+          class="w-4 h-4"
+        />
+      </button>
+    </form>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:value, :string, default: nil)
+  attr(:options, :list, required: true)
+  attr(:prompt, :string, required: true)
+
+  def enum_filter(assigns) do
+    ~H"""
+    <form phx-change="set_filter" class="contents">
+      <input type="hidden" name="column_id" value={@id} />
+      <.select
+        name="value"
+        id={"filter-#{@id}"}
+        value={@value}
+        prompt={@prompt}
+        options={@options}
+        class="select-sm"
+        aria-label={@label}
+      />
+    </form>
+    """
+  end
+end

--- a/lib/phoenix_kit_catalogue/web/view_config.ex
+++ b/lib/phoenix_kit_catalogue/web/view_config.ex
@@ -1,0 +1,81 @@
+defmodule PhoenixKitCatalogue.Web.ViewConfig do
+  @moduledoc """
+  Per-user table view config (columns / sort / filters / view mode) for the
+  catalogue admin tables. Stored in `phoenix_kit_users.custom_fields` under
+  the `"catalogue_view_configs"` key — no dedicated table. Precedent:
+  `PhoenixKit.Notifications.Prefs`.
+  """
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKitCatalogue.Web.TableConfig
+
+  @root "catalogue_view_configs"
+
+  @spec scope_key(TableConfig.scope()) :: String.t()
+  def scope_key(scope), do: to_string(scope)
+
+  @spec defaults(TableConfig.scope()) :: map()
+  def defaults(scope) do
+    {sort_by, sort_dir} = TableConfig.default_sort(scope)
+
+    %{
+      columns: TableConfig.default_columns(scope),
+      sort_by: sort_by,
+      sort_dir: sort_dir,
+      filters: %{},
+      view: "table"
+    }
+  end
+
+  @spec load(map() | nil, TableConfig.scope()) :: map()
+  def load(user, scope) do
+    raw =
+      case user do
+        %{custom_fields: cf} when is_map(cf) -> get_in(cf, [@root, scope_key(scope)]) || %{}
+        _ -> %{}
+      end
+
+    normalize(scope, raw)
+  end
+
+  @spec normalize(TableConfig.scope(), map()) :: map()
+  def normalize(scope, raw) when is_map(raw) do
+    d = defaults(scope)
+
+    cols =
+      case TableConfig.validate_columns(scope, List.wrap(raw["columns"])) do
+        [] -> d.columns
+        list -> list
+      end
+
+    %{
+      columns: cols,
+      sort_by: raw["sort_by"] || d.sort_by,
+      sort_dir: dir(raw["sort_dir"], d.sort_dir),
+      filters: (is_map(raw["filters"]) && raw["filters"]) || %{},
+      view: (raw["view"] in ["table", "card"] && raw["view"]) || "table"
+    }
+  end
+
+  def normalize(scope, _), do: defaults(scope)
+
+  defp dir("desc", _), do: :desc
+  defp dir("asc", _), do: :asc
+  defp dir(_, fallback), do: fallback
+
+  @spec save(map(), TableConfig.scope(), map()) :: {:ok, map()} | {:error, term()}
+  def save(user, scope, cfg) do
+    serialized = %{
+      "columns" => cfg.columns,
+      "sort_by" => cfg.sort_by,
+      "sort_dir" => to_string(cfg.sort_dir),
+      "filters" => cfg.filters,
+      "view" => cfg.view
+    }
+
+    current = user.custom_fields || %{}
+    scoped = Map.put(Map.get(current, @root, %{}), scope_key(scope), serialized)
+    merged = Map.put(current, @root, scoped)
+
+    Auth.update_user_custom_fields(user, merged, ensure_definitions: false, broadcast: false)
+  end
+end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -675,6 +675,9 @@ msgstr ""
 msgid "All events loaded"
 msgstr ""
 
+msgid "Events: %{count}"
+msgstr ""
+
 msgid "Danger Zone"
 msgstr ""
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -945,3 +945,6 @@ msgstr ""
 
 msgid "This will permanently delete this supplier. Manufacturer links will be removed."
 msgstr ""
+
+msgid "No results found."
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -790,3 +790,158 @@ msgstr ""
 
 msgid "Permanently deleted %{count} items."
 msgstr ""
+
+## Catalogue table toolbar
+msgid "Columns"
+msgstr ""
+
+msgid "Shown"
+msgstr ""
+
+msgid "Available"
+msgstr ""
+
+msgid "Reset"
+msgstr ""
+
+msgid "Apply"
+msgstr ""
+
+msgid "Toggle sort direction"
+msgstr ""
+
+## Catalogue table columns
+msgid "Folder"
+msgstr ""
+
+msgid "Discount %"
+msgstr ""
+
+msgid "Contact Info"
+msgstr ""
+
+msgid "Website"
+msgstr ""
+
+## Catalogue index toolbar / filters
+msgid "Folders"
+msgstr ""
+
+msgid "Folders…"
+msgstr ""
+
+msgid "All folders"
+msgstr ""
+
+msgid "All statuses"
+msgstr ""
+
+## Folder management modal
+msgid "No folders yet."
+msgstr ""
+
+msgid "Nothing in the trash."
+msgstr ""
+
+msgid "New Folder"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New subfolder"
+msgstr ""
+
+msgid "Move to folder"
+msgstr ""
+
+msgid "Rename"
+msgstr ""
+
+msgid "Permanently Delete Folder"
+msgstr ""
+
+msgid "Creating..."
+msgstr ""
+
+msgid "Moving..."
+msgstr ""
+
+msgid "Restoring..."
+msgstr ""
+
+msgid "— Root (unfiled) —"
+msgstr ""
+
+msgid "Choose a destination folder for this folder."
+msgstr ""
+
+msgid "Choose a destination folder for this catalogue."
+msgstr ""
+
+msgid "Can't move a folder into itself or one of its subfolders."
+msgstr ""
+
+msgid "That folder is in the trash."
+msgstr ""
+
+msgid "That folder no longer exists."
+msgstr ""
+
+msgid "This will permanently delete this folder. Subfolders are moved to root and catalogues filed here are unfiled — neither is deleted. This cannot be undone."
+msgstr ""
+
+msgid "Folder moved."
+msgstr ""
+
+msgid "Folder restored."
+msgstr ""
+
+msgid "Folder moved to deleted."
+msgstr ""
+
+msgid "Folder not found."
+msgstr ""
+
+msgid "Folder permanently deleted."
+msgstr ""
+
+msgid "Failed to create folder."
+msgstr ""
+
+msgid "Failed to delete folder."
+msgstr ""
+
+msgid "Failed to restore folder."
+msgstr ""
+
+msgid "Failed to move folder."
+msgstr ""
+
+msgid "Failed to move catalogue."
+msgstr ""
+
+msgid "Failed to move."
+msgstr ""
+
+msgid "Unexpected request. Please try again."
+msgstr ""
+
+## Catalogue confirm-delete dialogs
+msgid "Catalogue moved."
+msgstr ""
+
+msgid "Delete Manufacturer"
+msgstr ""
+
+msgid "Delete Supplier"
+msgstr ""
+
+msgid "This will permanently delete this catalogue, all its categories, and all items. This cannot be undone."
+msgstr ""
+
+msgid "This will permanently delete this manufacturer. Items referencing it will lose the association."
+msgstr ""
+
+msgid "This will permanently delete this supplier. Manufacturer links will be removed."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -670,6 +670,9 @@ msgstr "Map Columns"
 msgid "All events loaded"
 msgstr "All events loaded"
 
+msgid "Events: %{count}"
+msgstr "Events: %{count}"
+
 msgid "Danger Zone"
 msgstr "Danger Zone"
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -936,3 +936,6 @@ msgstr "This will permanently delete this manufacturer. Items referencing it wil
 
 msgid "This will permanently delete this supplier. Manufacturer links will be removed."
 msgstr "This will permanently delete this supplier. Manufacturer links will be removed."
+
+msgid "No results found."
+msgstr "No results found."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -781,3 +781,158 @@ msgstr "Moved %{count} items."
 
 msgid "Permanently deleted %{count} items."
 msgstr "Permanently deleted %{count} items."
+
+## Catalogue table toolbar
+msgid "Columns"
+msgstr "Columns"
+
+msgid "Shown"
+msgstr "Shown"
+
+msgid "Available"
+msgstr "Available"
+
+msgid "Reset"
+msgstr "Reset"
+
+msgid "Apply"
+msgstr "Apply"
+
+msgid "Toggle sort direction"
+msgstr "Toggle sort direction"
+
+## Catalogue table columns
+msgid "Folder"
+msgstr "Folder"
+
+msgid "Discount %"
+msgstr "Discount %"
+
+msgid "Contact Info"
+msgstr "Contact Info"
+
+msgid "Website"
+msgstr "Website"
+
+## Catalogue index toolbar / filters
+msgid "Folders"
+msgstr "Folders"
+
+msgid "Folders…"
+msgstr "Folders…"
+
+msgid "All folders"
+msgstr "All folders"
+
+msgid "All statuses"
+msgstr "All statuses"
+
+## Folder management modal
+msgid "No folders yet."
+msgstr "No folders yet."
+
+msgid "Nothing in the trash."
+msgstr "Nothing in the trash."
+
+msgid "New Folder"
+msgstr "New Folder"
+
+msgid "New folder"
+msgstr "New folder"
+
+msgid "New subfolder"
+msgstr "New subfolder"
+
+msgid "Move to folder"
+msgstr "Move to folder"
+
+msgid "Rename"
+msgstr "Rename"
+
+msgid "Permanently Delete Folder"
+msgstr "Permanently Delete Folder"
+
+msgid "Creating..."
+msgstr "Creating..."
+
+msgid "Moving..."
+msgstr "Moving..."
+
+msgid "Restoring..."
+msgstr "Restoring..."
+
+msgid "— Root (unfiled) —"
+msgstr "— Root (unfiled) —"
+
+msgid "Choose a destination folder for this folder."
+msgstr "Choose a destination folder for this folder."
+
+msgid "Choose a destination folder for this catalogue."
+msgstr "Choose a destination folder for this catalogue."
+
+msgid "Can't move a folder into itself or one of its subfolders."
+msgstr "Can't move a folder into itself or one of its subfolders."
+
+msgid "That folder is in the trash."
+msgstr "That folder is in the trash."
+
+msgid "That folder no longer exists."
+msgstr "That folder no longer exists."
+
+msgid "This will permanently delete this folder. Subfolders are moved to root and catalogues filed here are unfiled — neither is deleted. This cannot be undone."
+msgstr "This will permanently delete this folder. Subfolders are moved to root and catalogues filed here are unfiled — neither is deleted. This cannot be undone."
+
+msgid "Folder moved."
+msgstr "Folder moved."
+
+msgid "Folder restored."
+msgstr "Folder restored."
+
+msgid "Folder moved to deleted."
+msgstr "Folder moved to deleted."
+
+msgid "Folder not found."
+msgstr "Folder not found."
+
+msgid "Folder permanently deleted."
+msgstr "Folder permanently deleted."
+
+msgid "Failed to create folder."
+msgstr "Failed to create folder."
+
+msgid "Failed to delete folder."
+msgstr "Failed to delete folder."
+
+msgid "Failed to restore folder."
+msgstr "Failed to restore folder."
+
+msgid "Failed to move folder."
+msgstr "Failed to move folder."
+
+msgid "Failed to move catalogue."
+msgstr "Failed to move catalogue."
+
+msgid "Failed to move."
+msgstr "Failed to move."
+
+msgid "Unexpected request. Please try again."
+msgstr "Unexpected request. Please try again."
+
+## Catalogue confirm-delete dialogs
+msgid "Catalogue moved."
+msgstr "Catalogue moved."
+
+msgid "Delete Manufacturer"
+msgstr "Delete Manufacturer"
+
+msgid "Delete Supplier"
+msgstr "Delete Supplier"
+
+msgid "This will permanently delete this catalogue, all its categories, and all items. This cannot be undone."
+msgstr "This will permanently delete this catalogue, all its categories, and all items. This cannot be undone."
+
+msgid "This will permanently delete this manufacturer. Items referencing it will lose the association."
+msgstr "This will permanently delete this manufacturer. Items referencing it will lose the association."
+
+msgid "This will permanently delete this supplier. Manufacturer links will be removed."
+msgstr "This will permanently delete this supplier. Manufacturer links will be removed."

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -670,6 +670,9 @@ msgstr "Vastenda veerud"
 msgid "All events loaded"
 msgstr "Kõik sündmused laaditud"
 
+msgid "Events: %{count}"
+msgstr "Sündmusi: %{count}"
+
 msgid "Danger Zone"
 msgstr "Ohutsoon"
 

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -781,3 +781,158 @@ msgstr "Teisaldati %{count} toodet."
 
 msgid "Permanently deleted %{count} items."
 msgstr "Jäädavalt kustutati %{count} toodet."
+
+## Catalogue table toolbar
+msgid "Columns"
+msgstr "Veerud"
+
+msgid "Shown"
+msgstr "Näidatud"
+
+msgid "Available"
+msgstr "Saadaval"
+
+msgid "Reset"
+msgstr "Lähtesta"
+
+msgid "Apply"
+msgstr "Rakenda"
+
+msgid "Toggle sort direction"
+msgstr "Muuda sortimissuunda"
+
+## Catalogue table columns
+msgid "Folder"
+msgstr "Kaust"
+
+msgid "Discount %"
+msgstr "Allahindlus %"
+
+msgid "Contact Info"
+msgstr "Kontaktandmed"
+
+msgid "Website"
+msgstr "Veebisait"
+
+## Catalogue index toolbar / filters
+msgid "Folders"
+msgstr "Kaustad"
+
+msgid "Folders…"
+msgstr "Kaustad…"
+
+msgid "All folders"
+msgstr "Kõik kaustad"
+
+msgid "All statuses"
+msgstr "Kõik staatused"
+
+## Folder management modal
+msgid "No folders yet."
+msgstr "Kaustu pole veel."
+
+msgid "Nothing in the trash."
+msgstr "Prügikast on tühi."
+
+msgid "New Folder"
+msgstr "Uus kaust"
+
+msgid "New folder"
+msgstr "Uus kaust"
+
+msgid "New subfolder"
+msgstr "Uus alamkaust"
+
+msgid "Move to folder"
+msgstr "Teisalda kausta"
+
+msgid "Rename"
+msgstr "Nimeta ümber"
+
+msgid "Permanently Delete Folder"
+msgstr "Kustuta kaust jäädavalt"
+
+msgid "Creating..."
+msgstr "Loomisel..."
+
+msgid "Moving..."
+msgstr "Teisaldamisel..."
+
+msgid "Restoring..."
+msgstr "Taastamisel..."
+
+msgid "— Root (unfiled) —"
+msgstr "— Juur (liigitamata) —"
+
+msgid "Choose a destination folder for this folder."
+msgstr "Valige selle kausta jaoks sihtkaust."
+
+msgid "Choose a destination folder for this catalogue."
+msgstr "Valige kataloogi jaoks sihtkaust."
+
+msgid "Can't move a folder into itself or one of its subfolders."
+msgstr "Ei saa kausta iseendasse ega selle alamkaustadesse teisaldada."
+
+msgid "That folder is in the trash."
+msgstr "See kaust on prügikastis."
+
+msgid "That folder no longer exists."
+msgstr "See kaust enam ei eksisteeri."
+
+msgid "This will permanently delete this folder. Subfolders are moved to root and catalogues filed here are unfiled — neither is deleted. This cannot be undone."
+msgstr "See kustutab kausta jäädavalt. Alamkaustad teisaldatakse juure ja siin asuvad kataloogid muutuvad liigitamatuks — kumbagi ei kustutata. Seda ei saa tagasi võtta."
+
+msgid "Folder moved."
+msgstr "Kaust teisaldati."
+
+msgid "Folder restored."
+msgstr "Kaust taastati."
+
+msgid "Folder moved to deleted."
+msgstr "Kaust teisaldati kustututesse."
+
+msgid "Folder not found."
+msgstr "Kausta ei leitud."
+
+msgid "Folder permanently deleted."
+msgstr "Kaust kustutati jäädavalt."
+
+msgid "Failed to create folder."
+msgstr "Kausta loomine ebaõnnestus."
+
+msgid "Failed to delete folder."
+msgstr "Kausta kustutamine ebaõnnestus."
+
+msgid "Failed to restore folder."
+msgstr "Kausta taastamine ebaõnnestus."
+
+msgid "Failed to move folder."
+msgstr "Kausta teisaldamine ebaõnnestus."
+
+msgid "Failed to move catalogue."
+msgstr "Kataloogi teisaldamine ebaõnnestus."
+
+msgid "Failed to move."
+msgstr "Teisaldamine ebaõnnestus."
+
+msgid "Unexpected request. Please try again."
+msgstr "Ootamatu päring. Proovige uuesti."
+
+## Catalogue confirm-delete dialogs
+msgid "Catalogue moved."
+msgstr "Kataloog teisaldati."
+
+msgid "Delete Manufacturer"
+msgstr "Kustuta tootja"
+
+msgid "Delete Supplier"
+msgstr "Kustuta tarnija"
+
+msgid "This will permanently delete this catalogue, all its categories, and all items. This cannot be undone."
+msgstr "See kustutab selle kataloogi, kõik selle kategooriad ja tooted jäädavalt. Seda ei saa tagasi võtta."
+
+msgid "This will permanently delete this manufacturer. Items referencing it will lose the association."
+msgstr "See kustutab selle tootja jäädavalt. Tooted, mis sellele viitavad, kaotavad seose."
+
+msgid "This will permanently delete this supplier. Manufacturer links will be removed."
+msgstr "See kustutab selle tarnija jäädavalt. Tootjate seosed eemaldatakse."

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -936,3 +936,6 @@ msgstr "See kustutab selle tootja jäädavalt. Tooted, mis sellele viitavad, kao
 
 msgid "This will permanently delete this supplier. Manufacturer links will be removed."
 msgstr "See kustutab selle tarnija jäädavalt. Tootjate seosed eemaldatakse."
+
+msgid "No results found."
+msgstr "Tulemusi ei leitud."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -670,6 +670,9 @@ msgstr "Сопоставление столбцов"
 msgid "All events loaded"
 msgstr "Все события загружены"
 
+msgid "Events: %{count}"
+msgstr "Событий: %{count}"
+
 msgid "Danger Zone"
 msgstr "Опасная зона"
 

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -945,3 +945,6 @@ msgstr "Это навсегда удалит производителя. Поз�
 
 msgid "This will permanently delete this supplier. Manufacturer links will be removed."
 msgstr "Это навсегда удалит поставщика. Связи с производителями будут удалены."
+
+msgid "No results found."
+msgstr "Ничего не найдено."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -790,3 +790,158 @@ msgstr "Перемещено %{count} позиций."
 
 msgid "Permanently deleted %{count} items."
 msgstr "Окончательно удалено %{count} позиций."
+
+## Catalogue table toolbar
+msgid "Columns"
+msgstr "Колонки"
+
+msgid "Shown"
+msgstr "Показаны"
+
+msgid "Available"
+msgstr "Доступные"
+
+msgid "Reset"
+msgstr "Сбросить"
+
+msgid "Apply"
+msgstr "Применить"
+
+msgid "Toggle sort direction"
+msgstr "Сменить направление сортировки"
+
+## Catalogue table columns
+msgid "Folder"
+msgstr "Папка"
+
+msgid "Discount %"
+msgstr "Скидка %"
+
+msgid "Contact Info"
+msgstr "Контакты"
+
+msgid "Website"
+msgstr "Сайт"
+
+## Catalogue index toolbar / filters
+msgid "Folders"
+msgstr "Папки"
+
+msgid "Folders…"
+msgstr "Папки…"
+
+msgid "All folders"
+msgstr "Все папки"
+
+msgid "All statuses"
+msgstr "Все статусы"
+
+## Folder management modal
+msgid "No folders yet."
+msgstr "Папок ещё нет."
+
+msgid "Nothing in the trash."
+msgstr "В корзине ничего нет."
+
+msgid "New Folder"
+msgstr "Новая папка"
+
+msgid "New folder"
+msgstr "Новая папка"
+
+msgid "New subfolder"
+msgstr "Новая подпапка"
+
+msgid "Move to folder"
+msgstr "Переместить в папку"
+
+msgid "Rename"
+msgstr "Переименовать"
+
+msgid "Permanently Delete Folder"
+msgstr "Удалить папку навсегда"
+
+msgid "Creating..."
+msgstr "Создаётся..."
+
+msgid "Moving..."
+msgstr "Перемещается..."
+
+msgid "Restoring..."
+msgstr "Восстанавливается..."
+
+msgid "— Root (unfiled) —"
+msgstr "— Корень (без папки) —"
+
+msgid "Choose a destination folder for this folder."
+msgstr "Выберите папку назначения для этой папки."
+
+msgid "Choose a destination folder for this catalogue."
+msgstr "Выберите папку назначения для каталога."
+
+msgid "Can't move a folder into itself or one of its subfolders."
+msgstr "Нельзя переместить папку в саму себя или одну из её подпапок."
+
+msgid "That folder is in the trash."
+msgstr "Эта папка в корзине."
+
+msgid "That folder no longer exists."
+msgstr "Этой папки больше не существует."
+
+msgid "This will permanently delete this folder. Subfolders are moved to root and catalogues filed here are unfiled — neither is deleted. This cannot be undone."
+msgstr "Это навсегда удалит папку. Подпапки переместятся в корень, а каталоги из неё станут неотсортированными — ни те, ни другие удалены не будут. Отменить невозможно."
+
+msgid "Folder moved."
+msgstr "Папка перемещена."
+
+msgid "Folder restored."
+msgstr "Папка восстановлена."
+
+msgid "Folder moved to deleted."
+msgstr "Папка перемещена в корзину."
+
+msgid "Folder not found."
+msgstr "Папка не найдена."
+
+msgid "Folder permanently deleted."
+msgstr "Папка удалена навсегда."
+
+msgid "Failed to create folder."
+msgstr "Не удалось создать папку."
+
+msgid "Failed to delete folder."
+msgstr "Не удалось удалить папку."
+
+msgid "Failed to restore folder."
+msgstr "Не удалось восстановить папку."
+
+msgid "Failed to move folder."
+msgstr "Не удалось переместить папку."
+
+msgid "Failed to move catalogue."
+msgstr "Не удалось переместить каталог."
+
+msgid "Failed to move."
+msgstr "Не удалось переместить."
+
+msgid "Unexpected request. Please try again."
+msgstr "Неожиданный запрос. Попробуйте снова."
+
+## Catalogue confirm-delete dialogs
+msgid "Catalogue moved."
+msgstr "Каталог перемещён."
+
+msgid "Delete Manufacturer"
+msgstr "Удалить производителя"
+
+msgid "Delete Supplier"
+msgstr "Удалить поставщика"
+
+msgid "This will permanently delete this catalogue, all its categories, and all items. This cannot be undone."
+msgstr "Это навсегда удалит этот каталог, все его категории и позиции. Отменить невозможно."
+
+msgid "This will permanently delete this manufacturer. Items referencing it will lose the association."
+msgstr "Это навсегда удалит производителя. Позиции, ссылающиеся на него, потеряют эту связь."
+
+msgid "This will permanently delete this supplier. Manufacturer links will be removed."
+msgstr "Это навсегда удалит поставщика. Связи с производителями будут удалены."

--- a/test/phoenix_kit_catalogue/export/universal_json_test.exs
+++ b/test/phoenix_kit_catalogue/export/universal_json_test.exs
@@ -226,4 +226,12 @@ defmodule PhoenixKitCatalogue.Export.UniversalJsonTest do
       assert is_list(json["items"])
     end
   end
+
+  describe "filename sanitization" do
+    test "keeps a Cyrillic catalogue name (regression: \\w must be Unicode-aware)" do
+      cat = %{uuid: "cyr-1", name: "Кухня"}
+      {filename, _content, _mime} = UniversalJson.render(ctx([], [cat]))
+      assert filename =~ ~r/\AКухня \d{4}-\d{2}-\d{2} \d{2}-\d{2}\.json\z/
+    end
+  end
 end

--- a/test/web/table_config_test.exs
+++ b/test/web/table_config_test.exs
@@ -1,0 +1,27 @@
+defmodule PhoenixKitCatalogue.Web.TableConfigTest do
+  use ExUnit.Case, async: true
+  alias PhoenixKitCatalogue.Web.TableConfig, as: TC
+
+  test "catalogues defaults are the visible managed+name set, in order" do
+    assert TC.default_columns(:catalogues) == ["name", "folder", "items", "status", "updated"]
+  end
+
+  test "name is always present but not managed (never hidden via modal)" do
+    refute Enum.any?(TC.managed_columns(:catalogues), &(&1.id == "name"))
+    assert TC.column_map(:catalogues)["name"].managed? == false
+  end
+
+  test "validate_columns drops unknown + non-managed ids and dedups" do
+    assert TC.validate_columns(:catalogues, ["items", "items", "bogus", "name"]) == ["items"]
+  end
+
+  test "sortable_visible keeps only sortable, in given order" do
+    ids = ["status", "name", "markup"]
+    assert Enum.map(TC.sortable_visible(:catalogues, ids), & &1.id) == ids
+  end
+
+  test "suppliers/manufacturers share the column shape" do
+    assert TC.default_columns(:suppliers) == ["name", "website", "status"]
+    assert TC.default_columns(:manufacturers) == ["name", "website", "status"]
+  end
+end

--- a/test/web/table_query_test.exs
+++ b/test/web/table_query_test.exs
@@ -1,0 +1,48 @@
+defmodule PhoenixKitCatalogue.Web.TableQueryTest do
+  use ExUnit.Case, async: true
+  alias PhoenixKitCatalogue.Web.TableQuery, as: Q
+
+  defp rows do
+    [
+      %{
+        name: "Beta",
+        status: "active",
+        item_count: 3,
+        folder_uuid: "f1",
+        folder_name: "Kitchen",
+        updated_at: ~U[2026-01-02 00:00:00Z]
+      },
+      %{
+        name: "alpha",
+        status: "archived",
+        item_count: 9,
+        folder_uuid: nil,
+        folder_name: nil,
+        updated_at: ~U[2026-01-01 00:00:00Z]
+      }
+    ]
+  end
+
+  test "search is case-insensitive substring on name" do
+    assert Enum.map(Q.search(rows(), "al"), & &1.name) == ["alpha"]
+    assert Q.search(rows(), "") == rows()
+  end
+
+  test "filter by status; 'all'/nil are no-ops" do
+    assert Enum.map(Q.filter(rows(), :catalogues, %{"status" => "active"}), & &1.name) == ["Beta"]
+    assert Q.filter(rows(), :catalogues, %{"status" => "all"}) == rows()
+  end
+
+  test "filter by folder uuid" do
+    assert Enum.map(Q.filter(rows(), :catalogues, %{"folder" => "f1"}), & &1.name) == ["Beta"]
+  end
+
+  test "sort by name is case-insensitive; dir respected" do
+    assert Enum.map(Q.sort(rows(), :catalogues, "name", :asc), & &1.name) == ["alpha", "Beta"]
+    assert Enum.map(Q.sort(rows(), :catalogues, "name", :desc), & &1.name) == ["Beta", "alpha"]
+  end
+
+  test "enum_options for folder skips unfiled and dedups" do
+    assert Q.enum_options(rows(), :catalogues, "folder") == [{"f1", "Kitchen"}]
+  end
+end

--- a/test/web/view_config_test.exs
+++ b/test/web/view_config_test.exs
@@ -1,0 +1,35 @@
+defmodule PhoenixKitCatalogue.Web.ViewConfigTest do
+  use ExUnit.Case, async: true
+  alias PhoenixKitCatalogue.Web.ViewConfig, as: VC
+
+  test "defaults shape" do
+    assert %{
+             columns: ["name", "folder", "items", "status", "updated"],
+             sort_by: "name",
+             sort_dir: :asc,
+             filters: %{},
+             view: "table"
+           } = VC.defaults(:catalogues)
+  end
+
+  test "normalize falls back on empty/invalid, keeps valid" do
+    assert VC.normalize(:catalogues, %{}) == VC.defaults(:catalogues)
+
+    got =
+      VC.normalize(:catalogues, %{
+        "columns" => ["items", "bogus"],
+        "sort_dir" => "desc",
+        "view" => "card"
+      })
+
+    assert got.columns == ["items"]
+    assert got.sort_dir == :desc
+    assert got.view == "card"
+  end
+
+  test "load reads from a user struct's custom_fields" do
+    user = %{custom_fields: %{"catalogue_view_configs" => %{"suppliers" => %{"view" => "card"}}}}
+    assert VC.load(user, :suppliers).view == "card"
+    assert VC.load(%{custom_fields: nil}, :suppliers) == VC.defaults(:suppliers)
+  end
+end


### PR DESCRIPTION
Reworks the catalogue admin index into an orders-style table stack and moves catalogue admin page titles into the global admin header bar.

## Changes
- Move catalogue admin page headers into the global admin header bar
- Flatten the catalogues index into a sortable table with a folder filter (removes the old tree + global item search)
- `TableConfig` column metadata for catalogue admin tables
- `TableQuery` in-memory search / filter / sort pipeline
- `ViewConfig` per-user table-state persistence
- `TableToolbar` column-settings modal + toolbar controls; wire per-scope view-config state and toolbar handlers into `CataloguesLive`
- Apply the table toolbar, dynamic columns, and card view to Suppliers and Manufacturers
- Folders management modal on the catalogues index (+ empty-state polish)
- Unicode-safe JSON export filename + lightweight catalogue query
- gettext strings for the table toolbar, columns, and folder management

Design + plan: `dev_docs/2026-06-27-catalogue-table-stack-{design,plan}.md`.
